### PR TITLE
feat: introduce AbstractLattice interface, traits, and Bond

### DIFF
--- a/.github/scripts/setup_project.jl
+++ b/.github/scripts/setup_project.jl
@@ -22,8 +22,12 @@ for file in files_to_fix
             content = replace(content, r"^name = \".*\""m => "name = \"$new_name\"")
             content = replace(content, r"^uuid = \".*\""m => "uuid = \"$new_uuid\"")
         elseif file == "docs/Project.toml"
-            content = replace(content, Regex("$(new_name) = \".*\"") => "$(new_name) = \"$new_uuid\"")
-            content = replace(content, r"^uuid = \".*\""m => "uuid = \"$(string(uuid4()))\"")
+            content = replace(
+                content, Regex("$(new_name) = \".*\"") => "$(new_name) = \"$new_uuid\""
+            )
+            content = replace(
+                content, r"^uuid = \".*\""m => "uuid = \"$(string(uuid4()))\""
+            )
         end
         write(file, content)
     end

--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,14 @@ uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
 version = "0.1.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
+[deps]
+LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
+
+[compat]
+StaticArrays = "1"
+julia = "1.10"
+
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/src/AbstractLattice.jl
+++ b/src/AbstractLattice.jl
@@ -1,0 +1,122 @@
+"""
+    AbstractLattice{D, T}
+
+Abstract supertype for lattice types. Type parameters:
+- `D`: spatial dimension (integer literal)
+- `T`: numeric type for real-space positions (typically `Float64`)
+
+# Required interface (concrete subtypes must implement)
+- `position(lat, i)::SVector{D, T}`
+- `neighbors(lat, i)` — iterable of neighbor site indices
+- `boundary(lat)` — returns an `AbstractBoundaryCondition`
+- `size_trait(lat)::AbstractSizeTrait`
+- `num_sites(lat)::Int` — required for `FiniteSize` / `QuasiInfiniteSize`
+  lattices; `InfiniteSize` lattices should throw `DomainError`.
+
+# Optional interface (defaults provided)
+- `positions(lat)` — defaults to an iterator built from `position`
+- `bonds(lat)` — defaults to an iterator built from `neighbors`
+- `neighbor_bonds(lat, i)` — defaults to an iterator built from `neighbors`
+- `topology(lat)` — `TopologyTrait{:unknown}()`
+- `periodicity(lat)` — `Aperiodic()`
+- `is_bipartite(lat)` — `false`
+- `reciprocal_support(lat)` — `NoReciprocal()`
+- `is_finite(lat)` — derived from `size_trait`
+
+See `dev/note/04_architecture/02_lattice_interface/README.md` for the
+design rationale.
+"""
+abstract type AbstractLattice{D, T} end
+
+# ---- Dimension helpers (fully determined by type parameters) ---------
+
+"""
+    dimension(lat) → Int
+
+Spatial dimension `D` of the lattice.
+"""
+dimension(::AbstractLattice{D, T}) where {D, T} = D
+
+Base.eltype(::Type{<:AbstractLattice{D, T}}) where {D, T} = T
+Base.eltype(lat::AbstractLattice) = eltype(typeof(lat))
+
+# ---- Required interface (generic functions, methods added per type) --
+
+"""
+    num_sites(lat::AbstractLattice)::Int
+
+Number of sites in the lattice. Must be implemented by finite concrete
+types. `InfiniteSize` lattices should throw `DomainError`.
+"""
+function num_sites end
+
+"""
+    position(lat::AbstractLattice{D, T}, i::Int)::SVector{D, T}
+
+Real-space position of site `i`. This extends `Base.position` so that
+downstream code can write `position(lat, i)` directly after
+`using LatticeCore`.
+"""
+position(lat::AbstractLattice, i::Int) =
+    throw(MethodError(position, (lat, i)))
+
+"""
+    neighbors(lat::AbstractLattice, i::Int)
+
+Indices of sites adjacent to site `i` (nearest neighbors by default).
+Concrete types may additionally define `neighbors(lat, i; shell)` or
+`neighbors(lat, i, shell::Int)` to support higher shells.
+"""
+function neighbors end
+
+"""
+    boundary(lat::AbstractLattice)
+
+The lattice's boundary condition (subtype of
+`AbstractBoundaryCondition`, defined in `BoundaryCondition.jl`).
+"""
+function boundary end
+
+"""
+    size_trait(lat::AbstractLattice) → AbstractSizeTrait
+
+Size trait describing the lattice's extent. Must be implemented by
+concrete types.
+"""
+function size_trait end
+
+# ---- Optional interface with defaults --------------------------------
+
+"""
+    positions(lat::AbstractLattice)
+
+Iterator over all positions. Default implementation lazily constructs
+from `num_sites` and `position`; works only for finite lattices.
+Concrete types may override for efficiency.
+"""
+function positions(lat::AbstractLattice)
+    return (position(lat, i) for i in 1:num_sites(lat))
+end
+
+# ---- Trait defaults --------------------------------------------------
+
+"""Default topology trait: `TopologyTrait{:unknown}()`."""
+topology(::AbstractLattice) = TopologyTrait{:unknown}()
+
+"""Default periodicity: `Aperiodic()`."""
+periodicity(::AbstractLattice) = Aperiodic()
+
+"""Default bipartite flag: `false`."""
+is_bipartite(::AbstractLattice) = false
+
+"""Default reciprocal support: `NoReciprocal()`."""
+reciprocal_support(::AbstractLattice) = NoReciprocal()
+
+"""
+    is_finite(lat::AbstractLattice) → Bool
+
+`true` if `size_trait(lat)` is a [`FiniteSize`](@ref). Monte Carlo
+algorithms should guard against non-finite lattices with this
+predicate.
+"""
+is_finite(lat::AbstractLattice) = size_trait(lat) isa FiniteSize

--- a/src/AbstractLattice.jl
+++ b/src/AbstractLattice.jl
@@ -26,7 +26,7 @@ Abstract supertype for lattice types. Type parameters:
 See `dev/note/04_architecture/02_lattice_interface/README.md` for the
 design rationale.
 """
-abstract type AbstractLattice{D, T} end
+abstract type AbstractLattice{D,T} end
 
 # ---- Dimension helpers (fully determined by type parameters) ---------
 
@@ -35,9 +35,9 @@ abstract type AbstractLattice{D, T} end
 
 Spatial dimension `D` of the lattice.
 """
-dimension(::AbstractLattice{D, T}) where {D, T} = D
+dimension(::AbstractLattice{D,T}) where {D,T} = D
 
-Base.eltype(::Type{<:AbstractLattice{D, T}}) where {D, T} = T
+Base.eltype(::Type{<:AbstractLattice{D,T}}) where {D,T} = T
 Base.eltype(lat::AbstractLattice) = eltype(typeof(lat))
 
 # ---- Required interface (generic functions, methods added per type) --
@@ -57,8 +57,7 @@ Real-space position of site `i`. This extends `Base.position` so that
 downstream code can write `position(lat, i)` directly after
 `using LatticeCore`.
 """
-position(lat::AbstractLattice, i::Int) =
-    throw(MethodError(position, (lat, i)))
+position(lat::AbstractLattice, i::Int) = throw(MethodError(position, (lat, i)))
 
 """
     neighbors(lat::AbstractLattice, i::Int)

--- a/src/Bond.jl
+++ b/src/Bond.jl
@@ -1,0 +1,61 @@
+"""
+    Bond{D, T}
+
+A bond (edge) connecting two sites of a lattice.
+
+# Fields
+- `i::Int` — source site index
+- `j::Int` — target site index
+- `vector::SVector{D, T}` — displacement `position(j) - position(i)`,
+  wrapped by the lattice's boundary condition if applicable
+- `type::Symbol` — bond type tag (e.g. `:nearest`, `:next_nearest`,
+  `:dimer_strong`). Used as a dispatch key by anisotropic models
+  (see the 07 MC layer design note).
+"""
+struct Bond{D, T}
+    i::Int
+    j::Int
+    vector::SVector{D, T}
+    type::Symbol
+end
+
+"""
+    bond_center(lat::AbstractLattice, bond::Bond) → SVector{D, T}
+
+Geometric center (midpoint) of the bond in real space. Useful for
+bond-centered observables and for position-dependent bond modifiers
+such as sine-square deformation.
+"""
+function bond_center(lat::AbstractLattice{D, T}, bond::Bond{D, T}) where {D, T}
+    return (position(lat, bond.i) + position(lat, bond.j)) / 2
+end
+
+"""
+    bonds(lat::AbstractLattice)
+
+Iterator of all bonds in the lattice. The default implementation
+builds `Bond` objects on the fly from `neighbors(lat, i)` using the
+`:nearest` tag. Concrete lattices may override this for efficiency or
+to attach non-default bond types (e.g. dimer-strong vs dimer-weak).
+"""
+function bonds(lat::AbstractLattice{D, T}) where {D, T}
+    return (
+        Bond{D, T}(i, j, position(lat, j) - position(lat, i), :nearest)
+        for i in 1:num_sites(lat) for j in neighbors(lat, i) if j > i
+    )
+end
+
+"""
+    neighbor_bonds(lat::AbstractLattice, i::Int)
+
+Iterator of bonds incident to site `i`. The default implementation
+builds `Bond` objects from `neighbors(lat, i)` using the `:nearest`
+tag. This is the canonical entry point the 07 MC layer uses to walk
+interactions involving a given site.
+"""
+function neighbor_bonds(lat::AbstractLattice{D, T}, i::Int) where {D, T}
+    return (
+        Bond{D, T}(i, j, position(lat, j) - position(lat, i), :nearest)
+        for j in neighbors(lat, i)
+    )
+end

--- a/src/Bond.jl
+++ b/src/Bond.jl
@@ -12,10 +12,10 @@ A bond (edge) connecting two sites of a lattice.
   `:dimer_strong`). Used as a dispatch key by anisotropic models
   (see the 07 MC layer design note).
 """
-struct Bond{D, T}
+struct Bond{D,T}
     i::Int
     j::Int
-    vector::SVector{D, T}
+    vector::SVector{D,T}
     type::Symbol
 end
 
@@ -26,7 +26,7 @@ Geometric center (midpoint) of the bond in real space. Useful for
 bond-centered observables and for position-dependent bond modifiers
 such as sine-square deformation.
 """
-function bond_center(lat::AbstractLattice{D, T}, bond::Bond{D, T}) where {D, T}
+function bond_center(lat::AbstractLattice{D,T}, bond::Bond{D,T}) where {D,T}
     return (position(lat, bond.i) + position(lat, bond.j)) / 2
 end
 
@@ -38,10 +38,10 @@ builds `Bond` objects on the fly from `neighbors(lat, i)` using the
 `:nearest` tag. Concrete lattices may override this for efficiency or
 to attach non-default bond types (e.g. dimer-strong vs dimer-weak).
 """
-function bonds(lat::AbstractLattice{D, T}) where {D, T}
+function bonds(lat::AbstractLattice{D,T}) where {D,T}
     return (
-        Bond{D, T}(i, j, position(lat, j) - position(lat, i), :nearest)
-        for i in 1:num_sites(lat) for j in neighbors(lat, i) if j > i
+        Bond{D,T}(i, j, position(lat, j) - position(lat, i), :nearest) for
+        i in 1:num_sites(lat) for j in neighbors(lat, i) if j > i
     )
 end
 
@@ -53,9 +53,9 @@ builds `Bond` objects from `neighbors(lat, i)` using the `:nearest`
 tag. This is the canonical entry point the 07 MC layer uses to walk
 interactions involving a given site.
 """
-function neighbor_bonds(lat::AbstractLattice{D, T}, i::Int) where {D, T}
+function neighbor_bonds(lat::AbstractLattice{D,T}, i::Int) where {D,T}
     return (
-        Bond{D, T}(i, j, position(lat, j) - position(lat, i), :nearest)
-        for j in neighbors(lat, i)
+        Bond{D,T}(i, j, position(lat, j) - position(lat, i), :nearest) for
+        j in neighbors(lat, i)
     )
 end

--- a/src/LatticeCore.jl
+++ b/src/LatticeCore.jl
@@ -1,5 +1,31 @@
 module LatticeCore
 
-greet() = print("Hello World!")
+using LinearAlgebra
+using StaticArrays
+
+# We extend `Base.position` for `AbstractLattice` so downstream code can
+# write `position(lat, i)` without name shadowing. `Base.position(io)`
+# for IO streams has an unrelated signature.
+import Base: position
+
+include("Traits.jl")
+include("AbstractLattice.jl")
+include("Bond.jl")
+
+# ---- AbstractLattice ----
+export AbstractLattice
+export dimension, num_sites, position, positions, neighbors, boundary
+
+# ---- Bond ----
+export Bond, bond_center, bonds, neighbor_bonds
+
+# ---- Traits ----
+export TopologyTrait, topology
+export Periodic, Aperiodic, periodicity
+export is_bipartite
+export AbstractReciprocalSupport, HasReciprocal, HasFourierModule, NoReciprocal
+export reciprocal_support
+export AbstractSizeTrait, FiniteSize, InfiniteSize, QuasiInfiniteSize
+export size_trait, is_finite
 
 end # module LatticeCore

--- a/src/Traits.jl
+++ b/src/Traits.jl
@@ -71,7 +71,7 @@ Size trait for an ordinary finite lattice with the given per-axis cell
 counts.
 """
 struct FiniteSize{D} <: AbstractSizeTrait
-    dims::NTuple{D, Int}
+    dims::NTuple{D,Int}
 end
 
 """

--- a/src/Traits.jl
+++ b/src/Traits.jl
@@ -1,0 +1,95 @@
+# Lattice trait types.
+#
+# Only type declarations live here; defaults attached to
+# `AbstractLattice` are in `AbstractLattice.jl`.
+
+# ---- Topology ---------------------------------------------------------
+
+"""
+    TopologyTrait{Name}
+
+Singleton trait carrying the topology name as a type parameter
+(e.g. `TopologyTrait{:Square}`, `TopologyTrait{:Honeycomb}`,
+`TopologyTrait{:Penrose}`). Used for dispatch in topology-specific
+helpers such as high-symmetry-point tables.
+"""
+struct TopologyTrait{Name} end
+
+# ---- Periodicity ------------------------------------------------------
+
+"""Periodicity trait marker for Bravais-lattice-like structures."""
+struct Periodic end
+
+"""Periodicity trait marker for aperiodic structures (e.g. quasicrystals)."""
+struct Aperiodic end
+
+# ---- Reciprocal space support ----------------------------------------
+
+"""
+    AbstractReciprocalSupport
+
+Trait indicating what kind of k-space representation a lattice admits.
+
+Subtypes:
+- [`HasReciprocal`](@ref): standard Bravais reciprocal lattice.
+- [`HasFourierModule`](@ref): dense Fourier module arising from a
+  cut-and-project quasicrystal.
+- [`NoReciprocal`](@ref): neither of the above (e.g. generic graph).
+"""
+abstract type AbstractReciprocalSupport end
+
+"""Trait: the lattice has a standard Bravais reciprocal lattice."""
+struct HasReciprocal <: AbstractReciprocalSupport end
+
+"""Trait: the lattice has a Fourier module (quasicrystal)."""
+struct HasFourierModule <: AbstractReciprocalSupport end
+
+"""Trait: the lattice has no k-space representation."""
+struct NoReciprocal <: AbstractReciprocalSupport end
+
+# ---- Size trait -------------------------------------------------------
+
+"""
+    AbstractSizeTrait
+
+Trait describing whether a lattice has a finite, infinite, or
+finitely-materializable-but-conceptually-infinite extent.
+
+Subtypes:
+- [`FiniteSize`](@ref): ordinary finite lattice.
+- [`InfiniteSize`](@ref): true infinite lattice (used for
+  analytic/spectral work; MC is not applicable).
+- [`QuasiInfiniteSize`](@ref): conceptually infinite but materialized
+  up to a cutoff (e.g. Penrose radius, Fibonacci depth).
+"""
+abstract type AbstractSizeTrait end
+
+"""
+    FiniteSize{D}(dims::NTuple{D, Int})
+
+Size trait for an ordinary finite lattice with the given per-axis cell
+counts.
+"""
+struct FiniteSize{D} <: AbstractSizeTrait
+    dims::NTuple{D, Int}
+end
+
+"""
+    InfiniteSize()
+
+Size trait for a true infinite lattice. MC cannot run on such a
+lattice; spectral / analytic calculations only.
+"""
+struct InfiniteSize <: AbstractSizeTrait end
+
+"""
+    QuasiInfiniteSize{T}(cutoff::T)
+
+Size trait for a conceptually infinite lattice that has been (or will
+be) materialized up to a finite cutoff. The cutoff may represent a
+radius, a substitution depth, or any other scale parameter native to
+the lattice family.
+"""
+struct QuasiInfiniteSize{T} <: AbstractSizeTrait
+    cutoff::T
+end

--- a/test/core/test_abstract_lattice.jl
+++ b/test/core/test_abstract_lattice.jl
@@ -1,0 +1,99 @@
+using LatticeCore
+using StaticArrays
+using Test
+
+# A minimal concrete subtype used to exercise the abstract interface.
+# Deliberately local to this test file: the "real" reference
+# implementations (LineLattice, SimpleSquareLattice) will land in a
+# follow-up PR.
+
+struct TrivialBoundary end
+
+struct TestLattice1D <: AbstractLattice{1,Float64}
+    N::Int
+end
+
+LatticeCore.num_sites(l::TestLattice1D) = l.N
+LatticeCore.position(l::TestLattice1D, i::Int) = SVector{1,Float64}(Float64(i))
+function LatticeCore.neighbors(l::TestLattice1D, i::Int)
+    return filter(j -> 1 <= j <= l.N, [i - 1, i + 1])
+end
+LatticeCore.boundary(::TestLattice1D) = TrivialBoundary()
+LatticeCore.size_trait(l::TestLattice1D) = FiniteSize((l.N,))
+
+@testset "AbstractLattice via TestLattice1D" begin
+    lat = TestLattice1D(5)
+
+    @testset "type parameters and basic accessors" begin
+        @test lat isa AbstractLattice{1,Float64}
+        @test dimension(lat) == 1
+        @test eltype(lat) === Float64
+        @test eltype(typeof(lat)) === Float64
+        @test num_sites(lat) == 5
+    end
+
+    @testset "position" begin
+        @test position(lat, 1) == SVector(1.0)
+        @test position(lat, 3) == SVector(3.0)
+        @test position(lat, 5) == SVector(5.0)
+    end
+
+    @testset "neighbors" begin
+        @test neighbors(lat, 1) == [2]
+        @test neighbors(lat, 3) == [2, 4]
+        @test neighbors(lat, 5) == [4]
+    end
+
+    @testset "boundary" begin
+        @test boundary(lat) isa TrivialBoundary
+    end
+
+    @testset "size trait defaults and is_finite" begin
+        st = size_trait(lat)
+        @test st isa FiniteSize{1}
+        @test st.dims == (5,)
+        @test is_finite(lat) == true
+    end
+
+    @testset "trait defaults on AbstractLattice" begin
+        @test topology(lat) isa TopologyTrait{:unknown}
+        @test periodicity(lat) isa Aperiodic
+        @test is_bipartite(lat) == false
+        @test reciprocal_support(lat) isa NoReciprocal
+    end
+
+    @testset "positions iterator (default)" begin
+        ps = collect(positions(lat))
+        @test length(ps) == 5
+        @test ps[1] == SVector(1.0)
+        @test ps[5] == SVector(5.0)
+    end
+
+    @testset "bonds iterator (default)" begin
+        all_bonds = collect(bonds(lat))
+        # Expected: (1,2), (2,3), (3,4), (4,5) — 4 bonds for a 1D chain
+        @test length(all_bonds) == 4
+        @test all(b isa Bond{1,Float64} for b in all_bonds)
+        @test all(b.type === :nearest for b in all_bonds)
+        @test all_bonds[1].i == 1 && all_bonds[1].j == 2
+        @test all_bonds[end].i == 4 && all_bonds[end].j == 5
+    end
+
+    @testset "neighbor_bonds iterator (default)" begin
+        nb_mid = collect(neighbor_bonds(lat, 3))
+        @test length(nb_mid) == 2
+        @test Set((b.i, b.j) for b in nb_mid) == Set([(3, 2), (3, 4)])
+
+        nb_left = collect(neighbor_bonds(lat, 1))
+        @test length(nb_left) == 1
+        @test nb_left[1].j == 2
+    end
+
+    @testset "bond_center" begin
+        b = Bond{1,Float64}(1, 2, SVector(1.0), :nearest)
+        @test bond_center(lat, b) == SVector(1.5)
+
+        b2 = Bond{1,Float64}(3, 4, SVector(1.0), :nearest)
+        @test bond_center(lat, b2) == SVector(3.5)
+    end
+end

--- a/test/core/test_bond.jl
+++ b/test/core/test_bond.jl
@@ -1,0 +1,19 @@
+using LatticeCore
+using StaticArrays
+using Test
+
+@testset "Bond struct" begin
+    b = Bond{2, Float64}(1, 2, SVector(1.0, 0.0), :nearest)
+    @test b.i == 1
+    @test b.j == 2
+    @test b.vector == SVector(1.0, 0.0)
+    @test b.type === :nearest
+
+    # Different bond type tag
+    b2 = Bond{2, Float64}(3, 7, SVector(-0.5, 0.5), :dimer_strong)
+    @test b2.type === :dimer_strong
+    @test b2.vector == SVector(-0.5, 0.5)
+
+    # Bond is immutable (typeof check)
+    @test isimmutable(b)
+end

--- a/test/core/test_bond.jl
+++ b/test/core/test_bond.jl
@@ -3,14 +3,14 @@ using StaticArrays
 using Test
 
 @testset "Bond struct" begin
-    b = Bond{2, Float64}(1, 2, SVector(1.0, 0.0), :nearest)
+    b = Bond{2,Float64}(1, 2, SVector(1.0, 0.0), :nearest)
     @test b.i == 1
     @test b.j == 2
     @test b.vector == SVector(1.0, 0.0)
     @test b.type === :nearest
 
     # Different bond type tag
-    b2 = Bond{2, Float64}(3, 7, SVector(-0.5, 0.5), :dimer_strong)
+    b2 = Bond{2,Float64}(3, 7, SVector(-0.5, 0.5), :dimer_strong)
     @test b2.type === :dimer_strong
     @test b2.vector == SVector(-0.5, 0.5)
 

--- a/test/core/test_traits.jl
+++ b/test/core/test_traits.jl
@@ -1,0 +1,39 @@
+using LatticeCore
+using Test
+
+@testset "Traits" begin
+    @testset "TopologyTrait" begin
+        @test TopologyTrait{:Square}() isa TopologyTrait{:Square}
+        @test TopologyTrait{:Honeycomb} <: Any
+    end
+
+    @testset "Periodicity" begin
+        @test Periodic() isa Periodic
+        @test Aperiodic() isa Aperiodic
+    end
+
+    @testset "AbstractReciprocalSupport" begin
+        @test HasReciprocal <: AbstractReciprocalSupport
+        @test HasFourierModule <: AbstractReciprocalSupport
+        @test NoReciprocal <: AbstractReciprocalSupport
+        @test HasReciprocal() isa AbstractReciprocalSupport
+        @test HasFourierModule() isa AbstractReciprocalSupport
+        @test NoReciprocal() isa AbstractReciprocalSupport
+    end
+
+    @testset "AbstractSizeTrait" begin
+        @test FiniteSize <: AbstractSizeTrait
+        @test InfiniteSize <: AbstractSizeTrait
+        @test QuasiInfiniteSize <: AbstractSizeTrait
+
+        finite2d = FiniteSize((4, 5))
+        @test finite2d isa FiniteSize{2}
+        @test finite2d.dims == (4, 5)
+
+        @test InfiniteSize() isa InfiniteSize
+
+        qi = QuasiInfiniteSize(3.5)
+        @test qi isa QuasiInfiniteSize{Float64}
+        @test qi.cutoff == 3.5
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,7 @@
 ENV["GKSwstype"] = "100"
 
 using LatticeCore, Test
-const dirs = []
+const dirs = ["core"]
 
 const FIG_BASE = joinpath(pkgdir(LatticeCore), "docs", "src", "assets")
 const PATHS = Dict()


### PR DESCRIPTION
## Description

First skeleton of the `LatticeCore` abstract interface, following the design in [`dev/note/04_architecture/02_lattice_interface/README.md`](https://github.com/sotashimozono/work/blob/main/dev/note/04_architecture/02_lattice_interface/README.md). This PR establishes the type contract and trait scaffolding; **no concrete lattice implementation is shipped yet**. `LineLattice` and `SimpleSquareLattice` reference implementations will follow in a subsequent PR.

Fixed: (no linked issue)

## Type of Change

- [x] ✨ Feature (`enhancement`)
- [ ] 🐛 Bug Fix
- [ ] ⚡ Performance
- [ ] 📖 Documentation
- [ ] 🧰 Maintenance

## Proposed Changes

**Added**

- `src/AbstractLattice.jl` — `AbstractLattice{D, T}` abstract type with:
  - `dimension(lat)`, `num_sites(lat)`, `position(lat, i)` (extending `Base.position`), `neighbors(lat, i)`, `boundary(lat)`, `size_trait(lat)`
  - trait defaults: `topology`, `periodicity`, `is_bipartite`, `reciprocal_support`, `is_finite`
  - `positions(lat)` default iterator
- `src/Bond.jl` — `Bond{D, T}` struct with `:nearest`/`:dimer_strong`/etc `type::Symbol` tag; default `bonds(lat)` / `neighbor_bonds(lat, i)` iterators built from `neighbors()`; `bond_center(lat, bond)` midpoint helper.
- `src/Traits.jl`:
  - `TopologyTrait{Name}`
  - `Periodic` / `Aperiodic`
  - `AbstractReciprocalSupport` with 3 values: `HasReciprocal` (Bravais), `HasFourierModule` (quasicrystal), `NoReciprocal`
  - `AbstractSizeTrait` with `FiniteSize{D}`, `InfiniteSize`, `QuasiInfiniteSize{T}`
- `test/core/` — 58 unit tests covering:
  - Trait types and instance construction
  - `Bond` construction, immutability, `type` field
  - A minimal `TestLattice1D` mock exercising dimension / position / neighbors / boundary / size_trait / is_finite / trait defaults / positions, bonds, neighbor_bonds iterators / bond_center
- `StaticArrays` added to `[deps]` and `[compat]` (v1)

**Changed**

- `src/LatticeCore.jl`: remove template `greet()` stub, wire up new `include`s and exports, explicitly `import Base: position` to avoid IO-stream shadowing
- `test/runtests.jl`: register the `"core"` test directory

## Usage or Results

```julia
using LatticeCore, StaticArrays

# Define a concrete lattice by implementing the required interface
struct MyLattice <: AbstractLattice{2, Float64}
    Lx::Int
    Ly::Int
end

LatticeCore.num_sites(l::MyLattice)        = l.Lx * l.Ly
LatticeCore.position(l::MyLattice, i::Int) = SVector(...)
LatticeCore.neighbors(l::MyLattice, i::Int) = ...
LatticeCore.boundary(::MyLattice)           = PBC()
LatticeCore.size_trait(l::MyLattice)        = FiniteSize((l.Lx, l.Ly))

# Traits / iterators come for free:
is_finite(lat)        # true
reciprocal_support(lat)  # NoReciprocal()
collect(bonds(lat))   # Vector{Bond{2, Float64}}
```

Test summary: `58 Pass, 0 Fail` (local).

## check list
- [x] test駆動をしたか — TestLattice1D mock covers the full required interface