### PR TITLE
feat: add LineLattice and SimpleSquareLattice reference implementations

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.1.1"
+version = "0.2.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/BoundaryCondition.jl
+++ b/src/BoundaryCondition.jl
@@ -1,0 +1,32 @@
+"""
+    AbstractBoundaryCondition
+
+Abstract supertype for lattice boundary conditions.
+
+This file ships only the minimal vocabulary (`PBC`, `OBC`) required to
+exercise the reference lattices (`LineLattice`, `SimpleSquareLattice`)
+and the Monte Carlo smoke tests.
+
+The richer per-axis design from `dev/note/04_architecture/03_boundary_and_coordinates`
+—`LatticeBoundary{N, A, M}`, `AbstractAxisBC` (`PeriodicAxis` /
+`OpenAxis` / `TwistedAxis`), `AbstractBoundaryModifier`—will land in a
+subsequent PR. Concrete lattice types here treat `PBC` / `OBC` as
+uniform markers that apply to every axis at once.
+"""
+abstract type AbstractBoundaryCondition end
+
+"""
+    PBC()
+
+Periodic boundary condition marker. Applied uniformly to all axes by
+the reference lattices.
+"""
+struct PBC <: AbstractBoundaryCondition end
+
+"""
+    OBC()
+
+Open boundary condition marker. Applied uniformly to all axes by the
+reference lattices.
+"""
+struct OBC <: AbstractBoundaryCondition end

--- a/src/LatticeCore.jl
+++ b/src/LatticeCore.jl
@@ -11,6 +11,9 @@ import Base: position
 include("Traits.jl")
 include("AbstractLattice.jl")
 include("Bond.jl")
+include("BoundaryCondition.jl")
+include("reference/LineLattice.jl")
+include("reference/SimpleSquareLattice.jl")
 
 # ---- AbstractLattice ----
 export AbstractLattice
@@ -27,5 +30,11 @@ export AbstractReciprocalSupport, HasReciprocal, HasFourierModule, NoReciprocal
 export reciprocal_support
 export AbstractSizeTrait, FiniteSize, InfiniteSize, QuasiInfiniteSize
 export size_trait, is_finite
+
+# ---- Boundary conditions ----
+export AbstractBoundaryCondition, PBC, OBC
+
+# ---- Reference lattices ----
+export LineLattice, SimpleSquareLattice
 
 end # module LatticeCore

--- a/src/reference/LineLattice.jl
+++ b/src/reference/LineLattice.jl
@@ -1,0 +1,66 @@
+"""
+    LineLattice{T, B <: AbstractBoundaryCondition}(N, boundary)
+
+A 1D linear chain of `N` sites with unit spacing. The type parameter
+`B` selects the boundary condition: `PBC` (periodic) or `OBC` (open).
+
+This is LatticeCore's simplest reference implementation; paired with
+`SimpleSquareLattice` it is also the canonical mock used by downstream
+Monte Carlo unit tests.
+
+# Example
+```julia
+julia> lat = LineLattice(5, PBC());
+
+julia> num_sites(lat)
+5
+
+julia> neighbors(lat, 1)
+2-element Vector{Int64}:
+ 5
+ 2
+```
+"""
+struct LineLattice{T<:AbstractFloat,B<:AbstractBoundaryCondition} <: AbstractLattice{1,T}
+    N::Int
+    boundary::B
+end
+
+# Convenience constructor: default to Float64 positions.
+function LineLattice(N::Int, boundary::B=PBC()) where {B<:AbstractBoundaryCondition}
+    return LineLattice{Float64,B}(N, boundary)
+end
+
+# ---- Required interface ----
+
+num_sites(l::LineLattice) = l.N
+
+position(l::LineLattice{T}, i::Int) where {T} = SVector{1,T}(T(i))
+
+function neighbors(l::LineLattice{T,PBC}, i::Int) where {T}
+    # `unique!` collapses the degenerate N == 2 case (both neighbours
+    # point to the other site) to a single entry.
+    return unique!([mod1(i - 1, l.N), mod1(i + 1, l.N)])
+end
+
+function neighbors(l::LineLattice{T,OBC}, i::Int) where {T}
+    return filter(j -> 1 <= j <= l.N, [i - 1, i + 1])
+end
+
+boundary(l::LineLattice) = l.boundary
+
+size_trait(l::LineLattice) = FiniteSize((l.N,))
+
+# ---- Trait overrides ----
+
+topology(::LineLattice) = TopologyTrait{:line}()
+
+periodicity(::LineLattice{T,PBC}) where {T} = Periodic()
+periodicity(::LineLattice{T,OBC}) where {T} = Aperiodic()
+
+# PBC chain is bipartite iff the cycle length N is even.
+is_bipartite(l::LineLattice{T,PBC}) where {T} = iseven(l.N)
+is_bipartite(::LineLattice{T,OBC}) where {T} = true
+
+reciprocal_support(::LineLattice{T,PBC}) where {T} = HasReciprocal()
+reciprocal_support(::LineLattice{T,OBC}) where {T} = NoReciprocal()

--- a/src/reference/SimpleSquareLattice.jl
+++ b/src/reference/SimpleSquareLattice.jl
@@ -1,0 +1,119 @@
+"""
+    SimpleSquareLattice{T, B <: AbstractBoundaryCondition}(Lx, Ly, boundary)
+
+A 2D square lattice of `Lx × Ly` sites with unit spacing. The type
+parameter `B` selects the boundary condition (`PBC` or `OBC`), applied
+uniformly to both axes.
+
+This is LatticeCore's 2D reference implementation. It exists so that
+the core interface can be exercised end-to-end without depending on
+`Lattice2D.jl`. The production-grade 2D lattice, with the full
+topology catalogue (triangular, honeycomb, kagome, ...), sublattice
+site types, and reciprocal lattice machinery, lives in `Lattice2D.jl`.
+
+# Site indexing
+
+Sites are laid out in row-major order:
+
+    site_index(x, y) = (y - 1) * Lx + x     # 1 <= x <= Lx, 1 <= y <= Ly
+
+so sites 1..Lx form the bottom row, Lx+1..2Lx the next, and so on.
+
+# Example
+```julia
+julia> lat = SimpleSquareLattice(3, 3, PBC());
+
+julia> num_sites(lat)
+9
+
+julia> position(lat, 5)   # middle of a 3x3 lattice
+2-element StaticArraysCore.SVector{2, Float64} with indices SOneTo(2):
+ 2.0
+ 2.0
+```
+"""
+struct SimpleSquareLattice{T<:AbstractFloat,B<:AbstractBoundaryCondition} <:
+       AbstractLattice{2,T}
+    Lx::Int
+    Ly::Int
+    boundary::B
+end
+
+# Convenience constructor: default to Float64 positions and PBC.
+function SimpleSquareLattice(
+    Lx::Int, Ly::Int, boundary::B=PBC()
+) where {B<:AbstractBoundaryCondition}
+    return SimpleSquareLattice{Float64,B}(Lx, Ly, boundary)
+end
+
+# ---- Private row-major coordinate helpers ----
+
+@inline function _site_to_xy(l::SimpleSquareLattice, i::Int)
+    x = mod1(i, l.Lx)
+    y = ((i - 1) ÷ l.Lx) + 1
+    return (x, y)
+end
+
+@inline function _xy_to_site(l::SimpleSquareLattice, x::Int, y::Int)
+    return (y - 1) * l.Lx + x
+end
+
+# ---- Required interface ----
+
+num_sites(l::SimpleSquareLattice) = l.Lx * l.Ly
+
+function position(l::SimpleSquareLattice{T}, i::Int) where {T}
+    x, y = _site_to_xy(l, i)
+    return SVector{2,T}(T(x), T(y))
+end
+
+function neighbors(l::SimpleSquareLattice{T,PBC}, i::Int) where {T}
+    x, y = _site_to_xy(l, i)
+    ns = [
+        _xy_to_site(l, mod1(x + 1, l.Lx), y),
+        _xy_to_site(l, mod1(x - 1, l.Lx), y),
+        _xy_to_site(l, x, mod1(y + 1, l.Ly)),
+        _xy_to_site(l, x, mod1(y - 1, l.Ly)),
+    ]
+    # Collapse degenerate Lx == 2 / Ly == 2 cases that would otherwise
+    # return duplicate neighbours.
+    return unique!(ns)
+end
+
+function neighbors(l::SimpleSquareLattice{T,OBC}, i::Int) where {T}
+    x, y = _site_to_xy(l, i)
+    ns = Int[]
+    if x + 1 <= l.Lx
+        push!(ns, _xy_to_site(l, x + 1, y))
+    end
+    if x - 1 >= 1
+        push!(ns, _xy_to_site(l, x - 1, y))
+    end
+    if y + 1 <= l.Ly
+        push!(ns, _xy_to_site(l, x, y + 1))
+    end
+    if y - 1 >= 1
+        push!(ns, _xy_to_site(l, x, y - 1))
+    end
+    return ns
+end
+
+boundary(l::SimpleSquareLattice) = l.boundary
+
+size_trait(l::SimpleSquareLattice) = FiniteSize((l.Lx, l.Ly))
+
+# ---- Trait overrides ----
+
+topology(::SimpleSquareLattice) = TopologyTrait{:square}()
+
+periodicity(::SimpleSquareLattice{T,PBC}) where {T} = Periodic()
+periodicity(::SimpleSquareLattice{T,OBC}) where {T} = Aperiodic()
+
+# PBC square lattice is bipartite iff both axis lengths are even.
+function is_bipartite(l::SimpleSquareLattice{T,PBC}) where {T}
+    return iseven(l.Lx) && iseven(l.Ly)
+end
+is_bipartite(::SimpleSquareLattice{T,OBC}) where {T} = true
+
+reciprocal_support(::SimpleSquareLattice{T,PBC}) where {T} = HasReciprocal()
+reciprocal_support(::SimpleSquareLattice{T,OBC}) where {T} = NoReciprocal()

--- a/test/core/test_boundary_condition.jl
+++ b/test/core/test_boundary_condition.jl
@@ -1,0 +1,10 @@
+using LatticeCore
+using Test
+
+@testset "BoundaryCondition basics" begin
+    @test PBC <: AbstractBoundaryCondition
+    @test OBC <: AbstractBoundaryCondition
+    @test PBC() isa AbstractBoundaryCondition
+    @test OBC() isa AbstractBoundaryCondition
+    @test PBC() != OBC()
+end

--- a/test/core/test_line_lattice.jl
+++ b/test/core/test_line_lattice.jl
@@ -1,0 +1,89 @@
+using LatticeCore
+using StaticArrays
+using Test
+
+@testset "LineLattice" begin
+    @testset "construction (default Float64)" begin
+        lat = LineLattice(5)
+        @test lat isa LineLattice{Float64,PBC}
+        @test lat isa AbstractLattice{1,Float64}
+        @test dimension(lat) == 1
+        @test eltype(lat) === Float64
+        @test num_sites(lat) == 5
+        @test boundary(lat) isa PBC
+    end
+
+    @testset "PBC neighbors" begin
+        lat = LineLattice(5, PBC())
+        # interior
+        @test Set(neighbors(lat, 3)) == Set([2, 4])
+        # left edge wraps to right edge
+        @test Set(neighbors(lat, 1)) == Set([5, 2])
+        # right edge wraps to left edge
+        @test Set(neighbors(lat, 5)) == Set([4, 1])
+    end
+
+    @testset "OBC neighbors" begin
+        lat = LineLattice(5, OBC())
+        @test neighbors(lat, 1) == [2]
+        @test Set(neighbors(lat, 3)) == Set([2, 4])
+        @test neighbors(lat, 5) == [4]
+    end
+
+    @testset "positions" begin
+        lat = LineLattice(4, OBC())
+        ps = collect(positions(lat))
+        @test length(ps) == 4
+        @test ps[1] == SVector(1.0)
+        @test ps[4] == SVector(4.0)
+    end
+
+    @testset "bond counts" begin
+        # OBC chain of length N has N-1 bonds
+        lat_obc = LineLattice(5, OBC())
+        @test length(collect(bonds(lat_obc))) == 4
+        # PBC cycle of length N has N bonds
+        lat_pbc = LineLattice(5, PBC())
+        @test length(collect(bonds(lat_pbc))) == 5
+    end
+
+    @testset "neighbor_bonds" begin
+        lat = LineLattice(5, PBC())
+        nb_mid = collect(neighbor_bonds(lat, 3))
+        @test length(nb_mid) == 2
+        @test all(b.i == 3 for b in nb_mid)
+        @test Set(b.j for b in nb_mid) == Set([2, 4])
+    end
+
+    @testset "size trait / is_finite" begin
+        lat = LineLattice(7, OBC())
+        @test size_trait(lat) isa FiniteSize{1}
+        @test size_trait(lat).dims == (7,)
+        @test is_finite(lat) == true
+    end
+
+    @testset "trait overrides" begin
+        pbc_even = LineLattice(6, PBC())
+        pbc_odd = LineLattice(5, PBC())
+        obc = LineLattice(5, OBC())
+
+        @test topology(pbc_even) isa TopologyTrait{:line}
+        @test periodicity(pbc_even) isa Periodic
+        @test periodicity(obc) isa Aperiodic
+
+        @test is_bipartite(pbc_even) == true    # even cycle
+        @test is_bipartite(pbc_odd) == false    # odd cycle
+        @test is_bipartite(obc) == true         # chain is always bipartite
+
+        @test reciprocal_support(pbc_even) isa HasReciprocal
+        @test reciprocal_support(obc) isa NoReciprocal
+    end
+
+    @testset "degenerate N=2 PBC (duplicate neighbour collapse)" begin
+        lat = LineLattice(2, PBC())
+        # Both left and right wrap to the other site → just one neighbour.
+        @test neighbors(lat, 1) == [2]
+        @test neighbors(lat, 2) == [1]
+        @test length(collect(bonds(lat))) == 1
+    end
+end

--- a/test/core/test_simple_square_lattice.jl
+++ b/test/core/test_simple_square_lattice.jl
@@ -1,0 +1,111 @@
+using LatticeCore
+using StaticArrays
+using Test
+
+@testset "SimpleSquareLattice" begin
+    @testset "construction" begin
+        lat = SimpleSquareLattice(3, 4)
+        @test lat isa SimpleSquareLattice{Float64,PBC}
+        @test lat isa AbstractLattice{2,Float64}
+        @test dimension(lat) == 2
+        @test num_sites(lat) == 12
+        @test boundary(lat) isa PBC
+    end
+
+    @testset "position layout (row-major)" begin
+        lat = SimpleSquareLattice(3, 2, OBC())
+        # Row-major: sites 1,2,3 = row y=1; sites 4,5,6 = row y=2.
+        @test position(lat, 1) == SVector(1.0, 1.0)
+        @test position(lat, 2) == SVector(2.0, 1.0)
+        @test position(lat, 3) == SVector(3.0, 1.0)
+        @test position(lat, 4) == SVector(1.0, 2.0)
+        @test position(lat, 5) == SVector(2.0, 2.0)
+        @test position(lat, 6) == SVector(3.0, 2.0)
+    end
+
+    @testset "PBC neighbors (interior / edges)" begin
+        lat = SimpleSquareLattice(3, 3, PBC())
+
+        # Interior site (2,2) = site 5
+        @test Set(neighbors(lat, 5)) == Set([
+            6,  # (3,2)
+            4,  # (1,2)
+            8,  # (2,3)
+            2,  # (2,1)
+        ])
+
+        # Corner site (1,1) = site 1; wraps to (3,1) and (1,3)
+        @test Set(neighbors(lat, 1)) == Set([
+            2,  # (2,1)
+            3,  # (3,1) via wrap
+            4,  # (1,2)
+            7,  # (1,3) via wrap
+        ])
+    end
+
+    @testset "OBC neighbors (interior / corner / edge)" begin
+        lat = SimpleSquareLattice(3, 3, OBC())
+
+        # Interior site (2,2) = site 5
+        @test Set(neighbors(lat, 5)) == Set([6, 4, 8, 2])
+
+        # Corner site (1,1) = site 1: no wrap
+        @test Set(neighbors(lat, 1)) == Set([2, 4])
+
+        # Edge site (2,1) = site 2: has x-left, x-right, y-up only
+        @test Set(neighbors(lat, 2)) == Set([1, 3, 5])
+
+        # Opposite corner (3,3) = site 9
+        @test Set(neighbors(lat, 9)) == Set([8, 6])
+    end
+
+    @testset "bond counts" begin
+        # PBC Lx x Ly: 2 * Lx * Ly bonds (horizontal + vertical)
+        lat_pbc = SimpleSquareLattice(3, 3, PBC())
+        @test length(collect(bonds(lat_pbc))) == 18
+
+        lat_pbc_4x5 = SimpleSquareLattice(4, 5, PBC())
+        @test length(collect(bonds(lat_pbc_4x5))) == 40
+
+        # OBC Lx x Ly: (Lx-1) * Ly  +  Lx * (Ly-1) bonds
+        lat_obc = SimpleSquareLattice(3, 3, OBC())
+        @test length(collect(bonds(lat_obc))) == 12
+
+        lat_obc_4x5 = SimpleSquareLattice(4, 5, OBC())
+        @test length(collect(bonds(lat_obc_4x5))) == (3 * 5) + (4 * 4)
+    end
+
+    @testset "size trait / is_finite" begin
+        lat = SimpleSquareLattice(4, 6, PBC())
+        st = size_trait(lat)
+        @test st isa FiniteSize{2}
+        @test st.dims == (4, 6)
+        @test is_finite(lat) == true
+    end
+
+    @testset "trait overrides" begin
+        pbc_even = SimpleSquareLattice(4, 4, PBC())
+        pbc_odd = SimpleSquareLattice(3, 3, PBC())
+        obc = SimpleSquareLattice(3, 3, OBC())
+
+        @test topology(pbc_even) isa TopologyTrait{:square}
+        @test periodicity(pbc_even) isa Periodic
+        @test periodicity(obc) isa Aperiodic
+
+        # PBC square is bipartite iff both Lx, Ly even
+        @test is_bipartite(pbc_even) == true
+        @test is_bipartite(pbc_odd) == false
+        @test is_bipartite(SimpleSquareLattice(4, 3, PBC())) == false
+        @test is_bipartite(obc) == true
+
+        @test reciprocal_support(pbc_even) isa HasReciprocal
+        @test reciprocal_support(obc) isa NoReciprocal
+    end
+
+    @testset "bond_center via default Bond iteration" begin
+        lat = SimpleSquareLattice(3, 3, OBC())
+        # Pick the bond between sites 1 (1,1) and 2 (2,1).
+        b = Bond{2,Float64}(1, 2, SVector(1.0, 0.0), :nearest)
+        @test bond_center(lat, b) == SVector(1.5, 1.0)
+    end
+end


### PR DESCRIPTION
## Description

First concrete `AbstractLattice` subtypes in LatticeCore. These are deliberately minimal **reference implementations**, not production-grade lattices. The full 2D lattice catalogue (triangular, honeycomb, kagome, ...) lives in `Lattice2D.jl`.

**Purpose**

- Exercise the `AbstractLattice` interface end-to-end inside LatticeCore
- Serve as **mock lattices for downstream Monte Carlo unit tests** (so `Lattice2DMonteCarlo.jl` can be tested without depending on `Lattice2D.jl`)
- Make the 02 lattice-interface design concrete and verifiable

Fixed: (no linked issue)

## Type of Change

- [x] ✨ Feature (`enhancement`)
- [ ] 🐛 Bug Fix
- [ ] ⚡ Performance
- [ ] 📖 Documentation
- [ ] 🧰 Maintenance

## Proposed Changes

**Added**

- `src/BoundaryCondition.jl` — `AbstractBoundaryCondition` + `PBC` + `OBC`. Minimal vocabulary needed by the reference lattices. The richer per-axis design from 03 (`LatticeBoundary{N,A,M}`, `AbstractAxisBC`, `AbstractBoundaryModifier`) will land in a subsequent PR.
- `src/reference/LineLattice.jl` — 1D chain with PBC/OBC. Handles degenerate `N==2` PBC collapsed to a single neighbour via `unique!`.
- `src/reference/SimpleSquareLattice.jl` — 2D `Lx × Ly` lattice with PBC/OBC applied uniformly to both axes, row-major site indexing. Same degenerate-case guard.
- Trait overrides: `topology`, `periodicity`, `is_bipartite` (correctly handles parity for PBC cycles — odd cycles are not bipartite), `reciprocal_support`.
- `test/core/test_boundary_condition.jl`, `test_line_lattice.jl`, `test_simple_square_lattice.jl` — **73 new tests** covering:
  - Construction with both BCs
  - Position layout (row-major for 2D)
  - Neighbours for interior / edges / corners / degenerate `N==2` / `Lx==2` cases
  - Bond counts (OBC chain `N-1`, PBC cycle `N`, OBC square `(Lx-1)*Ly + Lx*(Ly-1)`, PBC square `2*Lx*Ly`)
  - Trait overrides (topology, periodicity, is_bipartite parity, reciprocal_support)
  - `bond_center` via default `Bond` iteration

**Changed**

- `src/LatticeCore.jl` — include and export the new modules
- `Project.toml` — bump `0.1.1` → `0.2.0` (first feature release)

## Usage or Results

```julia
using LatticeCore

# 1D PBC chain of 5 sites
line = LineLattice(5, PBC())
neighbors(line, 1)   # [5, 2]  — wraps
is_bipartite(line)   # false (odd cycle)

# 2D OBC 3x3 square
sq = SimpleSquareLattice(3, 3, OBC())
neighbors(sq, 1)     # [2, 4]  — corner has 2 neighbours
length(collect(bonds(sq)))  # 12
```

Local test run: **131 / 131 pass** (58 from the previous PR + 73 new).

## Known limitation

The default `bonds()` iterator inherited from `Bond.jl` returns raw `position(j) - position(i)` displacements, which are **not wrapped by PBC**. This is a known issue from the minimal bond design; the 03-designed `LatticeBoundary` + bond wrapping will fix it in the next PR alongside the per-axis BC work.

## check list
- [x] test駆動をしたか — 73 new tests covering interior / edge / corner / degenerate cases, both BCs, and all trait overrides