### PR TITLE
feat!: LatticeBoundary with per-axis BCs and wrapped bond vectors

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.2.0"
+version = "0.3.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/BoundaryCondition.jl
+++ b/src/BoundaryCondition.jl
@@ -3,30 +3,173 @@
 
 Abstract supertype for lattice boundary conditions.
 
-This file ships only the minimal vocabulary (`PBC`, `OBC`) required to
-exercise the reference lattices (`LineLattice`, `SimpleSquareLattice`)
-and the Monte Carlo smoke tests.
+The canonical concrete type is [`LatticeBoundary`](@ref), which
+composes:
 
-The richer per-axis design from `dev/note/04_architecture/03_boundary_and_coordinates`
-—`LatticeBoundary{N, A, M}`, `AbstractAxisBC` (`PeriodicAxis` /
-`OpenAxis` / `TwistedAxis`), `AbstractBoundaryModifier`—will land in a
-subsequent PR. Concrete lattice types here treat `PBC` / `OBC` as
-uniform markers that apply to every axis at once.
+- a tuple of per-axis boundary conditions (subtypes of
+  [`AbstractAxisBC`](@ref): [`PeriodicAxis`](@ref),
+  [`OpenAxis`](@ref), [`TwistedAxis`](@ref))
+- a non-topological modifier (subtype of
+  [`AbstractBoundaryModifier`](@ref): [`NoModifier`](@ref),
+  [`SSD`](@ref))
+
+The split is deliberate: an *axis BC* decides whether a candidate
+bond exists (and whether it carries a twist phase), while a *modifier*
+only reweights existing bonds (e.g. sine-square deformation). Multiple
+concerns are composed, not shoehorned into a single taxonomy.
+
+See `dev/note/04_architecture/03_boundary_and_coordinates/README.md`
+for the design rationale.
 """
 abstract type AbstractBoundaryCondition end
 
-"""
-    PBC()
-
-Periodic boundary condition marker. Applied uniformly to all axes by
-the reference lattices.
-"""
-struct PBC <: AbstractBoundaryCondition end
+# ---- Axis-level BC ---------------------------------------------------
 
 """
-    OBC()
+    AbstractAxisBC
 
-Open boundary condition marker. Applied uniformly to all axes by the
-reference lattices.
+Abstract supertype for per-axis boundary conditions. Concrete subtypes
+decide how a raw candidate cell index is wrapped into the lattice's
+index range along a single axis.
+
+Subtypes:
+- [`PeriodicAxis`](@ref) — wraps via `mod1`
+- [`OpenAxis`](@ref) — rejects out-of-range indices
+- [`TwistedAxis`](@ref) — wraps like `PeriodicAxis` but attaches a
+  phase factor to bonds that cross the boundary
 """
-struct OBC <: AbstractBoundaryCondition end
+abstract type AbstractAxisBC end
+
+"""Periodic axis BC: wrap-around via `mod1`."""
+struct PeriodicAxis <: AbstractAxisBC end
+
+"""Open axis BC: bonds crossing the boundary are dropped."""
+struct OpenAxis <: AbstractAxisBC end
+
+"""
+    TwistedAxis(phase::Real)
+
+Periodic axis BC with a phase angle (radians) attached to
+boundary-crossing bonds. The connectivity is identical to
+[`PeriodicAxis`](@ref); only the phase returned by [`axis_phase`](@ref)
+differs.
+"""
+struct TwistedAxis{T<:Real} <: AbstractAxisBC
+    phase::T
+end
+
+# ---- Modifier (non-topological) --------------------------------------
+
+"""
+    AbstractBoundaryModifier
+
+Abstract supertype for boundary modifiers. A modifier does not change
+which bonds exist — it only reweights existing bonds through
+[`bond_weight`](@ref). Examples: [`NoModifier`](@ref),
+[`SSD`](@ref).
+"""
+abstract type AbstractBoundaryModifier end
+
+"""Identity modifier: every bond has weight `1.0`."""
+struct NoModifier <: AbstractBoundaryModifier end
+
+"""
+    SSD(L)
+
+Sine-square deformation modifier. `L` is the characteristic scale
+used by the envelope `sin²(π · x/L)`. The concrete weight implementation
+will land with the MC layer; for now this serves as a placeholder
+carrying the scale parameter.
+"""
+struct SSD{T<:Real} <: AbstractBoundaryModifier
+    L::T
+end
+
+# ---- Composite boundary ----------------------------------------------
+
+"""
+    LatticeBoundary{N, A, M}(axes::NTuple{N, <:AbstractAxisBC}, modifier)
+
+Composite boundary condition for an `N`-dimensional lattice. Stores
+one [`AbstractAxisBC`](@ref) per axis plus a single
+[`AbstractBoundaryModifier`](@ref). Supports mixed-axis boundary
+conditions natively — a cylinder is
+
+```julia
+LatticeBoundary((PeriodicAxis(), OpenAxis()))
+```
+
+The zero-modifier form is the default.
+"""
+struct LatticeBoundary{N,A<:Tuple{Vararg{AbstractAxisBC}},M<:AbstractBoundaryModifier} <:
+       AbstractBoundaryCondition
+    axes::A
+    modifier::M
+
+    function LatticeBoundary(
+        axes::A, modifier::M
+    ) where {A<:Tuple{Vararg{AbstractAxisBC}},M<:AbstractBoundaryModifier}
+        return new{length(axes),A,M}(axes, modifier)
+    end
+end
+
+"""
+    LatticeBoundary(axes::NTuple{N, <:AbstractAxisBC})
+
+Convenience constructor: composite boundary with [`NoModifier`](@ref).
+"""
+LatticeBoundary(axes::Tuple{Vararg{AbstractAxisBC}}) = LatticeBoundary(axes, NoModifier())
+
+# ---- Hook functions --------------------------------------------------
+
+"""
+    apply_axis_bc(axis_bc::AbstractAxisBC, idx::Int, L::Int) → (wrapped, is_valid)
+
+Apply the axis-level BC to a raw cell index `idx ∈ ℤ` on an axis of
+length `L`. Returns a tuple `(wrapped::Int, is_valid::Bool)`:
+
+- `PeriodicAxis`, `TwistedAxis`: `(mod1(idx, L), true)`
+- `OpenAxis`: `(idx, 1 <= idx <= L)`
+
+The twist *phase* is intentionally reported separately by
+[`axis_phase`](@ref): MC code paths that do not need phases (classical
+Ising / XY / Heisenberg) are not forced to traffic in complex numbers.
+"""
+apply_axis_bc(::PeriodicAxis, idx::Int, L::Int) = (mod1(idx, L), true)
+apply_axis_bc(::OpenAxis, idx::Int, L::Int) = (idx, 1 <= idx <= L)
+apply_axis_bc(::TwistedAxis, idx::Int, L::Int) = (mod1(idx, L), true)
+
+"""
+    axis_phase(axis_bc::AbstractAxisBC, idx::Int, L::Int) → ComplexF64
+
+Phase factor attached to a bond that steps from a valid cell index
+to `idx` (possibly out of `1:L`) along a single axis.
+
+- `PeriodicAxis`, `OpenAxis`: always `1 + 0im`.
+- `TwistedAxis(θ)`: `cis(+θ)` if `idx > L`, `cis(-θ)` if `idx < 1`, otherwise `1 + 0im`.
+
+Classical MC paths may ignore this; quantum / flux-carrying code
+should multiply bond contributions by the phase.
+"""
+axis_phase(::PeriodicAxis, ::Int, ::Int) = complex(1.0, 0.0)
+axis_phase(::OpenAxis, ::Int, ::Int) = complex(1.0, 0.0)
+function axis_phase(ax::TwistedAxis, idx::Int, L::Int)
+    if idx > L
+        return cis(float(ax.phase))
+    elseif idx < 1
+        return cis(-float(ax.phase))
+    else
+        return complex(1.0, 0.0)
+    end
+end
+
+"""
+    bond_weight(modifier::AbstractBoundaryModifier, lat, i::Int, j::Int) → Float64
+
+Multiplicative weight applied to the bond `(i, j)` by a boundary
+modifier. Default implementation for [`NoModifier`](@ref) returns
+`1.0`. SSD and other non-trivial modifiers will override this.
+"""
+bond_weight(::NoModifier, lat, ::Int, ::Int) = 1.0
+# SSD weight is intentionally left unimplemented for now; it will land
+# with the MC layer once we have a `center(lat)` accessor.

--- a/src/LatticeCore.jl
+++ b/src/LatticeCore.jl
@@ -32,7 +32,10 @@ export AbstractSizeTrait, FiniteSize, InfiniteSize, QuasiInfiniteSize
 export size_trait, is_finite
 
 # ---- Boundary conditions ----
-export AbstractBoundaryCondition, PBC, OBC
+export AbstractBoundaryCondition
+export AbstractAxisBC, PeriodicAxis, OpenAxis, TwistedAxis
+export AbstractBoundaryModifier, NoModifier, SSD
+export LatticeBoundary, apply_axis_bc, axis_phase, bond_weight
 
 # ---- Reference lattices ----
 export LineLattice, SimpleSquareLattice

--- a/src/reference/LineLattice.jl
+++ b/src/reference/LineLattice.jl
@@ -1,33 +1,39 @@
 """
-    LineLattice{T, B <: AbstractBoundaryCondition}(N, boundary)
+    LineLattice{T, B <: LatticeBoundary}(N, boundary)
 
-A 1D linear chain of `N` sites with unit spacing. The type parameter
-`B` selects the boundary condition: `PBC` (periodic) or `OBC` (open).
+A 1D linear chain of `N` sites with unit spacing. `boundary` is a
+[`LatticeBoundary`](@ref) whose single axis component is one of
+[`PeriodicAxis`](@ref), [`OpenAxis`](@ref), or [`TwistedAxis`](@ref).
 
-This is LatticeCore's simplest reference implementation; paired with
-`SimpleSquareLattice` it is also the canonical mock used by downstream
-Monte Carlo unit tests.
+LatticeCore's simplest reference implementation; paired with
+[`SimpleSquareLattice`](@ref) it is also the canonical mock used by
+downstream Monte Carlo unit tests.
 
-# Example
+# Examples
 ```julia
-julia> lat = LineLattice(5, PBC());
+# Default: 1D periodic
+line = LineLattice(5)
 
-julia> num_sites(lat)
-5
+# Open boundary chain
+chain = LineLattice(5, OpenAxis())
 
-julia> neighbors(lat, 1)
-2-element Vector{Int64}:
- 5
- 2
+# Explicit LatticeBoundary (e.g. with a twist)
+twisted = LineLattice(5, LatticeBoundary((TwistedAxis(π/4),)))
 ```
 """
-struct LineLattice{T<:AbstractFloat,B<:AbstractBoundaryCondition} <: AbstractLattice{1,T}
+struct LineLattice{T<:AbstractFloat,B<:LatticeBoundary} <: AbstractLattice{1,T}
     N::Int
     boundary::B
 end
 
-# Convenience constructor: default to Float64 positions.
-function LineLattice(N::Int, boundary::B=PBC()) where {B<:AbstractBoundaryCondition}
+# Convenience constructors: default to Float64 positions. The axis BC
+# is wrapped in a `LatticeBoundary` automatically so users can write
+# `LineLattice(5, PeriodicAxis())` instead of the explicit tuple form.
+function LineLattice(N::Int, axis::AbstractAxisBC=PeriodicAxis())
+    return LineLattice(N, LatticeBoundary((axis,), NoModifier()))
+end
+
+function LineLattice(N::Int, boundary::B) where {B<:LatticeBoundary}
     return LineLattice{Float64,B}(N, boundary)
 end
 
@@ -37,30 +43,61 @@ num_sites(l::LineLattice) = l.N
 
 position(l::LineLattice{T}, i::Int) where {T} = SVector{1,T}(T(i))
 
-function neighbors(l::LineLattice{T,PBC}, i::Int) where {T}
-    # `unique!` collapses the degenerate N == 2 case (both neighbours
-    # point to the other site) to a single entry.
-    return unique!([mod1(i - 1, l.N), mod1(i + 1, l.N)])
-end
-
-function neighbors(l::LineLattice{T,OBC}, i::Int) where {T}
-    return filter(j -> 1 <= j <= l.N, [i - 1, i + 1])
+function neighbors(l::LineLattice, i::Int)
+    ax = l.boundary.axes[1]
+    ns = Int[]
+    seen = Set{Int}()
+    for step in (i + 1, i - 1)
+        j, ok = apply_axis_bc(ax, step, l.N)
+        if ok && j != i && !(j in seen)
+            push!(ns, j)
+            push!(seen, j)
+        end
+    end
+    return ns
 end
 
 boundary(l::LineLattice) = l.boundary
 
 size_trait(l::LineLattice) = FiniteSize((l.N,))
 
+# ---- Bond iteration with wrapped (unit) displacement vectors ---------
+
+function neighbor_bonds(l::LineLattice{T}, i::Int) where {T}
+    ax = l.boundary.axes[1]
+    out = Bond{1,T}[]
+    seen = Set{Int}()
+    for (step, dx) in ((i + 1, T(1)), (i - 1, T(-1)))
+        j, ok = apply_axis_bc(ax, step, l.N)
+        if ok && j != i && !(j in seen)
+            push!(out, Bond{1,T}(i, j, SVector{1,T}(dx), :nearest))
+            push!(seen, j)
+        end
+    end
+    return out
+end
+
+function bonds(l::LineLattice{T}) where {T}
+    return (b for i in 1:num_sites(l) for b in neighbor_bonds(l, i) if b.j > b.i)
+end
+
 # ---- Trait overrides ----
 
 topology(::LineLattice) = TopologyTrait{:line}()
 
-periodicity(::LineLattice{T,PBC}) where {T} = Periodic()
-periodicity(::LineLattice{T,OBC}) where {T} = Aperiodic()
+function periodicity(l::LineLattice)
+    ax = l.boundary.axes[1]
+    return ax isa OpenAxis ? Aperiodic() : Periodic()
+end
 
-# PBC chain is bipartite iff the cycle length N is even.
-is_bipartite(l::LineLattice{T,PBC}) where {T} = iseven(l.N)
-is_bipartite(::LineLattice{T,OBC}) where {T} = true
+# A 1D chain with PBC/TwistedBC is bipartite iff the cycle length is even.
+# Open chain is always bipartite.
+function is_bipartite(l::LineLattice)
+    ax = l.boundary.axes[1]
+    return ax isa OpenAxis ? true : iseven(l.N)
+end
 
-reciprocal_support(::LineLattice{T,PBC}) where {T} = HasReciprocal()
-reciprocal_support(::LineLattice{T,OBC}) where {T} = NoReciprocal()
+function reciprocal_support(l::LineLattice)
+    ax = l.boundary.axes[1]
+    return ax isa OpenAxis ? NoReciprocal() : HasReciprocal()
+end

--- a/src/reference/SimpleSquareLattice.jl
+++ b/src/reference/SimpleSquareLattice.jl
@@ -1,15 +1,17 @@
 """
-    SimpleSquareLattice{T, B <: AbstractBoundaryCondition}(Lx, Ly, boundary)
+    SimpleSquareLattice{T, B <: LatticeBoundary}(Lx, Ly, boundary)
 
-A 2D square lattice of `Lx × Ly` sites with unit spacing. The type
-parameter `B` selects the boundary condition (`PBC` or `OBC`), applied
-uniformly to both axes.
+A 2D square lattice of `Lx × Ly` sites with unit spacing. `boundary`
+is a [`LatticeBoundary`](@ref) whose two axis components independently
+select between [`PeriodicAxis`](@ref), [`OpenAxis`](@ref), and
+[`TwistedAxis`](@ref) — so mixed BCs (e.g. cylinders) are supported
+natively.
 
-This is LatticeCore's 2D reference implementation. It exists so that
-the core interface can be exercised end-to-end without depending on
+LatticeCore's 2D reference implementation. It exists so that the core
+interface can be exercised end-to-end without depending on
 `Lattice2D.jl`. The production-grade 2D lattice, with the full
 topology catalogue (triangular, honeycomb, kagome, ...), sublattice
-site types, and reciprocal lattice machinery, lives in `Lattice2D.jl`.
+site types, and reciprocal-lattice machinery, lives in `Lattice2D.jl`.
 
 # Site indexing
 
@@ -19,30 +21,31 @@ Sites are laid out in row-major order:
 
 so sites 1..Lx form the bottom row, Lx+1..2Lx the next, and so on.
 
-# Example
+# Examples
 ```julia
-julia> lat = SimpleSquareLattice(3, 3, PBC());
+# Default: 2D PBC
+sq = SimpleSquareLattice(3, 3)
 
-julia> num_sites(lat)
-9
+# Uniform open boundary
+open_sq = SimpleSquareLattice(3, 3, OpenAxis())
 
-julia> position(lat, 5)   # middle of a 3x3 lattice
-2-element StaticArraysCore.SVector{2, Float64} with indices SOneTo(2):
- 2.0
- 2.0
+# Cylinder: periodic in x, open in y
+cylinder = SimpleSquareLattice(3, 3, LatticeBoundary((PeriodicAxis(), OpenAxis())))
 ```
 """
-struct SimpleSquareLattice{T<:AbstractFloat,B<:AbstractBoundaryCondition} <:
-       AbstractLattice{2,T}
+struct SimpleSquareLattice{T<:AbstractFloat,B<:LatticeBoundary} <: AbstractLattice{2,T}
     Lx::Int
     Ly::Int
     boundary::B
 end
 
-# Convenience constructor: default to Float64 positions and PBC.
-function SimpleSquareLattice(
-    Lx::Int, Ly::Int, boundary::B=PBC()
-) where {B<:AbstractBoundaryCondition}
+# Convenience constructors. The single-axis overload applies the same
+# BC to both axes; mixed cases go through `LatticeBoundary` directly.
+function SimpleSquareLattice(Lx::Int, Ly::Int, axis::AbstractAxisBC=PeriodicAxis())
+    return SimpleSquareLattice(Lx, Ly, LatticeBoundary((axis, axis), NoModifier()))
+end
+
+function SimpleSquareLattice(Lx::Int, Ly::Int, boundary::B) where {B<:LatticeBoundary}
     return SimpleSquareLattice{Float64,B}(Lx, Ly, boundary)
 end
 
@@ -67,33 +70,33 @@ function position(l::SimpleSquareLattice{T}, i::Int) where {T}
     return SVector{2,T}(T(x), T(y))
 end
 
-function neighbors(l::SimpleSquareLattice{T,PBC}, i::Int) where {T}
+# Single helper shared with `neighbor_bonds`: walk the four axis steps,
+# apply per-axis BCs, deduplicate.
+function _square_steps(l::SimpleSquareLattice, i::Int)
     x, y = _site_to_xy(l, i)
-    ns = [
-        _xy_to_site(l, mod1(x + 1, l.Lx), y),
-        _xy_to_site(l, mod1(x - 1, l.Lx), y),
-        _xy_to_site(l, x, mod1(y + 1, l.Ly)),
-        _xy_to_site(l, x, mod1(y - 1, l.Ly)),
-    ]
-    # Collapse degenerate Lx == 2 / Ly == 2 cases that would otherwise
-    # return duplicate neighbours.
-    return unique!(ns)
+    bx, by = l.boundary.axes
+    steps = Tuple{Int,Int,Int,Int}[]           # (dx, dy, nx, ny)
+    for (dx, dy) in ((1, 0), (-1, 0), (0, 1), (0, -1))
+        nx_raw = x + dx
+        ny_raw = y + dy
+        nx, ok_x = apply_axis_bc(bx, nx_raw, l.Lx)
+        ok_x || continue
+        ny, ok_y = apply_axis_bc(by, ny_raw, l.Ly)
+        ok_y || continue
+        push!(steps, (dx, dy, nx, ny))
+    end
+    return steps
 end
 
-function neighbors(l::SimpleSquareLattice{T,OBC}, i::Int) where {T}
-    x, y = _site_to_xy(l, i)
+function neighbors(l::SimpleSquareLattice, i::Int)
     ns = Int[]
-    if x + 1 <= l.Lx
-        push!(ns, _xy_to_site(l, x + 1, y))
-    end
-    if x - 1 >= 1
-        push!(ns, _xy_to_site(l, x - 1, y))
-    end
-    if y + 1 <= l.Ly
-        push!(ns, _xy_to_site(l, x, y + 1))
-    end
-    if y - 1 >= 1
-        push!(ns, _xy_to_site(l, x, y - 1))
+    seen = Set{Int}()
+    for (_, _, nx, ny) in _square_steps(l, i)
+        j = _xy_to_site(l, nx, ny)
+        if j != i && !(j in seen)
+            push!(ns, j)
+            push!(seen, j)
+        end
     end
     return ns
 end
@@ -102,18 +105,49 @@ boundary(l::SimpleSquareLattice) = l.boundary
 
 size_trait(l::SimpleSquareLattice) = FiniteSize((l.Lx, l.Ly))
 
+# ---- Bond iteration with wrapped (unit) displacement vectors ---------
+
+function neighbor_bonds(l::SimpleSquareLattice{T}, i::Int) where {T}
+    out = Bond{2,T}[]
+    seen = Set{Int}()
+    for (dx, dy, nx, ny) in _square_steps(l, i)
+        j = _xy_to_site(l, nx, ny)
+        if j != i && !(j in seen)
+            vec = SVector{2,T}(T(dx), T(dy))
+            push!(out, Bond{2,T}(i, j, vec, :nearest))
+            push!(seen, j)
+        end
+    end
+    return out
+end
+
+function bonds(l::SimpleSquareLattice{T}) where {T}
+    return (b for i in 1:num_sites(l) for b in neighbor_bonds(l, i) if b.j > b.i)
+end
+
 # ---- Trait overrides ----
 
 topology(::SimpleSquareLattice) = TopologyTrait{:square}()
 
-periodicity(::SimpleSquareLattice{T,PBC}) where {T} = Periodic()
-periodicity(::SimpleSquareLattice{T,OBC}) where {T} = Aperiodic()
-
-# PBC square lattice is bipartite iff both axis lengths are even.
-function is_bipartite(l::SimpleSquareLattice{T,PBC}) where {T}
-    return iseven(l.Lx) && iseven(l.Ly)
+function periodicity(l::SimpleSquareLattice)
+    all_periodic = all(!(a isa OpenAxis) for a in l.boundary.axes)
+    return all_periodic ? Periodic() : Aperiodic()
 end
-is_bipartite(::SimpleSquareLattice{T,OBC}) where {T} = true
 
-reciprocal_support(::SimpleSquareLattice{T,PBC}) where {T} = HasReciprocal()
-reciprocal_support(::SimpleSquareLattice{T,OBC}) where {T} = NoReciprocal()
+# Square lattice graph bipartiteness:
+# - OBC axes never introduce odd cycles.
+# - PBC / Twisted cycles must have even length for bipartiteness.
+# We require every axis to be bipartite in isolation; the combined
+# graph is bipartite iff every axis along which the lattice wraps has
+# even length.
+function is_bipartite(l::SimpleSquareLattice)
+    bx, by = l.boundary.axes
+    bx_ok = (bx isa OpenAxis) || iseven(l.Lx)
+    by_ok = (by isa OpenAxis) || iseven(l.Ly)
+    return bx_ok && by_ok
+end
+
+function reciprocal_support(l::SimpleSquareLattice)
+    all_periodic = all(!(a isa OpenAxis) for a in l.boundary.axes)
+    return all_periodic ? HasReciprocal() : NoReciprocal()
+end

--- a/test/core/test_boundary_condition.jl
+++ b/test/core/test_boundary_condition.jl
@@ -1,10 +1,74 @@
 using LatticeCore
 using Test
 
-@testset "BoundaryCondition basics" begin
-    @test PBC <: AbstractBoundaryCondition
-    @test OBC <: AbstractBoundaryCondition
-    @test PBC() isa AbstractBoundaryCondition
-    @test OBC() isa AbstractBoundaryCondition
-    @test PBC() != OBC()
+@testset "BoundaryCondition type hierarchy" begin
+    @test AbstractAxisBC <: Any
+    @test PeriodicAxis <: AbstractAxisBC
+    @test OpenAxis <: AbstractAxisBC
+    @test TwistedAxis <: AbstractAxisBC
+
+    @test AbstractBoundaryModifier <: Any
+    @test NoModifier <: AbstractBoundaryModifier
+    @test SSD <: AbstractBoundaryModifier
+
+    @test LatticeBoundary <: AbstractBoundaryCondition
+end
+
+@testset "LatticeBoundary construction" begin
+    b1 = LatticeBoundary((PeriodicAxis(),))
+    @test b1 isa LatticeBoundary{1}
+    @test length(b1.axes) == 1
+    @test b1.axes[1] isa PeriodicAxis
+    @test b1.modifier isa NoModifier
+
+    b2 = LatticeBoundary((PeriodicAxis(), OpenAxis()))
+    @test b2 isa LatticeBoundary{2}
+    @test b2.axes[1] isa PeriodicAxis
+    @test b2.axes[2] isa OpenAxis
+
+    b3 = LatticeBoundary((PeriodicAxis(), PeriodicAxis()), SSD(8.0))
+    @test b3.modifier isa SSD
+    @test b3.modifier.L == 8.0
+end
+
+@testset "apply_axis_bc" begin
+    @testset "PeriodicAxis wraps via mod1" begin
+        @test apply_axis_bc(PeriodicAxis(), 0, 5) == (5, true)
+        @test apply_axis_bc(PeriodicAxis(), 1, 5) == (1, true)
+        @test apply_axis_bc(PeriodicAxis(), 5, 5) == (5, true)
+        @test apply_axis_bc(PeriodicAxis(), 6, 5) == (1, true)
+        @test apply_axis_bc(PeriodicAxis(), -1, 5) == (4, true)
+    end
+
+    @testset "OpenAxis rejects out-of-range" begin
+        @test apply_axis_bc(OpenAxis(), 0, 5) == (0, false)
+        @test apply_axis_bc(OpenAxis(), 1, 5) == (1, true)
+        @test apply_axis_bc(OpenAxis(), 3, 5) == (3, true)
+        @test apply_axis_bc(OpenAxis(), 5, 5) == (5, true)
+        @test apply_axis_bc(OpenAxis(), 6, 5) == (6, false)
+    end
+
+    @testset "TwistedAxis wraps like PBC" begin
+        ax = TwistedAxis(π / 4)
+        @test apply_axis_bc(ax, 6, 5) == (1, true)
+        @test apply_axis_bc(ax, 0, 5) == (5, true)
+    end
+end
+
+@testset "axis_phase" begin
+    # Non-twisted axes return unit phase.
+    @test axis_phase(PeriodicAxis(), 6, 5) == complex(1.0, 0.0)
+    @test axis_phase(OpenAxis(), 6, 5) == complex(1.0, 0.0)
+
+    # TwistedAxis attaches exp(±iθ) when the raw index exits the range.
+    θ = 0.3
+    ax = TwistedAxis(θ)
+    @test axis_phase(ax, 6, 5) ≈ cis(θ)
+    @test axis_phase(ax, 0, 5) ≈ cis(-θ)
+    @test axis_phase(ax, 3, 5) == complex(1.0, 0.0)   # interior: no phase
+end
+
+@testset "bond_weight" begin
+    # NoModifier always returns 1.0; no lattice actually needed.
+    @test bond_weight(NoModifier(), nothing, 1, 2) == 1.0
 end

--- a/test/core/test_line_lattice.jl
+++ b/test/core/test_line_lattice.jl
@@ -3,35 +3,47 @@ using StaticArrays
 using Test
 
 @testset "LineLattice" begin
-    @testset "construction (default Float64)" begin
+    @testset "construction (default Float64, default PBC)" begin
         lat = LineLattice(5)
-        @test lat isa LineLattice{Float64,PBC}
+        @test lat isa LineLattice{Float64}
         @test lat isa AbstractLattice{1,Float64}
         @test dimension(lat) == 1
         @test eltype(lat) === Float64
         @test num_sites(lat) == 5
-        @test boundary(lat) isa PBC
+
+        bc = boundary(lat)
+        @test bc isa LatticeBoundary{1}
+        @test bc.axes[1] isa PeriodicAxis
+        @test bc.modifier isa NoModifier
     end
 
-    @testset "PBC neighbors" begin
-        lat = LineLattice(5, PBC())
-        # interior
+    @testset "axis BC shorthand construction" begin
+        @test boundary(LineLattice(5, PeriodicAxis())).axes[1] isa PeriodicAxis
+        @test boundary(LineLattice(5, OpenAxis())).axes[1] isa OpenAxis
+        @test boundary(LineLattice(5, TwistedAxis(0.3))).axes[1] isa TwistedAxis
+    end
+
+    @testset "explicit LatticeBoundary construction" begin
+        lat = LineLattice(5, LatticeBoundary((PeriodicAxis(),), NoModifier()))
+        @test boundary(lat).axes[1] isa PeriodicAxis
+    end
+
+    @testset "PeriodicAxis neighbors" begin
+        lat = LineLattice(5, PeriodicAxis())
         @test Set(neighbors(lat, 3)) == Set([2, 4])
-        # left edge wraps to right edge
         @test Set(neighbors(lat, 1)) == Set([5, 2])
-        # right edge wraps to left edge
         @test Set(neighbors(lat, 5)) == Set([4, 1])
     end
 
-    @testset "OBC neighbors" begin
-        lat = LineLattice(5, OBC())
+    @testset "OpenAxis neighbors" begin
+        lat = LineLattice(5, OpenAxis())
         @test neighbors(lat, 1) == [2]
         @test Set(neighbors(lat, 3)) == Set([2, 4])
         @test neighbors(lat, 5) == [4]
     end
 
     @testset "positions" begin
-        lat = LineLattice(4, OBC())
+        lat = LineLattice(4, OpenAxis())
         ps = collect(positions(lat))
         @test length(ps) == 4
         @test ps[1] == SVector(1.0)
@@ -40,48 +52,60 @@ using Test
 
     @testset "bond counts" begin
         # OBC chain of length N has N-1 bonds
-        lat_obc = LineLattice(5, OBC())
-        @test length(collect(bonds(lat_obc))) == 4
+        @test length(collect(bonds(LineLattice(5, OpenAxis())))) == 4
         # PBC cycle of length N has N bonds
-        lat_pbc = LineLattice(5, PBC())
-        @test length(collect(bonds(lat_pbc))) == 5
+        @test length(collect(bonds(LineLattice(5, PeriodicAxis())))) == 5
     end
 
-    @testset "neighbor_bonds" begin
-        lat = LineLattice(5, PBC())
+    @testset "neighbor_bonds with wrapped unit displacements" begin
+        lat = LineLattice(5, PeriodicAxis())
+
+        # Interior site: both bonds have ±1 displacement.
         nb_mid = collect(neighbor_bonds(lat, 3))
         @test length(nb_mid) == 2
         @test all(b.i == 3 for b in nb_mid)
         @test Set(b.j for b in nb_mid) == Set([2, 4])
+        @test Set(b.vector[1] for b in nb_mid) == Set([1.0, -1.0])
+
+        # Boundary-crossing site: +1 direction wraps to site 1 (not raw +4).
+        nb_edge = collect(neighbor_bonds(lat, 5))
+        @test length(nb_edge) == 2
+        @test Set(b.j for b in nb_edge) == Set([4, 1])
+        # The bond (5 -> 1) must carry a +1 displacement, not a raw +(-4).
+        wrap_bond = first(b for b in nb_edge if b.j == 1)
+        @test wrap_bond.vector == SVector(1.0)
     end
 
     @testset "size trait / is_finite" begin
-        lat = LineLattice(7, OBC())
+        lat = LineLattice(7, OpenAxis())
         @test size_trait(lat) isa FiniteSize{1}
         @test size_trait(lat).dims == (7,)
         @test is_finite(lat) == true
     end
 
     @testset "trait overrides" begin
-        pbc_even = LineLattice(6, PBC())
-        pbc_odd = LineLattice(5, PBC())
-        obc = LineLattice(5, OBC())
+        pbc_even = LineLattice(6, PeriodicAxis())
+        pbc_odd = LineLattice(5, PeriodicAxis())
+        obc = LineLattice(5, OpenAxis())
+        twisted = LineLattice(6, TwistedAxis(0.2))
 
         @test topology(pbc_even) isa TopologyTrait{:line}
         @test periodicity(pbc_even) isa Periodic
         @test periodicity(obc) isa Aperiodic
+        @test periodicity(twisted) isa Periodic     # twisted ⇒ still cyclic
 
-        @test is_bipartite(pbc_even) == true    # even cycle
-        @test is_bipartite(pbc_odd) == false    # odd cycle
-        @test is_bipartite(obc) == true         # chain is always bipartite
+        @test is_bipartite(pbc_even) == true       # even cycle
+        @test is_bipartite(pbc_odd) == false       # odd cycle
+        @test is_bipartite(obc) == true            # chain is always bipartite
+        @test is_bipartite(twisted) == true        # even twisted cycle
 
         @test reciprocal_support(pbc_even) isa HasReciprocal
         @test reciprocal_support(obc) isa NoReciprocal
+        @test reciprocal_support(twisted) isa HasReciprocal
     end
 
     @testset "degenerate N=2 PBC (duplicate neighbour collapse)" begin
-        lat = LineLattice(2, PBC())
-        # Both left and right wrap to the other site → just one neighbour.
+        lat = LineLattice(2, PeriodicAxis())
         @test neighbors(lat, 1) == [2]
         @test neighbors(lat, 2) == [1]
         @test length(collect(bonds(lat))) == 1

--- a/test/core/test_simple_square_lattice.jl
+++ b/test/core/test_simple_square_lattice.jl
@@ -5,16 +5,31 @@ using Test
 @testset "SimpleSquareLattice" begin
     @testset "construction" begin
         lat = SimpleSquareLattice(3, 4)
-        @test lat isa SimpleSquareLattice{Float64,PBC}
+        @test lat isa SimpleSquareLattice{Float64}
         @test lat isa AbstractLattice{2,Float64}
         @test dimension(lat) == 2
         @test num_sites(lat) == 12
-        @test boundary(lat) isa PBC
+
+        bc = boundary(lat)
+        @test bc isa LatticeBoundary{2}
+        @test bc.axes[1] isa PeriodicAxis
+        @test bc.axes[2] isa PeriodicAxis
+    end
+
+    @testset "axis BC shorthand" begin
+        sq = SimpleSquareLattice(3, 3, OpenAxis())
+        @test boundary(sq).axes[1] isa OpenAxis
+        @test boundary(sq).axes[2] isa OpenAxis
+    end
+
+    @testset "explicit mixed BC (cylinder)" begin
+        cyl = SimpleSquareLattice(3, 3, LatticeBoundary((PeriodicAxis(), OpenAxis())))
+        @test boundary(cyl).axes[1] isa PeriodicAxis
+        @test boundary(cyl).axes[2] isa OpenAxis
     end
 
     @testset "position layout (row-major)" begin
-        lat = SimpleSquareLattice(3, 2, OBC())
-        # Row-major: sites 1,2,3 = row y=1; sites 4,5,6 = row y=2.
+        lat = SimpleSquareLattice(3, 2, OpenAxis())
         @test position(lat, 1) == SVector(1.0, 1.0)
         @test position(lat, 2) == SVector(2.0, 1.0)
         @test position(lat, 3) == SVector(3.0, 1.0)
@@ -23,60 +38,61 @@ using Test
         @test position(lat, 6) == SVector(3.0, 2.0)
     end
 
-    @testset "PBC neighbors (interior / edges)" begin
-        lat = SimpleSquareLattice(3, 3, PBC())
-
-        # Interior site (2,2) = site 5
-        @test Set(neighbors(lat, 5)) == Set([
-            6,  # (3,2)
-            4,  # (1,2)
-            8,  # (2,3)
-            2,  # (2,1)
-        ])
-
-        # Corner site (1,1) = site 1; wraps to (3,1) and (1,3)
-        @test Set(neighbors(lat, 1)) == Set([
-            2,  # (2,1)
-            3,  # (3,1) via wrap
-            4,  # (1,2)
-            7,  # (1,3) via wrap
-        ])
-    end
-
-    @testset "OBC neighbors (interior / corner / edge)" begin
-        lat = SimpleSquareLattice(3, 3, OBC())
-
+    @testset "PBC neighbors" begin
+        lat = SimpleSquareLattice(3, 3, PeriodicAxis())
         # Interior site (2,2) = site 5
         @test Set(neighbors(lat, 5)) == Set([6, 4, 8, 2])
+        # Corner site (1,1) = site 1; wraps to (3,1) and (1,3)
+        @test Set(neighbors(lat, 1)) == Set([2, 3, 4, 7])
+    end
 
-        # Corner site (1,1) = site 1: no wrap
+    @testset "OBC neighbors" begin
+        lat = SimpleSquareLattice(3, 3, OpenAxis())
+        @test Set(neighbors(lat, 5)) == Set([6, 4, 8, 2])
         @test Set(neighbors(lat, 1)) == Set([2, 4])
-
-        # Edge site (2,1) = site 2: has x-left, x-right, y-up only
         @test Set(neighbors(lat, 2)) == Set([1, 3, 5])
-
-        # Opposite corner (3,3) = site 9
         @test Set(neighbors(lat, 9)) == Set([8, 6])
     end
 
+    @testset "cylinder neighbors (x PBC, y OBC)" begin
+        cyl = SimpleSquareLattice(3, 3, LatticeBoundary((PeriodicAxis(), OpenAxis())))
+        # Corner (1,1) = site 1: x wraps to (3,1), y open so only (1,2)
+        @test Set(neighbors(cyl, 1)) == Set([2, 3, 4])
+        # Middle (2,2) = site 5: full 4 neighbours
+        @test Set(neighbors(cyl, 5)) == Set([6, 4, 8, 2])
+        # Top row (1,3) = site 7: wraps in x, open in y → (2,3), (3,3), (1,2)
+        @test Set(neighbors(cyl, 7)) == Set([8, 9, 4])
+    end
+
     @testset "bond counts" begin
-        # PBC Lx x Ly: 2 * Lx * Ly bonds (horizontal + vertical)
-        lat_pbc = SimpleSquareLattice(3, 3, PBC())
-        @test length(collect(bonds(lat_pbc))) == 18
+        # PBC Lx x Ly: 2 * Lx * Ly bonds
+        @test length(collect(bonds(SimpleSquareLattice(3, 3, PeriodicAxis())))) == 18
+        @test length(collect(bonds(SimpleSquareLattice(4, 5, PeriodicAxis())))) == 40
 
-        lat_pbc_4x5 = SimpleSquareLattice(4, 5, PBC())
-        @test length(collect(bonds(lat_pbc_4x5))) == 40
+        # OBC Lx x Ly: (Lx-1) * Ly + Lx * (Ly-1)
+        @test length(collect(bonds(SimpleSquareLattice(3, 3, OpenAxis())))) == 12
+        @test length(collect(bonds(SimpleSquareLattice(4, 5, OpenAxis())))) == (3 * 5) + (4 * 4)
 
-        # OBC Lx x Ly: (Lx-1) * Ly  +  Lx * (Ly-1) bonds
-        lat_obc = SimpleSquareLattice(3, 3, OBC())
-        @test length(collect(bonds(lat_obc))) == 12
+        # Cylinder: Lx PBC bonds per row (Lx) * Ly rows  +  (Ly-1) vertical bonds * Lx columns
+        cyl = SimpleSquareLattice(3, 3, LatticeBoundary((PeriodicAxis(), OpenAxis())))
+        @test length(collect(bonds(cyl))) == (3 * 3) + (2 * 3)   # 9 + 6 = 15
+    end
 
-        lat_obc_4x5 = SimpleSquareLattice(4, 5, OBC())
-        @test length(collect(bonds(lat_obc_4x5))) == (3 * 5) + (4 * 4)
+    @testset "bond wrapping: PBC corner bond carries unit vector" begin
+        lat = SimpleSquareLattice(3, 3, PeriodicAxis())
+        # Site 1 = (1,1): -x neighbour wraps to site 3 = (3,1).
+        # The bond vector must be (-1, 0), not the raw (2, 0).
+        nb1 = collect(neighbor_bonds(lat, 1))
+        wrap_x = first(b for b in nb1 if b.j == 3)
+        @test wrap_x.vector == SVector(-1.0, 0.0)
+
+        # Similarly for the y-wrapping bond to site 7 = (1, 3).
+        wrap_y = first(b for b in nb1 if b.j == 7)
+        @test wrap_y.vector == SVector(0.0, -1.0)
     end
 
     @testset "size trait / is_finite" begin
-        lat = SimpleSquareLattice(4, 6, PBC())
+        lat = SimpleSquareLattice(4, 6, PeriodicAxis())
         st = size_trait(lat)
         @test st isa FiniteSize{2}
         @test st.dims == (4, 6)
@@ -84,27 +100,30 @@ using Test
     end
 
     @testset "trait overrides" begin
-        pbc_even = SimpleSquareLattice(4, 4, PBC())
-        pbc_odd = SimpleSquareLattice(3, 3, PBC())
-        obc = SimpleSquareLattice(3, 3, OBC())
+        pbc_even = SimpleSquareLattice(4, 4, PeriodicAxis())
+        pbc_odd = SimpleSquareLattice(3, 3, PeriodicAxis())
+        obc = SimpleSquareLattice(3, 3, OpenAxis())
+        cyl = SimpleSquareLattice(4, 3, LatticeBoundary((PeriodicAxis(), OpenAxis())))
 
         @test topology(pbc_even) isa TopologyTrait{:square}
         @test periodicity(pbc_even) isa Periodic
         @test periodicity(obc) isa Aperiodic
+        @test periodicity(cyl) isa Aperiodic   # cylinder has an open axis
 
-        # PBC square is bipartite iff both Lx, Ly even
+        # Bipartiteness
         @test is_bipartite(pbc_even) == true
         @test is_bipartite(pbc_odd) == false
-        @test is_bipartite(SimpleSquareLattice(4, 3, PBC())) == false
+        @test is_bipartite(SimpleSquareLattice(4, 3, PeriodicAxis())) == false
         @test is_bipartite(obc) == true
+        @test is_bipartite(cyl) == true           # PBC axis is even (Lx=4)
 
         @test reciprocal_support(pbc_even) isa HasReciprocal
         @test reciprocal_support(obc) isa NoReciprocal
+        @test reciprocal_support(cyl) isa NoReciprocal  # mixed ⇒ no uniform recip
     end
 
     @testset "bond_center via default Bond iteration" begin
-        lat = SimpleSquareLattice(3, 3, OBC())
-        # Pick the bond between sites 1 (1,1) and 2 (2,1).
+        lat = SimpleSquareLattice(3, 3, OpenAxis())
         b = Bond{2,Float64}(1, 2, SVector(1.0, 0.0), :nearest)
         @test bond_center(lat, b) == SVector(1.5, 1.0)
     end

--- a/test/core/test_simple_square_lattice.jl
+++ b/test/core/test_simple_square_lattice.jl
@@ -71,7 +71,8 @@ using Test
 
         # OBC Lx x Ly: (Lx-1) * Ly + Lx * (Ly-1)
         @test length(collect(bonds(SimpleSquareLattice(3, 3, OpenAxis())))) == 12
-        @test length(collect(bonds(SimpleSquareLattice(4, 5, OpenAxis())))) == (3 * 5) + (4 * 4)
+        @test length(collect(bonds(SimpleSquareLattice(4, 5, OpenAxis())))) ==
+            (3 * 5) + (4 * 4)
 
         # Cylinder: Lx PBC bonds per row (Lx) * Ly rows  +  (Ly-1) vertical bonds * Lx columns
         cyl = SimpleSquareLattice(3, 3, LatticeBoundary((PeriodicAxis(), OpenAxis())))


### PR DESCRIPTION
## Description

Replace the minimal `PBC` / `OBC` singleton types with the full boundary model from [`dev/note/04_architecture/03_boundary_and_coordinates`](https://github.com/sotashimozono/work/blob/main/dev/note/04_architecture/03_boundary_and_coordinates/README.md). This is the **first half of plan B** of the 03 roadmap; the coordinate-system side (`AbstractCoordinate`, indexing) will follow in a subsequent PR.

Also fixes the known limitation from PR #3: `neighbor_bonds` / `bonds` on the reference lattices now emit correctly-wrapped unit displacement vectors (the default `Bond.jl` fallback using raw `position(j) - position(i)` is no longer exposed for these lattices).

Fixed: (no linked issue)

## Type of Change

- [x] ✨ Feature (`enhancement`) — new `LatticeBoundary` + per-axis BC + cylinder support
- [ ] 🐛 Bug Fix
- [ ] ⚡ Performance
- [ ] 📖 Documentation
- [ ] 🧰 Maintenance

**Breaking change** (pre-1.0 minor bump): `PBC()` and `OBC()` singleton types are **removed**. See migration notes below.

## Proposed Changes

**`src/BoundaryCondition.jl` (full rewrite)**

- `AbstractAxisBC` → `PeriodicAxis`, `OpenAxis`, `TwistedAxis{T}`
- `AbstractBoundaryModifier` → `NoModifier`, `SSD{T}`
- `LatticeBoundary{N, A, M}` composing `N` axes + one modifier
- Hooks:
  - `apply_axis_bc(axis_bc, idx, L) → (wrapped, is_valid)`
  - `axis_phase(axis_bc, idx, L) → ComplexF64` (only `TwistedAxis` is non-trivial)
  - `bond_weight(modifier, lat, i, j) → Float64` (`NoModifier → 1.0`; SSD deferred)

**Reference lattices**

- `LineLattice` and `SimpleSquareLattice` now parameterize on `LatticeBoundary` instead of `PBC` / `OBC`
- Single-axis BC shorthand: `LineLattice(5, PeriodicAxis())`, `SimpleSquareLattice(3, 3, OpenAxis())`
- **Cylinder support**: `SimpleSquareLattice(3, 3, LatticeBoundary((PeriodicAxis(), OpenAxis())))` — natively handles mixed axes
- Override `neighbor_bonds` to emit correctly-wrapped unit displacement vectors. The PBC corner bond at site 1 in a 3×3 PBC square now carries `SVector(-1, 0)` rather than the raw `SVector(2, 0)`
- Traits derived from the per-axis composition:
  - `periodicity` is `Aperiodic` iff any axis is `OpenAxis`
  - `is_bipartite` requires every wrapping axis to have even length
  - `reciprocal_support` is `HasReciprocal` only when every axis wraps

**Tests (189 pass, +58 from PR #3)**

- `test_boundary_condition.jl` rewrite: type hierarchy, `LatticeBoundary` construction, `apply_axis_bc` for all three axis types, `axis_phase` for `TwistedAxis`, `bond_weight` default
- `test_line_lattice.jl`: new axis BC shorthand, wrapped-unit-vector assertion at boundary-crossing sites, `TwistedAxis` trait derivation
- `test_simple_square_lattice.jl`: cylinder neighbours (PBC × OBC), cylinder bond count, wrapped bond vectors for PBC corner, mixed-axis trait derivation

## Usage or Results

```julia
using LatticeCore

# Old (PR #3, no longer compiles)
# lat = LineLattice(5, PBC())
# sq  = SimpleSquareLattice(3, 3, OBC())

# New (this PR)
lat = LineLattice(5)                              # default PBC
lat = LineLattice(5, PeriodicAxis())              # explicit
lat = LineLattice(5, OpenAxis())                  # open chain
lat = LineLattice(5, TwistedAxis(π/4))            # flux-carrying cycle

sq  = SimpleSquareLattice(3, 3)                   # default 2D PBC
sq  = SimpleSquareLattice(3, 3, OpenAxis())
cyl = SimpleSquareLattice(3, 3, LatticeBoundary((PeriodicAxis(), OpenAxis())))

# Bond vectors now wrap correctly:
nb1 = collect(neighbor_bonds(SimpleSquareLattice(3, 3, PeriodicAxis()), 1))
wrap_x = first(b for b in nb1 if b.j == 3)
wrap_x.vector  # SVector(-1.0, 0.0), not SVector(2.0, 0.0)
```

Local test run: **189 / 189 pass**.

## Migration

| Before | After |
|---|---|
| `LineLattice(N, PBC())` | `LineLattice(N)` or `LineLattice(N, PeriodicAxis())` |
| `LineLattice(N, OBC())` | `LineLattice(N, OpenAxis())` |
| `SimpleSquareLattice(Lx, Ly, PBC())` | `SimpleSquareLattice(Lx, Ly)` |
| `SimpleSquareLattice(Lx, Ly, OBC())` | `SimpleSquareLattice(Lx, Ly, OpenAxis())` |
| *(not possible)* | `SimpleSquareLattice(Lx, Ly, LatticeBoundary((PeriodicAxis(), OpenAxis())))` — cylinder |

## check list
- [x] test駆動をしたか — cylinder neighbours, wrapped bond vectors, trait derivation, all three axis types