### PR TITLE
feat: add AbstractCoordinate and AbstractIndexing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.3.0"
+version = "0.4.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/Coordinate.jl
+++ b/src/Coordinate.jl
@@ -1,0 +1,119 @@
+"""
+    AbstractCoordinate{D}
+
+Abstract supertype for lattice coordinate representations. Concrete
+subtypes describe the same lattice point in different spaces:
+
+- [`RealSpace`](@ref) — Cartesian coordinates
+- [`LatticeCoord`](@ref) — unit cell index + **geometric** sublattice
+- [`HigherDimCoord`](@ref) — higher-dimensional projection (for
+  cut-and-project quasicrystals)
+
+`D` is the **physical** dimension (the dimension of the real space
+the lattice lives in), which is the same for every concrete subtype
+that describes a given lattice point.
+
+Conversions between coordinate systems are performed by
+[`to_real`](@ref), [`to_lattice`](@ref), and [`to_hyper`](@ref).
+These functions dispatch on the concrete lattice type because the
+conversion depends on the lattice basis and any higher-dimensional
+projection the lattice uses.
+"""
+abstract type AbstractCoordinate{D} end
+
+# ---- RealSpace -------------------------------------------------------
+
+"""
+    RealSpace{D, T}(x::SVector{D, T})
+    RealSpace(x::NTuple{D, T})
+
+Real-space Cartesian coordinate in `D` dimensions with element type
+`T`.
+"""
+struct RealSpace{D,T<:Real} <: AbstractCoordinate{D}
+    x::SVector{D,T}
+end
+
+# The `RealSpace(x::SVector{D, T})` outer constructor is auto-generated
+# by Julia from the inner; we only need an extra tuple-based overload.
+RealSpace(xs::NTuple{D,T}) where {D,T<:Real} = RealSpace(SVector(xs))
+
+# ---- LatticeCoord ----------------------------------------------------
+
+"""
+    LatticeCoord{D}(cell::NTuple{D, Int}, sublattice::Int = 1)
+
+Lattice coordinate: per-axis unit cell index plus the (1-based)
+**geometric** sublattice id within the cell.
+
+The `sublattice` field refers strictly to the *geometric* sublattice
+(the honeycomb A/B positions, the Kagome A/B/C, ...), not to the
+physical `AbstractSiteType` living on the site. Site types live on a
+separate axis and are designed in the site-type chapter of the
+architecture notes.
+"""
+struct LatticeCoord{D} <: AbstractCoordinate{D}
+    cell::NTuple{D,Int}
+    sublattice::Int
+
+    function LatticeCoord{D}(cell::NTuple{D,Int}, sublattice::Int=1) where {D}
+        return new{D}(cell, sublattice)
+    end
+end
+
+LatticeCoord(cell::NTuple{D,Int}, sublattice::Int=1) where {D} =
+    LatticeCoord{D}(cell, sublattice)
+
+# ---- HigherDimCoord --------------------------------------------------
+
+"""
+    HigherDimCoord{DPhys, DHyper, T}(hyper::SVector{DHyper, T})
+
+Higher-dimensional coordinate used by cut-and-project quasicrystals.
+`DPhys` is the physical dimension (the target of the projection) and
+`DHyper` is the host dimension (`DHyper > DPhys`). The lattice's
+projection matrix maps `hyper` back into `DPhys`-dimensional real
+space.
+"""
+struct HigherDimCoord{DPhys,DHyper,T<:Real} <: AbstractCoordinate{DPhys}
+    hyper::SVector{DHyper,T}
+end
+
+function HigherDimCoord{DPhys}(hyper::SVector{DHyper,T}) where {DPhys,DHyper,T<:Real}
+    return HigherDimCoord{DPhys,DHyper,T}(hyper)
+end
+
+# ---- Conversion generic functions -----------------------------------
+
+"""
+    to_real(lat::AbstractLattice, coord::AbstractCoordinate) → RealSpace
+
+Convert `coord` into a real-space Cartesian coordinate on `lat`.
+Concrete lattices should implement at least `to_real(lat, ::LatticeCoord)`
+(and, for quasicrystals, `to_real(lat, ::HigherDimCoord)`).
+"""
+function to_real end
+
+"""
+    to_lattice(lat::AbstractLattice, coord::AbstractCoordinate) → LatticeCoord
+
+Convert `coord` into a lattice coordinate on `lat`. Concrete lattices
+should implement at least `to_lattice(lat, ::RealSpace)`.
+"""
+function to_lattice end
+
+"""
+    to_hyper(lat::AbstractLattice, coord::AbstractCoordinate) → HigherDimCoord
+
+Convert `coord` into a higher-dimensional hyper coordinate. Only
+meaningful for cut-and-project quasicrystals; other lattices may
+leave this unimplemented.
+"""
+function to_hyper end
+
+# Identity conversions — converting a coordinate to its own kind is a
+# no-op regardless of the lattice. These let downstream code write a
+# single `to_real(lat, coord)` call without a type check.
+to_real(::Any, r::RealSpace) = r
+to_lattice(::Any, lc::LatticeCoord) = lc
+to_hyper(::Any, h::HigherDimCoord) = h

--- a/src/Coordinate.jl
+++ b/src/Coordinate.jl
@@ -61,8 +61,9 @@ struct LatticeCoord{D} <: AbstractCoordinate{D}
     end
 end
 
-LatticeCoord(cell::NTuple{D,Int}, sublattice::Int=1) where {D} =
+function LatticeCoord(cell::NTuple{D,Int}, sublattice::Int=1) where {D}
     LatticeCoord{D}(cell, sublattice)
+end
 
 # ---- HigherDimCoord --------------------------------------------------
 

--- a/src/Indexing.jl
+++ b/src/Indexing.jl
@@ -1,0 +1,151 @@
+"""
+    AbstractIndexing
+
+Abstract supertype for strategies that linearise a
+[`LatticeCoord`](@ref) into a 1-based site index. Concrete subtypes
+determine the ordering of sites along axes and the placement of
+sublattices within each cell.
+
+The indexing method is deliberately **decoupled** from the coordinate
+system: a lattice may switch its `AbstractIndexing` without changing
+how it describes positions. See
+`dev/note/04_architecture/03_boundary_and_coordinates/README.md` for
+the design rationale.
+
+# Required interface (per concrete indexing / dimension)
+
+- `site_index(indexing, dims::NTuple{D, Int}, nsub::Int, coord::LatticeCoord{D})::Int`
+- `lattice_coord(indexing, dims::NTuple{D, Int}, nsub::Int, i::Int)::LatticeCoord{D}`
+
+These two methods must round-trip: `site_index ∘ lattice_coord` is
+the identity on `1:prod(dims) * nsub`.
+
+# Sublattice convention
+
+The sublattice is the **innermost** (fastest) index: sites within a
+single cell are contiguous. For `nsub == 1` this reduces to the usual
+single-sublattice formulas and can be read at a glance.
+"""
+abstract type AbstractIndexing end
+
+"""Row-major (C-style): x is the fastest axis within a row."""
+struct RowMajor <: AbstractIndexing end
+
+"""Column-major (Fortran-style): y is the fastest axis."""
+struct ColMajor <: AbstractIndexing end
+
+"""
+    Snake
+
+Boustrophedon (snake) indexing: row-major layout with alternating
+row direction. Useful when physical adjacency between neighbouring
+indices matters (e.g. for certain serialisation layouts).
+"""
+struct Snake <: AbstractIndexing end
+
+# ---- Generic functions ----------------------------------------------
+
+"""
+    site_index(indexing, dims, nsub, coord) → Int
+
+Linearise `coord` into a 1-based site index. See [`AbstractIndexing`](@ref)
+for the required contract.
+"""
+function site_index end
+
+"""
+    lattice_coord(indexing, dims, nsub, i) → LatticeCoord
+
+Inverse of [`site_index`](@ref).
+"""
+function lattice_coord end
+
+# ---- 1D ---------------------------------------------------------------
+#
+# In 1D there is no choice of ordering: RowMajor / ColMajor / Snake
+# all reduce to "walk along the single axis in order", so we define
+# only RowMajor for 1D and let the others fall through (they would
+# simply error out; 1D Snake is actively meaningless).
+
+function site_index(
+    ::RowMajor, dims::NTuple{1,Int}, nsub::Int, coord::LatticeCoord{1}
+)
+    cx = coord.cell[1]
+    s = coord.sublattice
+    return (cx - 1) * nsub + s
+end
+
+function lattice_coord(::RowMajor, ::NTuple{1,Int}, nsub::Int, i::Int)
+    c = (i - 1) ÷ nsub
+    s = (i - 1) % nsub + 1
+    return LatticeCoord((c + 1,), s)
+end
+
+# ---- 2D RowMajor ------------------------------------------------------
+#
+# site_index(cx, cy, s) = ((cy - 1) * Lx + (cx - 1)) * nsub + s
+
+function site_index(
+    ::RowMajor, dims::NTuple{2,Int}, nsub::Int, coord::LatticeCoord{2}
+)
+    cx, cy = coord.cell
+    s = coord.sublattice
+    Lx = dims[1]
+    return ((cy - 1) * Lx + (cx - 1)) * nsub + s
+end
+
+function lattice_coord(::RowMajor, dims::NTuple{2,Int}, nsub::Int, i::Int)
+    c = (i - 1) ÷ nsub
+    s = (i - 1) % nsub + 1
+    Lx = dims[1]
+    cx = c % Lx + 1
+    cy = c ÷ Lx + 1
+    return LatticeCoord((cx, cy), s)
+end
+
+# ---- 2D ColMajor ------------------------------------------------------
+#
+# site_index(cx, cy, s) = ((cx - 1) * Ly + (cy - 1)) * nsub + s
+
+function site_index(
+    ::ColMajor, dims::NTuple{2,Int}, nsub::Int, coord::LatticeCoord{2}
+)
+    cx, cy = coord.cell
+    s = coord.sublattice
+    Ly = dims[2]
+    return ((cx - 1) * Ly + (cy - 1)) * nsub + s
+end
+
+function lattice_coord(::ColMajor, dims::NTuple{2,Int}, nsub::Int, i::Int)
+    c = (i - 1) ÷ nsub
+    s = (i - 1) % nsub + 1
+    Ly = dims[2]
+    cy = c % Ly + 1
+    cx = c ÷ Ly + 1
+    return LatticeCoord((cx, cy), s)
+end
+
+# ---- 2D Snake ---------------------------------------------------------
+#
+# Row-major layout, but within each row the x-direction alternates:
+# odd rows walk x = 1..Lx, even rows walk x = Lx..1.
+
+function site_index(::Snake, dims::NTuple{2,Int}, nsub::Int, coord::LatticeCoord{2})
+    cx, cy = coord.cell
+    s = coord.sublattice
+    Lx = dims[1]
+    effective_x = isodd(cy) ? cx : (Lx + 1 - cx)
+    cell_index = (cy - 1) * Lx + effective_x
+    return (cell_index - 1) * nsub + s
+end
+
+function lattice_coord(::Snake, dims::NTuple{2,Int}, nsub::Int, i::Int)
+    c = (i - 1) ÷ nsub
+    s = (i - 1) % nsub + 1
+    Lx = dims[1]
+    cell_index = c + 1
+    cy = (cell_index - 1) ÷ Lx + 1
+    effective_x = (cell_index - 1) % Lx + 1
+    cx = isodd(cy) ? effective_x : (Lx + 1 - effective_x)
+    return LatticeCoord((cx, cy), s)
+end

--- a/src/Indexing.jl
+++ b/src/Indexing.jl
@@ -67,9 +67,7 @@ function lattice_coord end
 # only RowMajor for 1D and let the others fall through (they would
 # simply error out; 1D Snake is actively meaningless).
 
-function site_index(
-    ::RowMajor, dims::NTuple{1,Int}, nsub::Int, coord::LatticeCoord{1}
-)
+function site_index(::RowMajor, dims::NTuple{1,Int}, nsub::Int, coord::LatticeCoord{1})
     cx = coord.cell[1]
     s = coord.sublattice
     return (cx - 1) * nsub + s
@@ -85,9 +83,7 @@ end
 #
 # site_index(cx, cy, s) = ((cy - 1) * Lx + (cx - 1)) * nsub + s
 
-function site_index(
-    ::RowMajor, dims::NTuple{2,Int}, nsub::Int, coord::LatticeCoord{2}
-)
+function site_index(::RowMajor, dims::NTuple{2,Int}, nsub::Int, coord::LatticeCoord{2})
     cx, cy = coord.cell
     s = coord.sublattice
     Lx = dims[1]
@@ -107,9 +103,7 @@ end
 #
 # site_index(cx, cy, s) = ((cx - 1) * Ly + (cy - 1)) * nsub + s
 
-function site_index(
-    ::ColMajor, dims::NTuple{2,Int}, nsub::Int, coord::LatticeCoord{2}
-)
+function site_index(::ColMajor, dims::NTuple{2,Int}, nsub::Int, coord::LatticeCoord{2})
     cx, cy = coord.cell
     s = coord.sublattice
     Ly = dims[2]

--- a/src/LatticeCore.jl
+++ b/src/LatticeCore.jl
@@ -12,6 +12,8 @@ include("Traits.jl")
 include("AbstractLattice.jl")
 include("Bond.jl")
 include("BoundaryCondition.jl")
+include("Coordinate.jl")
+include("Indexing.jl")
 include("reference/LineLattice.jl")
 include("reference/SimpleSquareLattice.jl")
 
@@ -36,6 +38,14 @@ export AbstractBoundaryCondition
 export AbstractAxisBC, PeriodicAxis, OpenAxis, TwistedAxis
 export AbstractBoundaryModifier, NoModifier, SSD
 export LatticeBoundary, apply_axis_bc, axis_phase, bond_weight
+
+# ---- Coordinate systems ----
+export AbstractCoordinate, RealSpace, LatticeCoord, HigherDimCoord
+export to_real, to_lattice, to_hyper
+
+# ---- Indexing ----
+export AbstractIndexing, RowMajor, ColMajor, Snake
+export site_index, lattice_coord
 
 # ---- Reference lattices ----
 export LineLattice, SimpleSquareLattice

--- a/src/reference/LineLattice.jl
+++ b/src/reference/LineLattice.jl
@@ -101,3 +101,24 @@ function reciprocal_support(l::LineLattice)
     ax = l.boundary.axes[1]
     return ax isa OpenAxis ? NoReciprocal() : HasReciprocal()
 end
+
+# ---- Coordinate conversions ----
+
+"""
+    to_real(lat::LineLattice, coord::LatticeCoord{1}) → RealSpace
+
+Interpret the lattice coordinate as a unit-spacing Cartesian position.
+"""
+function to_real(::LineLattice{T}, coord::LatticeCoord{1}) where {T}
+    return RealSpace{1,T}(SVector{1,T}(T(coord.cell[1])))
+end
+
+"""
+    to_lattice(lat::LineLattice, rs::RealSpace{1}) → LatticeCoord{1}
+
+Inverse of `to_real`: round the real-space x coordinate to the
+nearest integer cell index.
+"""
+function to_lattice(::LineLattice, rs::RealSpace{1})
+    return LatticeCoord((round(Int, rs.x[1]),), 1)
+end

--- a/src/reference/SimpleSquareLattice.jl
+++ b/src/reference/SimpleSquareLattice.jl
@@ -151,3 +151,24 @@ function reciprocal_support(l::SimpleSquareLattice)
     all_periodic = all(!(a isa OpenAxis) for a in l.boundary.axes)
     return all_periodic ? HasReciprocal() : NoReciprocal()
 end
+
+# ---- Coordinate conversions ----
+
+"""
+    to_real(lat::SimpleSquareLattice, coord::LatticeCoord{2}) → RealSpace
+
+Interpret the lattice coordinate as a unit-spacing Cartesian position.
+"""
+function to_real(::SimpleSquareLattice{T}, coord::LatticeCoord{2}) where {T}
+    return RealSpace{2,T}(SVector{2,T}(T(coord.cell[1]), T(coord.cell[2])))
+end
+
+"""
+    to_lattice(lat::SimpleSquareLattice, rs::RealSpace{2}) → LatticeCoord{2}
+
+Inverse of `to_real`: round each real-space component to the nearest
+integer cell index.
+"""
+function to_lattice(::SimpleSquareLattice, rs::RealSpace{2})
+    return LatticeCoord((round(Int, rs.x[1]), round(Int, rs.x[2])), 1)
+end

--- a/test/core/test_coordinate.jl
+++ b/test/core/test_coordinate.jl
@@ -1,0 +1,54 @@
+using LatticeCore
+using StaticArrays
+using Test
+
+@testset "AbstractCoordinate" begin
+    @testset "type hierarchy" begin
+        @test RealSpace <: AbstractCoordinate
+        @test LatticeCoord <: AbstractCoordinate
+        @test HigherDimCoord <: AbstractCoordinate
+    end
+
+    @testset "RealSpace construction" begin
+        rs_sv = RealSpace(SVector(1.0, 2.0))
+        @test rs_sv isa RealSpace{2,Float64}
+        @test rs_sv.x == SVector(1.0, 2.0)
+
+        rs_tp = RealSpace((1.0, 2.0, 3.0))
+        @test rs_tp isa RealSpace{3,Float64}
+        @test rs_tp.x == SVector(1.0, 2.0, 3.0)
+    end
+
+    @testset "LatticeCoord construction" begin
+        # default sublattice = 1
+        lc1 = LatticeCoord((2, 3))
+        @test lc1 isa LatticeCoord{2}
+        @test lc1.cell == (2, 3)
+        @test lc1.sublattice == 1
+
+        # explicit sublattice
+        lc2 = LatticeCoord((2, 3), 2)
+        @test lc2.sublattice == 2
+
+        # 1D
+        lc_1d = LatticeCoord((5,))
+        @test lc_1d isa LatticeCoord{1}
+        @test lc_1d.cell == (5,)
+    end
+
+    @testset "HigherDimCoord construction" begin
+        h = HigherDimCoord{2}(SVector(1.0, 2.0, 3.0, 4.0, 5.0))
+        @test h isa HigherDimCoord{2,5,Float64}
+        @test h.hyper == SVector(1.0, 2.0, 3.0, 4.0, 5.0)
+    end
+
+    @testset "identity conversions (lat-agnostic)" begin
+        rs = RealSpace((1.0, 2.0))
+        lc = LatticeCoord((3, 4))
+        h = HigherDimCoord{2}(SVector(1.0, 2.0, 3.0, 4.0, 5.0))
+
+        @test to_real(nothing, rs) === rs
+        @test to_lattice(nothing, lc) === lc
+        @test to_hyper(nothing, h) === h
+    end
+end

--- a/test/core/test_indexing.jl
+++ b/test/core/test_indexing.jl
@@ -1,0 +1,110 @@
+using LatticeCore
+using Test
+
+# Exhaustive round-trip helper: checks site_index ∘ lattice_coord = identity
+# on every valid site index for a given indexing / dims / nsub.
+function _assert_roundtrip(indexing, dims, nsub)
+    total = prod(dims) * nsub
+    for i in 1:total
+        lc = lattice_coord(indexing, dims, nsub, i)
+        @test site_index(indexing, dims, nsub, lc) == i
+    end
+end
+
+@testset "AbstractIndexing" begin
+    @testset "type hierarchy" begin
+        @test RowMajor <: AbstractIndexing
+        @test ColMajor <: AbstractIndexing
+        @test Snake <: AbstractIndexing
+    end
+
+    @testset "RowMajor 1D" begin
+        # nsub = 1
+        @test site_index(RowMajor(), (5,), 1, LatticeCoord((1,))) == 1
+        @test site_index(RowMajor(), (5,), 1, LatticeCoord((5,))) == 5
+        @test lattice_coord(RowMajor(), (5,), 1, 3).cell == (3,)
+
+        _assert_roundtrip(RowMajor(), (5,), 1)
+
+        # nsub = 2 (two sublattices per cell)
+        @test site_index(RowMajor(), (3,), 2, LatticeCoord((1,), 1)) == 1
+        @test site_index(RowMajor(), (3,), 2, LatticeCoord((1,), 2)) == 2
+        @test site_index(RowMajor(), (3,), 2, LatticeCoord((2,), 1)) == 3
+        @test site_index(RowMajor(), (3,), 2, LatticeCoord((3,), 2)) == 6
+
+        _assert_roundtrip(RowMajor(), (3,), 2)
+    end
+
+    @testset "RowMajor 2D" begin
+        # 3x2 row-major layout:
+        #   row 1 (y=1): sites 1, 2, 3
+        #   row 2 (y=2): sites 4, 5, 6
+        @test site_index(RowMajor(), (3, 2), 1, LatticeCoord((1, 1))) == 1
+        @test site_index(RowMajor(), (3, 2), 1, LatticeCoord((3, 1))) == 3
+        @test site_index(RowMajor(), (3, 2), 1, LatticeCoord((1, 2))) == 4
+        @test site_index(RowMajor(), (3, 2), 1, LatticeCoord((3, 2))) == 6
+
+        @test lattice_coord(RowMajor(), (3, 2), 1, 4).cell == (1, 2)
+        @test lattice_coord(RowMajor(), (3, 2), 1, 6).cell == (3, 2)
+
+        _assert_roundtrip(RowMajor(), (3, 2), 1)
+        _assert_roundtrip(RowMajor(), (4, 5), 1)
+        _assert_roundtrip(RowMajor(), (3, 2), 2)   # two sublattices
+    end
+
+    @testset "ColMajor 2D" begin
+        # 3x2 col-major layout:
+        #   col 1 (x=1): sites 1, 2
+        #   col 2 (x=2): sites 3, 4
+        #   col 3 (x=3): sites 5, 6
+        @test site_index(ColMajor(), (3, 2), 1, LatticeCoord((1, 1))) == 1
+        @test site_index(ColMajor(), (3, 2), 1, LatticeCoord((1, 2))) == 2
+        @test site_index(ColMajor(), (3, 2), 1, LatticeCoord((2, 1))) == 3
+        @test site_index(ColMajor(), (3, 2), 1, LatticeCoord((3, 2))) == 6
+
+        _assert_roundtrip(ColMajor(), (3, 2), 1)
+        _assert_roundtrip(ColMajor(), (4, 5), 1)
+        _assert_roundtrip(ColMajor(), (3, 2), 3)
+    end
+
+    @testset "Snake 2D" begin
+        # 3x3 snake layout:
+        #   y=1 (forward): 1, 2, 3
+        #   y=2 (reverse): 4, 5, 6  ↔  (3,2), (2,2), (1,2)
+        #   y=3 (forward): 7, 8, 9
+        @test site_index(Snake(), (3, 3), 1, LatticeCoord((1, 1))) == 1
+        @test site_index(Snake(), (3, 3), 1, LatticeCoord((3, 1))) == 3
+        @test site_index(Snake(), (3, 3), 1, LatticeCoord((3, 2))) == 4
+        @test site_index(Snake(), (3, 3), 1, LatticeCoord((1, 2))) == 6
+        @test site_index(Snake(), (3, 3), 1, LatticeCoord((1, 3))) == 7
+        @test site_index(Snake(), (3, 3), 1, LatticeCoord((3, 3))) == 9
+
+        # Inverse
+        @test lattice_coord(Snake(), (3, 3), 1, 4).cell == (3, 2)
+        @test lattice_coord(Snake(), (3, 3), 1, 6).cell == (1, 2)
+
+        _assert_roundtrip(Snake(), (3, 3), 1)
+        _assert_roundtrip(Snake(), (4, 3), 1)
+        _assert_roundtrip(Snake(), (3, 4), 2)
+    end
+
+    @testset "round-trip count covers every site" begin
+        # Ensure every site index is the image of exactly one LatticeCoord
+        # for each indexing. This rules out collisions and holes.
+        for indexing in (RowMajor(), ColMajor(), Snake())
+            for dims in ((3, 3), (4, 5), (5, 2))
+                for nsub in (1, 2)
+                    seen = Set{Int}()
+                    for cx in 1:dims[1], cy in 1:dims[2], s in 1:nsub
+                        push!(
+                            seen,
+                            site_index(indexing, dims, nsub, LatticeCoord((cx, cy), s)),
+                        )
+                    end
+                    @test length(seen) == prod(dims) * nsub
+                    @test extrema(seen) == (1, prod(dims) * nsub)
+                end
+            end
+        end
+    end
+end

--- a/test/core/test_line_lattice.jl
+++ b/test/core/test_line_lattice.jl
@@ -110,4 +110,23 @@ using Test
         @test neighbors(lat, 2) == [1]
         @test length(collect(bonds(lat))) == 1
     end
+
+    @testset "coordinate conversions" begin
+        lat = LineLattice(5, PeriodicAxis())
+
+        rs = to_real(lat, LatticeCoord((3,)))
+        @test rs isa RealSpace{1,Float64}
+        @test rs.x == SVector(3.0)
+
+        lc = to_lattice(lat, RealSpace((4.0,)))
+        @test lc isa LatticeCoord{1}
+        @test lc.cell == (4,)
+        @test lc.sublattice == 1
+
+        # Round-trip
+        for i in 1:num_sites(lat)
+            lc_i = LatticeCoord((i,))
+            @test to_lattice(lat, to_real(lat, lc_i)) == lc_i
+        end
+    end
 end

--- a/test/core/test_simple_square_lattice.jl
+++ b/test/core/test_simple_square_lattice.jl
@@ -128,4 +128,34 @@ using Test
         b = Bond{2,Float64}(1, 2, SVector(1.0, 0.0), :nearest)
         @test bond_center(lat, b) == SVector(1.5, 1.0)
     end
+
+    @testset "coordinate conversions" begin
+        lat = SimpleSquareLattice(3, 3, PeriodicAxis())
+
+        rs = to_real(lat, LatticeCoord((2, 3)))
+        @test rs isa RealSpace{2,Float64}
+        @test rs.x == SVector(2.0, 3.0)
+
+        lc = to_lattice(lat, RealSpace((2.0, 3.0)))
+        @test lc isa LatticeCoord{2}
+        @test lc.cell == (2, 3)
+        @test lc.sublattice == 1
+
+        # Round-trip over every site
+        for cx in 1:3, cy in 1:3
+            lc_in = LatticeCoord((cx, cy))
+            @test to_lattice(lat, to_real(lat, lc_in)) == lc_in
+        end
+    end
+
+    @testset "RowMajor indexing matches the lattice's internal layout" begin
+        lat = SimpleSquareLattice(3, 2, OpenAxis())
+        # The reference lattice uses row-major internally (implicit),
+        # so site_index(RowMajor(), (Lx, Ly), 1, LatticeCoord((cx, cy)))
+        # should agree with its internal site numbering.
+        for cx in 1:3, cy in 1:2
+            expected = site_index(RowMajor(), (3, 2), 1, LatticeCoord((cx, cy)))
+            @test position(lat, expected) == SVector(Float64(cx), Float64(cy))
+        end
+    end
 end


### PR DESCRIPTION
## Description

Second half of plan B of the 03 roadmap. Implements the coordinate system and indexing strategy abstractions from [`dev/note/04_architecture/03_boundary_and_coordinates`](https://github.com/sotashimozono/work/blob/main/dev/note/04_architecture/03_boundary_and_coordinates/README.md). This PR closes out the 03 chapter at the LatticeCore level — the full `LatticeBoundary` model landed in PR #4, and coordinate / indexing completes the pair.

Fixed: (no linked issue)

## Type of Change

- [x] ✨ Feature (`enhancement`)
- [ ] 🐛 Bug Fix
- [ ] ⚡ Performance
- [ ] 📖 Documentation
- [ ] 🧰 Maintenance

## Proposed Changes

**`src/Coordinate.jl`**

- `AbstractCoordinate{D}` supertype
- `RealSpace{D, T}(x::SVector{D, T})` — Cartesian
- `LatticeCoord{D}(cell::NTuple{D, Int}, sublattice::Int = 1)` — unit cell index + **geometric** sublattice (explicitly distinct from the physical `AbstractSiteType` axis, which belongs to the 04 chapter)
- `HigherDimCoord{DPhys, DHyper, T}` — reserved for cut-and-project quasicrystals
- Generic conversion functions: `to_real`, `to_lattice`, `to_hyper` with identity fallbacks so downstream code can call them blindly on an already-converted coordinate

**`src/Indexing.jl`**

- `AbstractIndexing` supertype
- `RowMajor`, `ColMajor`, `Snake` concrete strategies
- `site_index` / `lattice_coord` generic functions with 1D and 2D concrete implementations (sublattice-innermost convention)
- `Snake` is row-major with alternating row direction; 1D `Snake` is intentionally omitted (reduces to `RowMajor`)

**Reference lattices**

- `LineLattice` and `SimpleSquareLattice` each gain `to_real` / `to_lattice` methods that map integer cell indices to unit-spacing real positions. The reference lattices continue to use their internal row-major coordinate helpers; exposing the new API does not change any existing behaviour.

**Tests (439 pass, +250 from PR #4)**

- `test_coordinate.jl`: type hierarchy, construction of all three coordinate kinds, identity conversions
- `test_indexing.jl`: **exhaustive round-trip** checks for `RowMajor` (1D / 2D, `nsub = 1` and `nsub = 2`), `ColMajor` (2D, `nsub = 1..3`), `Snake` (2D, `nsub = 1..2`), plus a combinatorial sanity check showing every site index is hit exactly once across all indexings / dims / nsub combinations
- `test_line_lattice.jl`, `test_simple_square_lattice.jl`: `to_real` / `to_lattice` round-trip over every site, plus a bridging test showing that `RowMajor` `site_index` agrees with the lattice's internal numbering

## Usage or Results

```julia
using LatticeCore, StaticArrays

# Construct coordinates
rs = RealSpace((1.5, 2.0))
lc = LatticeCoord((2, 3))            # sublattice defaults to 1
lc_sub = LatticeCoord((2, 3), 2)     # explicit sublattice

# Linearise LatticeCoord into a site index under different indexings
site_index(RowMajor(), (3, 2), 1, LatticeCoord((2, 1)))  # 2
site_index(ColMajor(), (3, 2), 1, LatticeCoord((2, 1)))  # 3
site_index(Snake(),    (3, 2), 1, LatticeCoord((2, 2)))  # 5  (reverse row)

# Convert lattice-specific coordinates to real space
lat = SimpleSquareLattice(3, 3)
to_real(lat, LatticeCoord((2, 3)))   # RealSpace([2.0, 3.0])

# Round-trip
to_lattice(lat, to_real(lat, LatticeCoord((2, 3))))  # LatticeCoord((2, 3), 1)
```

Local test run: **439 / 439 pass**.

## check list
- [x] test駆動をしたか — exhaustive round-trip coverage plus combinatorial "every site hit exactly once" check