### PR TITLE
feat: site types, site layouts, and lattice element centering

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.4.0"
+version = "0.5.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]
@@ -12,7 +12,8 @@ StaticArrays = "1"
 julia = "1.10"
 
 [extras]
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Test"]
+test = ["Random", "Test"]

--- a/src/AbstractLattice.jl
+++ b/src/AbstractLattice.jl
@@ -119,3 +119,38 @@ algorithms should guard against non-finite lattices with this
 predicate.
 """
 is_finite(lat::AbstractLattice) = size_trait(lat) isa FiniteSize
+
+# ---- Site type interface --------------------------------------------
+
+"""
+    site_layout(lat::AbstractLattice) → AbstractSiteLayout
+
+Return the lattice's site layout. Concrete lattices must either
+implement this method directly or hold an `AbstractSiteLayout` in a
+field of that name.
+"""
+function site_layout end
+
+"""
+    site_type(lat::AbstractLattice, i::Int) → AbstractSiteType
+
+Site type at site `i`. Defaults to `site_type(site_layout(lat), i)`
+so concrete lattices only need to implement [`site_layout`](@ref).
+"""
+site_type(lat::AbstractLattice, i::Int) = site_type(site_layout(lat), i)
+
+"""
+    num_sublattices(lat::AbstractLattice) → Int
+
+Number of **geometric** sublattices in the lattice. Defaults to `1`
+so lattices that are not sublattice-aware need not override.
+"""
+num_sublattices(::AbstractLattice) = 1
+
+"""
+    sublattice(lat::AbstractLattice, i::Int) → Int
+
+Geometric sublattice id (1-based) of site `i`. Defaults to `1`,
+matching the default [`num_sublattices`](@ref) of 1.
+"""
+sublattice(::AbstractLattice, ::Int) = 1

--- a/src/LatticeCore.jl
+++ b/src/LatticeCore.jl
@@ -9,6 +9,9 @@ using StaticArrays
 import Base: position
 
 include("Traits.jl")
+include("LatticeElement.jl")
+include("SiteType.jl")
+include("SiteLayout.jl")
 include("AbstractLattice.jl")
 include("Bond.jl")
 include("BoundaryCondition.jl")
@@ -20,6 +23,19 @@ include("reference/SimpleSquareLattice.jl")
 # ---- AbstractLattice ----
 export AbstractLattice
 export dimension, num_sites, position, positions, neighbors, boundary
+export site_layout, site_type, num_sublattices, sublattice
+
+# ---- Lattice elements ----
+export AbstractLatticeElement, VertexCenter, BondCenter, PlaquetteCenter, CellCenter
+export element_type
+
+# ---- Site types ----
+export AbstractSiteType
+export IsingSite, PottsSite, XYSite, HeisenbergSite, EmptySite
+export state_type, random_state, zero_state, domain
+
+# ---- Site layouts ----
+export AbstractSiteLayout, UniformLayout, SublatticeLayout, ExplicitLayout
 
 # ---- Bond ----
 export Bond, bond_center, bonds, neighbor_bonds

--- a/src/LatticeElement.jl
+++ b/src/LatticeElement.jl
@@ -1,0 +1,27 @@
+"""
+    AbstractLatticeElement
+
+Abstract supertype identifying which geometric element of a lattice
+a given degree of freedom lives on. The default for every
+[`AbstractSiteType`](@ref) is [`VertexCenter`](@ref); other
+`element_type` overrides let the interface describe bond / plaquette /
+cell-centered variables such as dimers, gauge links, and flux
+variables without breaking existing site-centered code.
+
+See `dev/note/04_architecture/04_site_type/README.md` for the
+two-approach strategy (line-graph versus multi-layer) that uses this
+trait.
+"""
+abstract type AbstractLatticeElement end
+
+"""Vertex-centered element: a site in the usual sense (default)."""
+struct VertexCenter <: AbstractLatticeElement end
+
+"""Bond-centered element: the midpoint of an edge."""
+struct BondCenter <: AbstractLatticeElement end
+
+"""Plaquette-centered element: the centre of a face."""
+struct PlaquetteCenter <: AbstractLatticeElement end
+
+"""Cell-centered element: the centre of a 3D (or higher) cell."""
+struct CellCenter <: AbstractLatticeElement end

--- a/src/SiteLayout.jl
+++ b/src/SiteLayout.jl
@@ -1,0 +1,79 @@
+"""
+    AbstractSiteLayout
+
+Abstract supertype for strategies that store the per-site
+[`AbstractSiteType`](@ref) of a lattice. Three concrete layouts are
+provided, each picking a different memory / flexibility trade-off:
+
+- [`UniformLayout`](@ref) — every site shares the same site type
+  (stored once; zero per-site memory overhead)
+- [`SublatticeLayout`](@ref) — each geometric sublattice has its own
+  site type (`Vector{Int}` of sublattice ids)
+- [`ExplicitLayout`](@ref) — one `AbstractSiteType` per site (for
+  disordered / quenched-random configurations)
+
+All layouts satisfy `site_type(layout, i)::AbstractSiteType`.
+"""
+abstract type AbstractSiteLayout end
+
+"""
+    site_type(layout::AbstractSiteLayout, i::Int) → AbstractSiteType
+
+Return the site type stored at site index `i`.
+"""
+function site_type end
+
+# ---- UniformLayout ---------------------------------------------------
+
+"""
+    UniformLayout(st::AbstractSiteType)
+
+Every site has the same site type. The type parameter carries the
+concrete site-type singleton so that downstream MC code can dispatch
+on it at compile time (constant folding in the hot loop).
+"""
+struct UniformLayout{S<:AbstractSiteType} <: AbstractSiteLayout
+    site_type::S
+end
+
+site_type(l::UniformLayout, ::Int) = l.site_type
+
+# ---- SublatticeLayout ------------------------------------------------
+
+"""
+    SublatticeLayout(by_sublattice::NTuple{N, <:AbstractSiteType}, sublattice_of::Vector{Int})
+
+Per-sublattice site type. `by_sublattice` is a tuple of site type
+instances, one per geometric sublattice; `sublattice_of[i]` tells
+which sublattice site `i` belongs to (1-based).
+
+This is the natural layout for mixed-spin models (e.g. Ising on the
+A sublattice, XY on B).
+"""
+struct SublatticeLayout{N,Tup<:NTuple{N,AbstractSiteType}} <: AbstractSiteLayout
+    by_sublattice::Tup
+    sublattice_of::Vector{Int}
+
+    function SublatticeLayout(
+        by_sublattice::Tup, sublattice_of::Vector{Int}
+    ) where {N,Tup<:NTuple{N,AbstractSiteType}}
+        return new{N,Tup}(by_sublattice, sublattice_of)
+    end
+end
+
+site_type(l::SublatticeLayout, i::Int) = l.by_sublattice[l.sublattice_of[i]]
+
+# ---- ExplicitLayout --------------------------------------------------
+
+"""
+    ExplicitLayout(types::Vector{<:AbstractSiteType})
+
+One site type per site. Use for quenched disorder or any
+configuration where the per-site type cannot be factored through a
+sublattice assignment.
+"""
+struct ExplicitLayout{S<:AbstractSiteType} <: AbstractSiteLayout
+    types::Vector{S}
+end
+
+site_type(l::ExplicitLayout, i::Int) = l.types[i]

--- a/src/SiteType.jl
+++ b/src/SiteType.jl
@@ -1,0 +1,138 @@
+"""
+    AbstractSiteType
+
+Abstract supertype for site types — value-level descriptors of the
+physical degree of freedom living on a lattice site.
+
+Concrete subtypes are deliberately lightweight (typically singletons
+or thin parametric singletons) so they can be embedded in lattice
+structs and used as a dispatch key by MC models.
+
+# Required interface
+
+- `state_type(st)::Type` — the Julia type used to store a state
+- `random_state(rng, st)` — sample a uniformly random state
+
+# Optional interface
+
+- `zero_state(st)` — a canonical zero state (if defined)
+- `domain(st)` — iterable over the state space (for small discrete
+  site types)
+- `element_type(st)::AbstractLatticeElement` — which geometric element
+  the DOF lives on. Defaults to [`VertexCenter`](@ref). Override for
+  bond / plaquette-centered variables such as dimer or gauge fields.
+
+See `dev/note/04_architecture/04_site_type/README.md`.
+"""
+abstract type AbstractSiteType end
+
+# ---- Required / optional generic functions ----
+
+"""
+    state_type(st::AbstractSiteType) → Type
+
+Julia type used to store a state of site type `st`.
+"""
+function state_type end
+
+"""
+    random_state(rng, st::AbstractSiteType)
+
+Sample a uniformly random state on site type `st`.
+"""
+function random_state end
+
+"""
+    zero_state(st::AbstractSiteType)
+
+Canonical zero state (e.g. `0` for Ising, `0.0` for XY). Not all site
+types have to define this.
+"""
+function zero_state end
+
+"""
+    domain(st::AbstractSiteType)
+
+Iterable over the state space. Only meaningful for small discrete
+site types (Ising, Potts); continuous types leave this unimplemented.
+"""
+function domain end
+
+"""
+    element_type(st::AbstractSiteType) → AbstractLatticeElement
+
+Which geometric element the DOF lives on. Defaults to
+[`VertexCenter`](@ref). Override for bond / plaquette / cell-centered
+site types.
+"""
+element_type(::AbstractSiteType) = VertexCenter()
+
+# ---- Built-in site types ---------------------------------------------
+
+"""
+    IsingSite{T <: Integer}()
+
+Ising spin: state is `±1` stored as `T` (default `Int8`).
+"""
+struct IsingSite{T<:Integer} <: AbstractSiteType end
+IsingSite() = IsingSite{Int8}()
+
+state_type(::IsingSite{T}) where {T} = T
+random_state(rng, ::IsingSite{T}) where {T} = rand(rng, (T(-1), T(1)))
+zero_state(::IsingSite{T}) where {T} = zero(T)
+domain(::IsingSite{T}) where {T} = (T(-1), T(1))
+
+"""
+    PottsSite{Q, T <: Integer}()
+
+`Q`-state Potts spin: state is an integer in `1..Q` stored as `T`.
+"""
+struct PottsSite{Q,T<:Integer} <: AbstractSiteType end
+PottsSite(q::Integer) = PottsSite{Int(q),Int8}()
+
+state_type(::PottsSite{Q,T}) where {Q,T} = T
+random_state(rng, ::PottsSite{Q,T}) where {Q,T} = T(rand(rng, 1:Q))
+domain(::PottsSite{Q,T}) where {Q,T} = ntuple(i -> T(i), Q)
+
+"""
+    XYSite{T <: AbstractFloat}()
+
+Planar rotor: state is an angle `θ ∈ [0, 2π)` stored as `T`
+(default `Float64`).
+"""
+struct XYSite{T<:AbstractFloat} <: AbstractSiteType end
+XYSite() = XYSite{Float64}()
+
+state_type(::XYSite{T}) where {T} = T
+random_state(rng, ::XYSite{T}) where {T} = T(2π) * rand(rng, T)
+zero_state(::XYSite{T}) where {T} = zero(T)
+
+"""
+    HeisenbergSite{T <: AbstractFloat}()
+
+Classical Heisenberg spin: state is a unit vector in ℝ³ stored as
+`SVector{3, T}` (default `Float64`).
+"""
+struct HeisenbergSite{T<:AbstractFloat} <: AbstractSiteType end
+HeisenbergSite() = HeisenbergSite{Float64}()
+
+state_type(::HeisenbergSite{T}) where {T} = SVector{3,T}
+function random_state(rng, ::HeisenbergSite{T}) where {T}
+    # Marsaglia-style uniform point on S².
+    z = T(2) * rand(rng, T) - one(T)
+    φ = T(2π) * rand(rng, T)
+    sxy = sqrt(one(T) - z * z)
+    return SVector{3,T}(sxy * cos(φ), sxy * sin(φ), z)
+end
+
+"""
+    EmptySite()
+
+Vacancy / empty site: stores `nothing`. Useful for diluted models
+and as a placeholder where a site has no degrees of freedom.
+"""
+struct EmptySite <: AbstractSiteType end
+
+state_type(::EmptySite) = Nothing
+random_state(::Any, ::EmptySite) = nothing
+zero_state(::EmptySite) = nothing

--- a/src/reference/LineLattice.jl
+++ b/src/reference/LineLattice.jl
@@ -1,9 +1,14 @@
 """
-    LineLattice{T, B <: LatticeBoundary}(N, boundary)
+    LineLattice{T, B, L}(N, boundary, layout)
 
-A 1D linear chain of `N` sites with unit spacing. `boundary` is a
-[`LatticeBoundary`](@ref) whose single axis component is one of
-[`PeriodicAxis`](@ref), [`OpenAxis`](@ref), or [`TwistedAxis`](@ref).
+A 1D linear chain of `N` sites with unit spacing.
+
+- `boundary` is a [`LatticeBoundary`](@ref) whose single axis
+  component is one of [`PeriodicAxis`](@ref), [`OpenAxis`](@ref), or
+  [`TwistedAxis`](@ref).
+- `layout` is an [`AbstractSiteLayout`](@ref) that decides which
+  [`AbstractSiteType`](@ref) lives on each site. The default is
+  `UniformLayout(IsingSite())`.
 
 LatticeCore's simplest reference implementation; paired with
 [`SimpleSquareLattice`](@ref) it is also the canonical mock used by
@@ -11,30 +16,41 @@ downstream Monte Carlo unit tests.
 
 # Examples
 ```julia
-# Default: 1D periodic
+# Default: PBC + UniformLayout(IsingSite())
 line = LineLattice(5)
 
 # Open boundary chain
 chain = LineLattice(5, OpenAxis())
 
-# Explicit LatticeBoundary (e.g. with a twist)
-twisted = LineLattice(5, LatticeBoundary((TwistedAxis(π/4),)))
+# Custom layout (e.g. XY sites)
+xy = LineLattice(5; layout = UniformLayout(XYSite()))
 ```
 """
-struct LineLattice{T<:AbstractFloat,B<:LatticeBoundary} <: AbstractLattice{1,T}
+struct LineLattice{T<:AbstractFloat,B<:LatticeBoundary,L<:AbstractSiteLayout} <:
+       AbstractLattice{1,T}
     N::Int
     boundary::B
+    layout::L
 end
 
-# Convenience constructors: default to Float64 positions. The axis BC
-# is wrapped in a `LatticeBoundary` automatically so users can write
-# `LineLattice(5, PeriodicAxis())` instead of the explicit tuple form.
-function LineLattice(N::Int, axis::AbstractAxisBC=PeriodicAxis())
-    return LineLattice(N, LatticeBoundary((axis,), NoModifier()))
+# Convenience constructors: default to Float64 positions and an Ising
+# UniformLayout. The axis BC is wrapped in a `LatticeBoundary`
+# automatically so users can write `LineLattice(5, PeriodicAxis())`
+# instead of the explicit tuple form.
+function LineLattice(
+    N::Int,
+    axis::AbstractAxisBC=PeriodicAxis();
+    layout::AbstractSiteLayout=UniformLayout(IsingSite()),
+)
+    return LineLattice(N, LatticeBoundary((axis,), NoModifier()); layout)
 end
 
-function LineLattice(N::Int, boundary::B) where {B<:LatticeBoundary}
-    return LineLattice{Float64,B}(N, boundary)
+function LineLattice(
+    N::Int,
+    boundary::LatticeBoundary;
+    layout::AbstractSiteLayout=UniformLayout(IsingSite()),
+)
+    return LineLattice{Float64,typeof(boundary),typeof(layout)}(N, boundary, layout)
 end
 
 # ---- Required interface ----
@@ -58,6 +74,8 @@ function neighbors(l::LineLattice, i::Int)
 end
 
 boundary(l::LineLattice) = l.boundary
+
+site_layout(l::LineLattice) = l.layout
 
 size_trait(l::LineLattice) = FiniteSize((l.N,))
 

--- a/src/reference/LineLattice.jl
+++ b/src/reference/LineLattice.jl
@@ -46,9 +46,7 @@ function LineLattice(
 end
 
 function LineLattice(
-    N::Int,
-    boundary::LatticeBoundary;
-    layout::AbstractSiteLayout=UniformLayout(IsingSite()),
+    N::Int, boundary::LatticeBoundary; layout::AbstractSiteLayout=UniformLayout(IsingSite())
 )
     return LineLattice{Float64,typeof(boundary),typeof(layout)}(N, boundary, layout)
 end

--- a/src/reference/SimpleSquareLattice.jl
+++ b/src/reference/SimpleSquareLattice.jl
@@ -50,9 +50,7 @@ function SimpleSquareLattice(
     axis::AbstractAxisBC=PeriodicAxis();
     layout::AbstractSiteLayout=UniformLayout(IsingSite()),
 )
-    return SimpleSquareLattice(
-        Lx, Ly, LatticeBoundary((axis, axis), NoModifier()); layout
-    )
+    return SimpleSquareLattice(Lx, Ly, LatticeBoundary((axis, axis), NoModifier()); layout)
 end
 
 function SimpleSquareLattice(

--- a/src/reference/SimpleSquareLattice.jl
+++ b/src/reference/SimpleSquareLattice.jl
@@ -33,20 +33,37 @@ open_sq = SimpleSquareLattice(3, 3, OpenAxis())
 cylinder = SimpleSquareLattice(3, 3, LatticeBoundary((PeriodicAxis(), OpenAxis())))
 ```
 """
-struct SimpleSquareLattice{T<:AbstractFloat,B<:LatticeBoundary} <: AbstractLattice{2,T}
+struct SimpleSquareLattice{T<:AbstractFloat,B<:LatticeBoundary,L<:AbstractSiteLayout} <:
+       AbstractLattice{2,T}
     Lx::Int
     Ly::Int
     boundary::B
+    layout::L
 end
 
 # Convenience constructors. The single-axis overload applies the same
 # BC to both axes; mixed cases go through `LatticeBoundary` directly.
-function SimpleSquareLattice(Lx::Int, Ly::Int, axis::AbstractAxisBC=PeriodicAxis())
-    return SimpleSquareLattice(Lx, Ly, LatticeBoundary((axis, axis), NoModifier()))
+# The site layout defaults to a uniform Ising layout.
+function SimpleSquareLattice(
+    Lx::Int,
+    Ly::Int,
+    axis::AbstractAxisBC=PeriodicAxis();
+    layout::AbstractSiteLayout=UniformLayout(IsingSite()),
+)
+    return SimpleSquareLattice(
+        Lx, Ly, LatticeBoundary((axis, axis), NoModifier()); layout
+    )
 end
 
-function SimpleSquareLattice(Lx::Int, Ly::Int, boundary::B) where {B<:LatticeBoundary}
-    return SimpleSquareLattice{Float64,B}(Lx, Ly, boundary)
+function SimpleSquareLattice(
+    Lx::Int,
+    Ly::Int,
+    boundary::LatticeBoundary;
+    layout::AbstractSiteLayout=UniformLayout(IsingSite()),
+)
+    return SimpleSquareLattice{Float64,typeof(boundary),typeof(layout)}(
+        Lx, Ly, boundary, layout
+    )
 end
 
 # ---- Private row-major coordinate helpers ----
@@ -102,6 +119,8 @@ function neighbors(l::SimpleSquareLattice, i::Int)
 end
 
 boundary(l::SimpleSquareLattice) = l.boundary
+
+site_layout(l::SimpleSquareLattice) = l.layout
 
 size_trait(l::SimpleSquareLattice) = FiniteSize((l.Lx, l.Ly))
 

--- a/test/core/test_lattice_element.jl
+++ b/test/core/test_lattice_element.jl
@@ -1,0 +1,15 @@
+using LatticeCore
+using Test
+
+@testset "AbstractLatticeElement" begin
+    @test VertexCenter <: AbstractLatticeElement
+    @test BondCenter <: AbstractLatticeElement
+    @test PlaquetteCenter <: AbstractLatticeElement
+    @test CellCenter <: AbstractLatticeElement
+
+    # Singleton values
+    @test VertexCenter() isa AbstractLatticeElement
+    @test BondCenter() isa AbstractLatticeElement
+    @test PlaquetteCenter() isa AbstractLatticeElement
+    @test CellCenter() isa AbstractLatticeElement
+end

--- a/test/core/test_line_lattice.jl
+++ b/test/core/test_line_lattice.jl
@@ -129,4 +129,20 @@ using Test
             @test to_lattice(lat, to_real(lat, lc_i)) == lc_i
         end
     end
+
+    @testset "site layout integration" begin
+        # Default: UniformLayout(IsingSite())
+        lat = LineLattice(5)
+        @test site_layout(lat) isa UniformLayout{IsingSite{Int8}}
+        @test site_type(lat, 1) isa IsingSite
+        @test site_type(lat, 3) === site_type(lat, 5)
+
+        # num_sublattices / sublattice default to 1
+        @test num_sublattices(lat) == 1
+        @test sublattice(lat, 3) == 1
+
+        # Swap in an XY layout via keyword
+        lat_xy = LineLattice(5; layout=UniformLayout(XYSite()))
+        @test site_type(lat_xy, 2) isa XYSite
+    end
 end

--- a/test/core/test_simple_square_lattice.jl
+++ b/test/core/test_simple_square_lattice.jl
@@ -158,4 +158,31 @@ using Test
             @test position(lat, expected) == SVector(Float64(cx), Float64(cy))
         end
     end
+
+    @testset "site layout integration" begin
+        # Default UniformLayout(IsingSite())
+        lat = SimpleSquareLattice(3, 3)
+        @test site_layout(lat) isa UniformLayout{IsingSite{Int8}}
+        for i in 1:num_sites(lat)
+            @test site_type(lat, i) isa IsingSite
+        end
+
+        @test num_sublattices(lat) == 1
+        @test sublattice(lat, 5) == 1
+
+        # Custom layout via keyword argument
+        heis = SimpleSquareLattice(3, 3; layout=UniformLayout(HeisenbergSite()))
+        @test site_type(heis, 1) isa HeisenbergSite
+
+        # Boundary + custom layout together
+        cyl = SimpleSquareLattice(
+            3,
+            3,
+            LatticeBoundary((PeriodicAxis(), OpenAxis()));
+            layout=UniformLayout(XYSite()),
+        )
+        @test boundary(cyl).axes[1] isa PeriodicAxis
+        @test boundary(cyl).axes[2] isa OpenAxis
+        @test site_type(cyl, 4) isa XYSite
+    end
 end

--- a/test/core/test_site_layout.jl
+++ b/test/core/test_site_layout.jl
@@ -1,0 +1,41 @@
+using LatticeCore
+using Test
+
+@testset "AbstractSiteLayout" begin
+    @testset "type hierarchy" begin
+        @test UniformLayout <: AbstractSiteLayout
+        @test SublatticeLayout <: AbstractSiteLayout
+        @test ExplicitLayout <: AbstractSiteLayout
+    end
+
+    @testset "UniformLayout" begin
+        l = UniformLayout(IsingSite())
+        @test l isa UniformLayout{IsingSite{Int8}}
+        @test l.site_type isa IsingSite
+
+        # Every site returns the same site type regardless of i
+        @test site_type(l, 1) === l.site_type
+        @test site_type(l, 42) === l.site_type
+        @test site_type(l, 10_000) === l.site_type
+    end
+
+    @testset "SublatticeLayout (mixed-spin)" begin
+        # Honeycomb-style mixed layout: A = Ising, B = XY
+        sublattice_of = [1, 2, 1, 2, 1, 2]  # ABABAB
+        l = SublatticeLayout((IsingSite(), XYSite()), sublattice_of)
+        @test l isa SublatticeLayout{2}
+
+        @test site_type(l, 1) isa IsingSite   # A
+        @test site_type(l, 2) isa XYSite      # B
+        @test site_type(l, 5) isa IsingSite
+        @test site_type(l, 6) isa XYSite
+    end
+
+    @testset "ExplicitLayout" begin
+        types = AbstractSiteType[IsingSite(), IsingSite(), XYSite(), HeisenbergSite()]
+        l = ExplicitLayout(types)
+        @test site_type(l, 1) isa IsingSite
+        @test site_type(l, 3) isa XYSite
+        @test site_type(l, 4) isa HeisenbergSite
+    end
+end

--- a/test/core/test_site_type.jl
+++ b/test/core/test_site_type.jl
@@ -1,0 +1,91 @@
+using LatticeCore
+using LinearAlgebra
+using StaticArrays
+using Random
+using Test
+
+@testset "AbstractSiteType" begin
+    @testset "type hierarchy" begin
+        @test IsingSite <: AbstractSiteType
+        @test PottsSite <: AbstractSiteType
+        @test XYSite <: AbstractSiteType
+        @test HeisenbergSite <: AbstractSiteType
+        @test EmptySite <: AbstractSiteType
+    end
+
+    @testset "element_type default is VertexCenter" begin
+        @test element_type(IsingSite()) isa VertexCenter
+        @test element_type(XYSite()) isa VertexCenter
+        @test element_type(HeisenbergSite()) isa VertexCenter
+        @test element_type(PottsSite(3)) isa VertexCenter
+        @test element_type(EmptySite()) isa VertexCenter
+    end
+
+    @testset "IsingSite" begin
+        s = IsingSite()
+        @test s isa IsingSite{Int8}
+        @test state_type(s) === Int8
+        @test zero_state(s) === Int8(0)
+        @test domain(s) == (Int8(-1), Int8(1))
+
+        rng = MersenneTwister(42)
+        for _ in 1:20
+            v = random_state(rng, s)
+            @test v isa Int8
+            @test v == Int8(-1) || v == Int8(1)
+        end
+
+        # Custom storage type
+        s_int = IsingSite{Int}()
+        @test state_type(s_int) === Int
+        @test random_state(MersenneTwister(0), s_int) isa Int
+    end
+
+    @testset "PottsSite" begin
+        s = PottsSite(3)
+        @test s isa PottsSite{3,Int8}
+        @test state_type(s) === Int8
+        @test domain(s) == (Int8(1), Int8(2), Int8(3))
+
+        rng = MersenneTwister(42)
+        for _ in 1:30
+            v = random_state(rng, s)
+            @test v isa Int8
+            @test 1 <= v <= 3
+        end
+    end
+
+    @testset "XYSite" begin
+        s = XYSite()
+        @test s isa XYSite{Float64}
+        @test state_type(s) === Float64
+        @test zero_state(s) === 0.0
+
+        rng = MersenneTwister(42)
+        for _ in 1:20
+            θ = random_state(rng, s)
+            @test θ isa Float64
+            @test 0.0 <= θ < 2π
+        end
+    end
+
+    @testset "HeisenbergSite (unit vectors)" begin
+        s = HeisenbergSite()
+        @test s isa HeisenbergSite{Float64}
+        @test state_type(s) === SVector{3,Float64}
+
+        rng = MersenneTwister(42)
+        for _ in 1:30
+            v = random_state(rng, s)
+            @test v isa SVector{3,Float64}
+            @test isapprox(norm(v), 1.0; atol=1e-12)
+        end
+    end
+
+    @testset "EmptySite" begin
+        s = EmptySite()
+        @test state_type(s) === Nothing
+        @test random_state(MersenneTwister(0), s) === nothing
+        @test zero_state(s) === nothing
+    end
+end


### PR DESCRIPTION
## Description

Implements the [04 site-type chapter](https://github.com/sotashimozono/work/blob/main/dev/note/04_architecture/04_site_type/README.md). This PR closes out the geometry side of LatticeCore; the chapters that remain are **05 momentum space** and **06 lazy infinite lattices**, followed by the final MC-layer work in Lattice2DMonteCarlo.

Fixed: (no linked issue)

## Type of Change

- [x] ✨ Feature (`enhancement`)
- [ ] 🐛 Bug Fix
- [ ] ⚡ Performance
- [ ] 📖 Documentation
- [ ] 🧰 Maintenance

## Key design decisions (inherited from 04)

- **sublattice (geometric role)** and **site type (physical dof)** are separated. `LatticeCoord.sublattice` is the geometric id; `AbstractSiteType` describes the DOF living on the site.
- A site type carries an `element_type` trait defaulting to `VertexCenter`, leaving room for bond / plaquette / cell-centered variables (dimer, gauge link, flux) without a breaking rewrite.
- Storage is layered through `AbstractSiteLayout`:
  - `UniformLayout` — zero per-site overhead, constant folds in the hot loop
  - `SublatticeLayout` — one site type per geometric sublattice, natural fit for mixed-spin
  - `ExplicitLayout` — one site type per site, for quenched disorder

## Proposed Changes

**`src/LatticeElement.jl` (new)**
- `AbstractLatticeElement`, `VertexCenter`, `BondCenter`, `PlaquetteCenter`, `CellCenter`

**`src/SiteType.jl` (new)**
- `AbstractSiteType` with `state_type` / `random_state` / `zero_state` / `domain` / `element_type` interface
- `IsingSite{T}` (default `Int8`), `PottsSite{Q,T}`, `XYSite{T}`, `HeisenbergSite{T}` (`SVector{3,T}`, Marsaglia unit-vector sampling), `EmptySite`

**`src/SiteLayout.jl` (new)**
- `AbstractSiteLayout`, `UniformLayout`, `SublatticeLayout`, `ExplicitLayout`, each implementing `site_type(layout, i)`

**`src/AbstractLattice.jl`**
- Add `site_layout(lat)`, `site_type(lat, i)` default delegating to `site_layout`, plus `num_sublattices` / `sublattice` accessors with safe defaults of `1`.

**Reference lattices (`LineLattice` / `SimpleSquareLattice`)**
- Add a `layout` field parameterized on `AbstractSiteLayout`
- Constructors gain a `layout` keyword argument; default `UniformLayout(IsingSite())` so every existing call site keeps compiling
- Implement `site_layout` for each

**`Project.toml`** — `0.4.0` → `0.5.0`; `Random` added to `[extras]` / `[targets]`

## Usage or Results

```julia
using LatticeCore, LinearAlgebra, StaticArrays

# Default Ising on a 2D PBC square lattice
sq = SimpleSquareLattice(3, 3)
site_type(sq, 5)          # IsingSite{Int8}()

# Swap in Heisenberg sites via the keyword argument
heis = SimpleSquareLattice(3, 3; layout = UniformLayout(HeisenbergSite()))
site_type(heis, 5)        # HeisenbergSite{Float64}()

# Mixed-spin honeycomb-style layout
mixed = SublatticeLayout((IsingSite(), XYSite()), [1,2,1,2,1,2])
site_type(mixed, 1)       # IsingSite
site_type(mixed, 2)       # XYSite

# Future hook: bond-centered site types
# element_type(::GaugeLink) = BondCenter()   # downstream
```

Local test run: **712 / 712 pass** (+273 from PR #5).

## check list
- [x] test駆動をしたか — layout invariance, mixed-spin dispatch, Marsaglia unit-vector sampling, round-trip integration with reference lattices