### PR TITLE
feat: momentum-space lattices and structure factor

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.5.0"
+version = "0.6.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/LatticeCore.jl
+++ b/src/LatticeCore.jl
@@ -17,6 +17,8 @@ include("Bond.jl")
 include("BoundaryCondition.jl")
 include("Coordinate.jl")
 include("Indexing.jl")
+include("MomentumLattice.jl")
+include("StructureFactor.jl")
 include("reference/LineLattice.jl")
 include("reference/SimpleSquareLattice.jl")
 
@@ -63,7 +65,15 @@ export to_real, to_lattice, to_hyper
 export AbstractIndexing, RowMajor, ColMajor, Snake
 export site_index, lattice_coord
 
+# ---- Momentum space ----
+export AbstractMomentumLattice, PeriodicMomentumLattice
+export num_k_points, k_point, reciprocal_basis
+export reciprocal_lattice, fourier_module, momentum_lattice
+export monkhorst_pack, gamma_centered
+export structure_factor
+export AcceptanceWindow, HyperReciprocalLattice, BraggPeakSet
+
 # ---- Reference lattices ----
-export LineLattice, SimpleSquareLattice
+export LineLattice, SimpleSquareLattice, basis_vectors
 
 end # module LatticeCore

--- a/src/MomentumLattice.jl
+++ b/src/MomentumLattice.jl
@@ -1,0 +1,244 @@
+"""
+    AbstractMomentumLattice{D, T} <: AbstractLattice{D, T}
+
+Abstract supertype for k-space lattices. A momentum lattice is itself
+an `AbstractLattice` — its "sites" are k-points, its "positions" are
+k-vectors in the reciprocal basis — so 02's lattice interface
+(`num_sites`, `position`, traits, test suite) can be re-used for
+k-space work. See `dev/note/04_architecture/05_momentum_space`.
+
+# Required interface for concrete subtypes
+- `num_k_points(ml)::Int`
+- `k_point(ml, i::Int)::SVector{D, T}`
+- `reciprocal_basis(ml)::SMatrix{D, D, T}`
+
+The graph-neighbour side of `AbstractLattice` (`neighbors`, `bonds`)
+is deliberately vacuous for momentum lattices: k-space is not a graph
+in the same sense. Concrete momentum lattices return an empty
+neighbour list; MC code should never walk them as a graph.
+"""
+abstract type AbstractMomentumLattice{D,T} <: AbstractLattice{D,T} end
+
+"""
+    num_k_points(ml::AbstractMomentumLattice) → Int
+
+Number of k-points stored in the lattice.
+"""
+function num_k_points end
+
+"""
+    k_point(ml::AbstractMomentumLattice, i::Int) → SVector{D, T}
+
+The i-th k-vector in real (Cartesian) units — i.e. already multiplied
+through the reciprocal basis.
+"""
+function k_point end
+
+"""
+    reciprocal_basis(ml::AbstractMomentumLattice) → SMatrix{D, D, T}
+
+Reciprocal-space basis matrix. Columns are the primitive reciprocal
+lattice vectors.
+"""
+function reciprocal_basis end
+
+# AbstractLattice specialisations -------------------------------------
+num_sites(ml::AbstractMomentumLattice) = num_k_points(ml)
+position(ml::AbstractMomentumLattice, i::Int) = k_point(ml, i)
+
+# Graph interface is vacuous for momentum lattices.
+neighbors(::AbstractMomentumLattice, ::Int) = Int[]
+
+# ---- PeriodicMomentumLattice -----------------------------------------
+
+"""
+    PeriodicMomentumLattice{D, T}
+
+Concrete momentum lattice for a Bravais periodic lattice. Stores the
+reciprocal basis, the mesh dimensions, the Γ-offset, and an explicit
+list of k-points (eager construction).
+
+Construct via [`monkhorst_pack`](@ref) or [`gamma_centered`](@ref)
+rather than calling the struct directly.
+"""
+struct PeriodicMomentumLattice{D,T<:AbstractFloat} <: AbstractMomentumLattice{D,T}
+    reciprocal_basis::SMatrix{D,D,T}
+    mesh::NTuple{D,Int}
+    shift::SVector{D,T}
+    k_points::Vector{SVector{D,T}}
+end
+
+num_k_points(ml::PeriodicMomentumLattice) = length(ml.k_points)
+k_point(ml::PeriodicMomentumLattice, i::Int) = ml.k_points[i]
+reciprocal_basis(ml::PeriodicMomentumLattice) = ml.reciprocal_basis
+
+size_trait(ml::PeriodicMomentumLattice) = FiniteSize(ml.mesh)
+
+# Momentum lattices are implicitly periodic in k (wrapping at BZ
+# boundaries). Return an all-periodic LatticeBoundary so calls to
+# `boundary(ml)` don't explode.
+function boundary(ml::PeriodicMomentumLattice{D}) where {D}
+    axes = ntuple(_ -> PeriodicAxis(), D)
+    return LatticeBoundary(axes, NoModifier())
+end
+
+periodicity(::PeriodicMomentumLattice) = Periodic()
+reciprocal_support(::PeriodicMomentumLattice) = HasReciprocal()
+
+# Momentum lattices carry no site-type information of their own. We
+# give a default `UniformLayout(EmptySite())` so `site_layout` /
+# `site_type` keep working if someone calls them.
+site_layout(::PeriodicMomentumLattice) = UniformLayout(EmptySite())
+
+# ---- Mesh constructors -----------------------------------------------
+
+"""
+    monkhorst_pack(basis::SMatrix{D, D, T}, mesh::NTuple{D, Int})
+        → PeriodicMomentumLattice{D, T}
+
+Construct a Monkhorst–Pack half-shifted mesh over the Brillouin zone
+spanned by `basis`. For each axis the fractional k-coordinates are
+
+    frac_i ∈ { (n + 0.5) / N - 0.5 | n = 0, …, N - 1 }
+
+so the mesh is centred at Γ and avoids the BZ edges.
+"""
+function monkhorst_pack(basis::SMatrix{D,D,T}, mesh::NTuple{D,Int}) where {D,T}
+    shift = zero(SVector{D,T})
+    k_points = SVector{D,T}[]
+    for idx in CartesianIndices(mesh)
+        frac = SVector{D,T}(
+            ntuple(i -> (T(idx.I[i] - 1) + T(0.5)) / T(mesh[i]) - T(0.5), D)
+        )
+        push!(k_points, basis * frac)
+    end
+    return PeriodicMomentumLattice{D,T}(basis, mesh, shift, k_points)
+end
+
+"""
+    gamma_centered(basis::SMatrix{D, D, T}, mesh::NTuple{D, Int})
+        → PeriodicMomentumLattice{D, T}
+
+Construct a Γ-centred regular mesh. Fractional k-coordinates are
+`n / N` with `n = 0, …, N - 1`, so the mesh includes Γ and walks to
+but not through the BZ edge.
+"""
+function gamma_centered(basis::SMatrix{D,D,T}, mesh::NTuple{D,Int}) where {D,T}
+    shift = zero(SVector{D,T})
+    k_points = SVector{D,T}[]
+    for idx in CartesianIndices(mesh)
+        frac = SVector{D,T}(ntuple(i -> T(idx.I[i] - 1) / T(mesh[i]), D))
+        push!(k_points, basis * frac)
+    end
+    return PeriodicMomentumLattice{D,T}(basis, mesh, shift, k_points)
+end
+
+# ---- Entry points ----------------------------------------------------
+
+"""
+    reciprocal_lattice(lat::AbstractLattice) → PeriodicMomentumLattice
+
+Construct the reciprocal lattice for a Bravais-like `lat`. Concrete
+lattices are expected to specialise this method; the fallback throws.
+"""
+function reciprocal_lattice(lat::AbstractLattice)
+    throw(
+        MethodError(reciprocal_lattice, (lat,))
+    )
+end
+
+"""
+    fourier_module(lat::AbstractLattice) → AbstractMomentumLattice
+
+Quasicrystal-side entry point: construct the discrete Fourier module
+(Bragg peak set) for a cut-and-project lattice. Concrete quasicrystal
+lattices implement this in their own package; the fallback throws.
+"""
+function fourier_module(lat::AbstractLattice)
+    throw(MethodError(fourier_module, (lat,)))
+end
+
+"""
+    momentum_lattice(lat::AbstractLattice) → AbstractMomentumLattice
+
+Unified trait-dispatched entry point. Returns the reciprocal lattice
+for Bravais-like structures, the Fourier module for quasicrystals,
+and throws for lattices without any k-space representation.
+"""
+momentum_lattice(lat::AbstractLattice) = _momentum_lattice(lat, reciprocal_support(lat))
+_momentum_lattice(lat, ::HasReciprocal) = reciprocal_lattice(lat)
+_momentum_lattice(lat, ::HasFourierModule) = fourier_module(lat)
+function _momentum_lattice(lat, ::NoReciprocal)
+    throw(ArgumentError("$(typeof(lat)) has no k-space representation"))
+end
+
+# ---- Quasicrystal hooks (type skeletons only) ------------------------
+#
+# The concrete implementations (generation algorithms, window Fourier
+# transforms, symmetry reduction) live in QuasiCrystal.jl. We only
+# expose the type vocabulary here so downstream code can refer to
+# them.
+
+"""
+    AcceptanceWindow
+
+Abstract supertype for acceptance windows in the internal (perp)
+space of a cut-and-project quasicrystal. Concrete windows
+(`PolygonalWindow`, `IntervalWindow`, etc.) live in QuasiCrystal.jl.
+"""
+abstract type AcceptanceWindow end
+
+"""
+    HyperReciprocalLattice{DPhys, DHyper, T}
+
+Infinite-abstract representation of a quasicrystal's reciprocal
+structure: the higher-dimensional reciprocal basis, the parallel and
+perpendicular projections, and the acceptance window used to decide
+peak intensities.
+
+Concrete construction (building the projections, sampling peaks)
+lives in QuasiCrystal.jl.
+"""
+struct HyperReciprocalLattice{
+    DPhys,DHyper,DPerp,T<:AbstractFloat,W<:AcceptanceWindow
+}
+    hyper_basis::SMatrix{DHyper,DHyper,T}
+    parallel_proj::SMatrix{DPhys,DHyper,T}
+    perp_proj::SMatrix{DPerp,DHyper,T}
+    window::W
+end
+
+"""
+    BraggPeakSet{DPhys, T}
+
+Finite materialisation of a `HyperReciprocalLattice` up to a cutoff
+radius: a list of physical-space k-positions with intensities and a
+back-pointer to the higher-dimensional indices that generated them.
+
+Being a subtype of [`AbstractMomentumLattice`](@ref), a `BraggPeakSet`
+can be passed straight to `structure_factor` or to a
+`StructureFactorObserver` so the same code paths work for periodic
+and quasiperiodic lattices.
+"""
+struct BraggPeakSet{DPhys,DHyper,T<:AbstractFloat} <: AbstractMomentumLattice{DPhys,T}
+    peaks::Vector{SVector{DPhys,T}}
+    intensities::Vector{T}
+    hyper_indices::Vector{NTuple{DHyper,Int}}
+end
+
+num_k_points(bps::BraggPeakSet) = length(bps.peaks)
+k_point(bps::BraggPeakSet, i::Int) = bps.peaks[i]
+function reciprocal_basis(::BraggPeakSet{DPhys,DHyper,T}) where {DPhys,DHyper,T}
+    # A quasicrystal does not have a Bravais reciprocal basis; the
+    # Fourier module is dense. We return a zero matrix as a sentinel
+    # so downstream code can detect the situation.
+    return zero(SMatrix{DPhys,DPhys,T})
+end
+
+size_trait(bps::BraggPeakSet) = FiniteSize((length(bps.peaks),))
+function boundary(::BraggPeakSet{DPhys}) where {DPhys}
+    axes = ntuple(_ -> OpenAxis(), DPhys)
+    return LatticeBoundary(axes, NoModifier())
+end
+reciprocal_support(::BraggPeakSet) = HasFourierModule()
+site_layout(::BraggPeakSet) = UniformLayout(EmptySite())

--- a/src/MomentumLattice.jl
+++ b/src/MomentumLattice.jl
@@ -142,9 +142,7 @@ Construct the reciprocal lattice for a Bravais-like `lat`. Concrete
 lattices are expected to specialise this method; the fallback throws.
 """
 function reciprocal_lattice(lat::AbstractLattice)
-    throw(
-        MethodError(reciprocal_lattice, (lat,))
-    )
+    throw(MethodError(reciprocal_lattice, (lat,)))
 end
 
 """
@@ -199,9 +197,7 @@ peak intensities.
 Concrete construction (building the projections, sampling peaks)
 lives in QuasiCrystal.jl.
 """
-struct HyperReciprocalLattice{
-    DPhys,DHyper,DPerp,T<:AbstractFloat,W<:AcceptanceWindow
-}
+struct HyperReciprocalLattice{DPhys,DHyper,DPerp,T<:AbstractFloat,W<:AcceptanceWindow}
     hyper_basis::SMatrix{DHyper,DHyper,T}
     parallel_proj::SMatrix{DPhys,DHyper,T}
     perp_proj::SMatrix{DPerp,DHyper,T}

--- a/src/StructureFactor.jl
+++ b/src/StructureFactor.jl
@@ -1,0 +1,37 @@
+"""
+    structure_factor(lat, state, k::SVector) → Float64
+
+Scalar structure factor at a single k-point:
+
+    S(k) = (1/N) |⟨ Σ_i s_i exp(-i k · r_i) ⟩|²
+
+computed on a single snapshot (no thermal averaging). The default
+implementation is naive O(N) per k-point; FFT-based specialisations
+on regular meshes can be added later without changing the API.
+"""
+function structure_factor(
+    lat::AbstractLattice, state::AbstractVector, k::SVector{D,T}
+) where {D,T}
+    N = num_sites(lat)
+    acc = zero(ComplexF64)
+    for i in 1:N
+        acc += state[i] * cis(-dot(k, position(lat, i)))
+    end
+    return abs2(acc) / N
+end
+
+"""
+    structure_factor(lat, state, ml::AbstractMomentumLattice) → Vector{Float64}
+
+Evaluate the structure factor at every k-point of `ml`. Naive
+O(N · M) where `M = num_k_points(ml)`.
+"""
+function structure_factor(
+    lat::AbstractLattice, state::AbstractVector, ml::AbstractMomentumLattice
+)
+    out = Vector{Float64}(undef, num_k_points(ml))
+    for i in 1:num_k_points(ml)
+        out[i] = structure_factor(lat, state, k_point(ml, i))
+    end
+    return out
+end

--- a/src/reference/LineLattice.jl
+++ b/src/reference/LineLattice.jl
@@ -138,3 +138,24 @@ nearest integer cell index.
 function to_lattice(::LineLattice, rs::RealSpace{1})
     return LatticeCoord((round(Int, rs.x[1]),), 1)
 end
+
+# ---- Reciprocal lattice ----
+
+"""
+    basis_vectors(lat::LineLattice) → SMatrix{1, 1, T}
+
+Real-space basis matrix. For the unit-spacing reference chain this
+is the 1×1 identity.
+"""
+basis_vectors(::LineLattice{T}) where {T} = SMatrix{1,1,T}(one(T))
+
+function reciprocal_lattice(lat::LineLattice{T}) where {T}
+    reciprocal_support(lat) isa HasReciprocal || throw(
+        ArgumentError(
+            "LineLattice has no reciprocal lattice under non-periodic BC"
+        ),
+    )
+    A = basis_vectors(lat)
+    B = SMatrix{1,1,T}(T(2π) * inv(transpose(A)))
+    return monkhorst_pack(B, (lat.N,))
+end

--- a/src/reference/LineLattice.jl
+++ b/src/reference/LineLattice.jl
@@ -150,11 +150,8 @@ is the 1×1 identity.
 basis_vectors(::LineLattice{T}) where {T} = SMatrix{1,1,T}(one(T))
 
 function reciprocal_lattice(lat::LineLattice{T}) where {T}
-    reciprocal_support(lat) isa HasReciprocal || throw(
-        ArgumentError(
-            "LineLattice has no reciprocal lattice under non-periodic BC"
-        ),
-    )
+    reciprocal_support(lat) isa HasReciprocal ||
+        throw(ArgumentError("LineLattice has no reciprocal lattice under non-periodic BC"))
     A = basis_vectors(lat)
     B = SMatrix{1,1,T}(T(2π) * inv(transpose(A)))
     return monkhorst_pack(B, (lat.N,))

--- a/src/reference/SimpleSquareLattice.jl
+++ b/src/reference/SimpleSquareLattice.jl
@@ -198,7 +198,9 @@ end
 Real-space basis matrix. For the unit-spacing reference square this
 is the 2×2 identity.
 """
-basis_vectors(::SimpleSquareLattice{T}) where {T} = SMatrix{2,2,T}(one(T), zero(T), zero(T), one(T))
+function basis_vectors(::SimpleSquareLattice{T}) where {T}
+    SMatrix{2,2,T}(one(T), zero(T), zero(T), one(T))
+end
 
 function reciprocal_lattice(lat::SimpleSquareLattice{T}) where {T}
     reciprocal_support(lat) isa HasReciprocal || throw(

--- a/src/reference/SimpleSquareLattice.jl
+++ b/src/reference/SimpleSquareLattice.jl
@@ -189,3 +189,24 @@ integer cell index.
 function to_lattice(::SimpleSquareLattice, rs::RealSpace{2})
     return LatticeCoord((round(Int, rs.x[1]), round(Int, rs.x[2])), 1)
 end
+
+# ---- Reciprocal lattice ----
+
+"""
+    basis_vectors(lat::SimpleSquareLattice) → SMatrix{2, 2, T}
+
+Real-space basis matrix. For the unit-spacing reference square this
+is the 2×2 identity.
+"""
+basis_vectors(::SimpleSquareLattice{T}) where {T} = SMatrix{2,2,T}(one(T), zero(T), zero(T), one(T))
+
+function reciprocal_lattice(lat::SimpleSquareLattice{T}) where {T}
+    reciprocal_support(lat) isa HasReciprocal || throw(
+        ArgumentError(
+            "SimpleSquareLattice has no reciprocal lattice unless both axes are periodic",
+        ),
+    )
+    A = basis_vectors(lat)
+    B = SMatrix{2,2,T}(T(2π) * inv(transpose(A)))
+    return monkhorst_pack(B, (lat.Lx, lat.Ly))
+end

--- a/test/core/test_momentum_lattice.jl
+++ b/test/core/test_momentum_lattice.jl
@@ -1,0 +1,101 @@
+using LatticeCore
+using StaticArrays
+using LinearAlgebra
+using Test
+
+@testset "AbstractMomentumLattice" begin
+    @testset "type hierarchy" begin
+        @test AbstractMomentumLattice <: AbstractLattice
+        @test PeriodicMomentumLattice <: AbstractMomentumLattice
+        @test BraggPeakSet <: AbstractMomentumLattice
+    end
+
+    @testset "monkhorst_pack 1D" begin
+        basis = SMatrix{1,1,Float64}(2π)          # reciprocal of unit-spacing chain
+        ml = monkhorst_pack(basis, (4,))
+        @test ml isa PeriodicMomentumLattice{1,Float64}
+        @test num_k_points(ml) == 4
+        @test num_sites(ml) == 4                  # AbstractLattice delegation
+        @test dimension(ml) == 1
+        @test reciprocal_basis(ml) == basis
+
+        # MP mesh is half-shifted and Γ-centred: for N=4 the fractions
+        # are (n + 0.5)/N - 0.5 = -3/8, -1/8, 1/8, 3/8
+        expected_fracs = [-3 / 8, -1 / 8, 1 / 8, 3 / 8]
+        for i in 1:4
+            @test k_point(ml, i)[1] ≈ 2π * expected_fracs[i]
+        end
+
+        @test position(ml, 2) == k_point(ml, 2)   # AbstractLattice delegation
+        @test size_trait(ml) isa FiniteSize{1}
+        @test is_finite(ml) == true
+        @test neighbors(ml, 1) == Int[]           # graph interface is vacuous
+    end
+
+    @testset "gamma_centered 2D" begin
+        basis = SMatrix{2,2,Float64}(2π, 0.0, 0.0, 2π)
+        ml = gamma_centered(basis, (3, 3))
+        @test num_k_points(ml) == 9
+        # First k-point should be Γ = (0, 0)
+        @test k_point(ml, 1) == SVector(0.0, 0.0)
+    end
+
+    @testset "BraggPeakSet skeleton (QuasiCrystal will fill it)" begin
+        peaks = [SVector(1.0, 2.0), SVector(3.0, 4.0)]
+        intensities = [0.5, 0.2]
+        hyper_indices = [(1, 0, 0, 1, 0), (0, 1, 1, 0, 0)]   # 5D indices
+        bps = BraggPeakSet{2,5,Float64}(peaks, intensities, hyper_indices)
+        @test bps isa AbstractMomentumLattice{2,Float64}
+        @test num_k_points(bps) == 2
+        @test k_point(bps, 1) == SVector(1.0, 2.0)
+        @test reciprocal_support(bps) isa HasFourierModule
+    end
+end
+
+@testset "Trait-dispatched momentum_lattice entry point" begin
+    # LineLattice under PBC: HasReciprocal, returns PeriodicMomentumLattice
+    lat_pbc = LineLattice(4, PeriodicAxis())
+    @test reciprocal_support(lat_pbc) isa HasReciprocal
+    ml = momentum_lattice(lat_pbc)
+    @test ml isa PeriodicMomentumLattice{1,Float64}
+    @test num_k_points(ml) == 4
+
+    # LineLattice under OBC: NoReciprocal, momentum_lattice throws
+    lat_obc = LineLattice(4, OpenAxis())
+    @test reciprocal_support(lat_obc) isa NoReciprocal
+    @test_throws ArgumentError momentum_lattice(lat_obc)
+end
+
+@testset "LineLattice reciprocal_lattice" begin
+    lat = LineLattice(6, PeriodicAxis())
+    @test basis_vectors(lat) == SMatrix{1,1,Float64}(1.0)
+
+    ml = reciprocal_lattice(lat)
+    @test ml isa PeriodicMomentumLattice{1,Float64}
+    @test reciprocal_basis(ml)[1, 1] ≈ 2π
+    @test num_k_points(ml) == 6
+
+    # OBC → should error
+    @test_throws ArgumentError reciprocal_lattice(LineLattice(6, OpenAxis()))
+end
+
+@testset "SimpleSquareLattice reciprocal_lattice" begin
+    lat = SimpleSquareLattice(3, 3, PeriodicAxis())
+    A = basis_vectors(lat)
+    @test A == SMatrix{2,2,Float64}(1.0, 0.0, 0.0, 1.0)
+
+    ml = reciprocal_lattice(lat)
+    @test ml isa PeriodicMomentumLattice{2,Float64}
+    B = reciprocal_basis(ml)
+    # Orthogonality: a_i · b_j = 2π δ_ij
+    for i in 1:2, j in 1:2
+        expected = i == j ? 2π : 0.0
+        @test dot(A[:, i], B[:, j]) ≈ expected
+    end
+
+    @test num_k_points(ml) == 9
+
+    # Cylinder / OBC → error
+    cyl = SimpleSquareLattice(3, 3, LatticeBoundary((PeriodicAxis(), OpenAxis())))
+    @test_throws ArgumentError reciprocal_lattice(cyl)
+end

--- a/test/core/test_structure_factor.jl
+++ b/test/core/test_structure_factor.jl
@@ -1,0 +1,69 @@
+using LatticeCore
+using StaticArrays
+using Test
+
+@testset "structure_factor" begin
+    @testset "ferromagnet at k=0" begin
+        # S(k=0) = |Σ s_i|² / N = N² / N = N for s_i ≡ 1
+        lat = SimpleSquareLattice(4, 4, PeriodicAxis())
+        state = ones(Int8, num_sites(lat))
+        S0 = structure_factor(lat, state, SVector(0.0, 0.0))
+        @test S0 ≈ Float64(num_sites(lat))
+    end
+
+    @testset "ferromagnet vanishes at BZ-interior k" begin
+        # A k inside the first BZ but not a reciprocal-lattice vector.
+        # At k = (π/2, 0), Σ_{x=1..4} exp(-i(π/2)x) = -i + (-1) + i + 1 = 0,
+        # so the row sum vanishes and S(k) = 0.
+        lat = SimpleSquareLattice(4, 4, PeriodicAxis())
+        state = ones(Int8, num_sites(lat))
+        S_mid = structure_factor(lat, state, SVector(π / 2, 0.0))
+        @test isapprox(S_mid, 0.0; atol=1e-10)
+
+        # At a full reciprocal-lattice vector b = (2π, 0), the phase is
+        # trivial on every integer site, so we are still sitting at Γ:
+        # S(b) = N, matching S(0). Sanity-check this to lock the
+        # convention down.
+        S_G = structure_factor(lat, state, SVector(2π, 0.0))
+        @test S_G ≈ Float64(num_sites(lat))
+    end
+
+    @testset "Neel antiferromagnet peaks at (π, π)" begin
+        # 4x4 PBC square is bipartite; build the Neel state s = (-1)^(x+y).
+        lat = SimpleSquareLattice(4, 4, PeriodicAxis())
+        N = num_sites(lat)
+        state = Vector{Int8}(undef, N)
+        for i in 1:N
+            p = position(lat, i)
+            state[i] = Int8((-1)^(Int(p[1]) + Int(p[2])))
+        end
+        # S(π, π) should equal N for the Neel state.
+        S_afm = structure_factor(lat, state, SVector(Float64(π), Float64(π)))
+        @test S_afm ≈ Float64(N)
+
+        # Off-peak should be small at (0, 0)
+        S0 = structure_factor(lat, state, SVector(0.0, 0.0))
+        @test isapprox(S0, 0.0; atol=1e-10)
+    end
+
+    @testset "structure_factor over a whole momentum lattice" begin
+        lat = SimpleSquareLattice(4, 4, PeriodicAxis())
+        state = ones(Int8, num_sites(lat))
+        ml = reciprocal_lattice(lat)
+        Sks = structure_factor(lat, state, ml)
+        @test Sks isa Vector{Float64}
+        @test length(Sks) == num_k_points(ml)
+        # Ferromagnet: all k-space mass is at k = 0. The MP mesh on a
+        # 4x4 square does not contain (0, 0), but the total weight
+        # should still concentrate on small-k points. A weaker check:
+        # the total sum of |S(k)| * (peak indicator) is finite.
+        @test all(S >= -1e-10 for S in Sks)
+    end
+
+    @testset "1D chain" begin
+        lat = LineLattice(6, PeriodicAxis())
+        state = ones(Int8, num_sites(lat))
+        # k = 0: all phases are 1 → |N|² / N = N
+        @test structure_factor(lat, state, SVector(0.0)) ≈ Float64(num_sites(lat))
+    end
+end


### PR DESCRIPTION
## Description

Implements the [05 momentum-space chapter](https://github.com/sotashimozono/work/blob/main/dev/note/04_architecture/05_momentum_space/README.md) at the LatticeCore level. The quasicrystal-specific generation algorithms (hyper reciprocal lattice construction, window Fourier transforms, Bragg peak enumeration) stay in `QuasiCrystal.jl`, but the **type vocabulary is now in LatticeCore** so downstream code has a single interface for both Bravais-periodic and quasiperiodic lattices.

Fixed: (no linked issue)

## Type of Change

- [x] ✨ Feature (`enhancement`)
- [ ] 🐛 Bug Fix
- [ ] ⚡ Performance
- [ ] 📖 Documentation
- [ ] 🧰 Maintenance

## Proposed Changes

**`src/MomentumLattice.jl` (new)**

- `AbstractMomentumLattice{D, T} <: AbstractLattice{D, T}` — the `AbstractLattice` interface is specialised so that `num_sites`, `position`, and traits come for free; `neighbors` returns an empty list because k-space is not a walkable graph
- `PeriodicMomentumLattice{D, T}` — eager k-point storage, reciprocal basis, mesh dimensions, Γ offset
- Mesh constructors:
  - `monkhorst_pack(basis, mesh)` — half-shifted Γ-centred mesh `(n + 0.5)/N - 0.5`
  - `gamma_centered(basis, mesh)` — Γ-inclusive forward mesh `n/N`
- Entry points:
  - `reciprocal_lattice(lat)` — periodic-only
  - `fourier_module(lat)` — quasicrystal-only
  - `momentum_lattice(lat)` — trait dispatched (`HasReciprocal` / `HasFourierModule` / `NoReciprocal`)
- **Type skeletons for QuasiCrystal**:
  - `AcceptanceWindow` abstract type
  - `HyperReciprocalLattice{DPhys, DHyper, DPerp, T, W}`
  - `BraggPeakSet{DPhys, DHyper, T}` — a subtype of `AbstractMomentumLattice` so `structure_factor` and future observers work **identically** on periodic and quasiperiodic lattices

**`src/StructureFactor.jl` (new)**

- Scalar `structure_factor(lat, state, k::SVector) → Float64`, naive O(N):
  ```julia
  S(k) = |Σ_i s_i exp(-i k · r_i)|² / N
  ```
- Vector overload iterating over every k-point of a momentum lattice

**Reference lattices**

- `LineLattice` and `SimpleSquareLattice` gain `basis_vectors` (unit-spacing identity) and `reciprocal_lattice`. The latter builds `B = 2π · inv(A')` and feeds it to `monkhorst_pack`; cylinder / OBC boundaries throw, matching the `reciprocal_support` trait.

**`Project.toml`** — `0.5.0` → `0.6.0` (additive)

## Usage or Results

```julia
using LatticeCore, StaticArrays

lat = SimpleSquareLattice(4, 4, PeriodicAxis())

# Build the reciprocal lattice (a 4x4 MP mesh in 2π units)
ml = reciprocal_lattice(lat)
num_k_points(ml)         # 16
reciprocal_basis(ml)     # SMatrix 2π * I₂

# Neel state: S(π, π) peaks at N
state = Int8[(-1)^(Int(position(lat, i)[1]) + Int(position(lat, i)[2]))
             for i in 1:num_sites(lat)]
structure_factor(lat, state, SVector(π, π))   # 16.0
structure_factor(lat, state, SVector(0.0, 0.0))  # ~0

# Sweep over the whole momentum lattice
Sks = structure_factor(lat, state, ml)
```

Local test run: **761 / 761 pass**.

## Notes

- During test authoring I got bitten by the convention that `k = (2π, 0)` is a **reciprocal-lattice vector** (Γ-equivalent), so `S(2π, 0)` is `N`, not `0`. The fix uses `k = (π/2, 0)` inside the BZ and adds an explicit sanity check at the reciprocal vector to prevent regression.
- `BraggPeakSet` is shipped as an empty-fillable type — QuasiCrystal.jl will add the generation algorithms in a subsequent PR that targets the `QuasiCrystal.jl` repo.

## check list
- [x] test駆動をしたか — orthogonality check `a_i · b_j = 2π δ_ij`, ferromagnet `S(0) = N` / BZ-interior vanishing, Neel `S(π, π) = N`