### PR TITLE
feat: materialize and require_finite for lazy / infinite lattices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.6.0"
+version = "0.7.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/LatticeCore.jl
+++ b/src/LatticeCore.jl
@@ -19,6 +19,7 @@ include("Coordinate.jl")
 include("Indexing.jl")
 include("MomentumLattice.jl")
 include("StructureFactor.jl")
+include("LazyInfinite.jl")
 include("reference/LineLattice.jl")
 include("reference/SimpleSquareLattice.jl")
 
@@ -72,6 +73,9 @@ export reciprocal_lattice, fourier_module, momentum_lattice
 export monkhorst_pack, gamma_centered
 export structure_factor
 export AcceptanceWindow, HyperReciprocalLattice, BraggPeakSet
+
+# ---- Lazy / infinite ----
+export materialize, require_finite
 
 # ---- Reference lattices ----
 export LineLattice, SimpleSquareLattice, basis_vectors

--- a/src/LazyInfinite.jl
+++ b/src/LazyInfinite.jl
@@ -1,0 +1,64 @@
+"""
+    materialize(abstract; kwargs...) → AbstractLattice
+
+Materialise an infinite / conceptually-infinite abstract lattice into
+a finite [`AbstractLattice`](@ref) up to the given cutoff.
+
+This is the entry point for working with infinite structures
+(quasicrystals beyond a cutoff radius, Fibonacci / L-system
+substitutions beyond a certain depth, etc.) inside LatticeCore. It
+is intentionally **generic with no typed supertype**: any package can
+ship its own "infinite abstract" type and implement `materialize`
+without having to inherit from a LatticeCore hierarchy.
+
+# Cutoff convention
+
+The meaning of the cutoff keyword argument(s) is implementation-
+defined. Typical choices are:
+
+- `depth::Int` — substitution depth (Fibonacci, L-system)
+- `radius::Real` — spatial radius (Penrose cut-and-project)
+- `dims::NTuple{D, Int}` — explicit per-axis sizes
+
+The returned lattice must be [`is_finite`](@ref) `== true`, i.e. its
+[`size_trait`](@ref) should be a [`FiniteSize`](@ref), so it can be
+fed directly into Monte Carlo algorithms guarded by
+[`require_finite`](@ref).
+
+See `dev/note/04_architecture/06_lazy_infinite/README.md` for the
+infinite-abstract ↔ finite-materialisation design pattern, and for
+the parallel pattern in 05 Part B (`HyperReciprocalLattice →
+BraggPeakSet`).
+"""
+function materialize end
+
+"""
+    require_finite(lat::AbstractLattice)
+
+Assert that `lat` is a finite lattice. Throws `ArgumentError` if
+[`is_finite`](@ref) returns `false`.
+
+Intended as a guard at the entry point of Monte Carlo algorithms or
+any routine that cannot operate on an infinite or not-yet-materialised
+lattice. Returns `nothing` on success.
+
+# Example
+
+```julia
+function run!(rng, state, lat::AbstractLattice, model, alg; kwargs...)
+    require_finite(lat)
+    # ... safe to walk the full site list from here ...
+end
+```
+"""
+function require_finite(lat::AbstractLattice)
+    if !is_finite(lat)
+        throw(
+            ArgumentError(
+                "$(typeof(lat)) is not finite " *
+                "(size_trait = $(size_trait(lat))); call `materialize` first",
+            ),
+        )
+    end
+    return nothing
+end

--- a/test/core/test_lazy_infinite.jl
+++ b/test/core/test_lazy_infinite.jl
@@ -1,0 +1,57 @@
+using LatticeCore
+using Test
+
+# ---- Minimal mock of an infinite lattice, local to this test file ----
+#
+# A proper infinite lattice like `InfiniteFibonacci` is out of scope
+# for LatticeCore itself; it will live in a downstream package
+# (QuasiCrystal.jl / a future LSystemAdapter). We only need a
+# *contract check* here: `size_trait = InfiniteSize()` must make
+# `is_finite` false and trip `require_finite`.
+
+struct _InfiniteChain <: AbstractLattice{1,Float64} end
+
+LatticeCore.size_trait(::_InfiniteChain) = InfiniteSize()
+LatticeCore.boundary(::_InfiniteChain) = LatticeBoundary((PeriodicAxis(),), NoModifier())
+LatticeCore.site_layout(::_InfiniteChain) = UniformLayout(IsingSite())
+
+# And a minimal "infinite abstract" + matching `materialize` overload,
+# demonstrating the intended usage pattern from the 06 chapter.
+
+struct _InfiniteChainAbstract end
+
+LatticeCore.materialize(::_InfiniteChainAbstract; depth::Int) =
+    LineLattice(depth, PeriodicAxis())
+
+@testset "LazyInfinite" begin
+    @testset "require_finite on finite lattices is a no-op" begin
+        @test require_finite(LineLattice(5)) === nothing
+        @test require_finite(SimpleSquareLattice(3, 3)) === nothing
+        @test require_finite(LineLattice(5, OpenAxis())) === nothing
+    end
+
+    @testset "require_finite throws on InfiniteSize" begin
+        inf_lat = _InfiniteChain()
+        @test is_finite(inf_lat) == false
+        @test_throws ArgumentError require_finite(inf_lat)
+    end
+
+    @testset "materialize turns an infinite abstract into a finite lattice" begin
+        abs_chain = _InfiniteChainAbstract()
+
+        lat = materialize(abs_chain; depth=10)
+        @test lat isa LineLattice
+        @test num_sites(lat) == 10
+        @test is_finite(lat) == true
+
+        # The materialised lattice passes the MC guard.
+        @test require_finite(lat) === nothing
+    end
+
+    @testset "materialize is a generic function with no default" begin
+        # Calling it on a bare type with no specialised method should
+        # raise a MethodError, because `materialize` deliberately has
+        # no fallback implementation.
+        @test_throws MethodError materialize(Ref(nothing); depth=1)
+    end
+end

--- a/test/core/test_lazy_infinite.jl
+++ b/test/core/test_lazy_infinite.jl
@@ -20,8 +20,9 @@ LatticeCore.site_layout(::_InfiniteChain) = UniformLayout(IsingSite())
 
 struct _InfiniteChainAbstract end
 
-LatticeCore.materialize(::_InfiniteChainAbstract; depth::Int) =
+function LatticeCore.materialize(::_InfiniteChainAbstract; depth::Int)
     LineLattice(depth, PeriodicAxis())
+end
 
 @testset "LazyInfinite" begin
     @testset "require_finite on finite lattices is a no-op" begin


### PR DESCRIPTION
## Description

Implements the [06 lazy-infinite chapter](https://github.com/sotashimozono/work/blob/main/dev/note/04_architecture/06_lazy_infinite/README.md) at the LatticeCore level. The heavy lifting — an on-demand-expanding `InfiniteFibonacci`, a cached L-system lattice, and so on — stays **out of LatticeCore proper**; it belongs in `QuasiCrystal.jl` or a future `LSystemAdapter`. This PR lands the two small contract surfaces that the 06 chapter required.

Fixed: (no linked issue)

## Type of Change

- [x] ✨ Feature (`enhancement`)
- [ ] 🐛 Bug Fix
- [ ] ⚡ Performance
- [ ] 📖 Documentation
- [ ] 🧰 Maintenance

## Proposed Changes

**`src/LazyInfinite.jl` (new)**

1. `materialize(abstract; kwargs...)` — a generic function that any package can specialise to turn an infinite abstract lattice into a finite `AbstractLattice` at a cutoff (depth, radius, dims, ...). **Intentionally no typed supertype** so package authors do not have to subtype a LatticeCore hierarchy; they just add a method.
2. `require_finite(lat::AbstractLattice)` — an assertion guard that throws `ArgumentError` when `is_finite(lat)` is false. This is the canonical hook MC algorithms should call at the entry point of `run!` so non-finite lattices fail loudly instead of hanging.

**Tests (`test/core/test_lazy_infinite.jl`)**

- Contract checks for `require_finite` on existing finite reference lattices (`LineLattice`, `SimpleSquareLattice`, both PBC and OBC).
- A local `_InfiniteChain` mock that implements `size_trait = InfiniteSize()`; verifies `is_finite == false` and that `require_finite` throws `ArgumentError`.
- A local `_InfiniteChainAbstract` mock with a matching `materialize(::_InfiniteChainAbstract; depth)` method that returns a `LineLattice`. This is the **runnable example** of the infinite-abstract → finite-materialisation pattern from 06.
- `materialize` on an unhandled type raises `MethodError`.

## Usage or Results

```julia
using LatticeCore

# Define a custom "infinite abstract" type in your package
struct InfiniteFibonacci end

# Implement materialize to build a finite chain at the given depth
LatticeCore.materialize(::InfiniteFibonacci; depth::Int) =
    # ... your substitution logic here ...

# Guard your MC entry point with require_finite
function run!(rng, state, lat::AbstractLattice, model, alg; kwargs...)
    require_finite(lat)
    # safe to walk the full site list from here
end
```

What was already in place (from earlier PRs, used as substrate here):
- `AbstractSizeTrait` / `FiniteSize` / `InfiniteSize` / `QuasiInfiniteSize` (PR #1)
- `is_finite(lat)` (PR #1)
- `size_trait(lat)` stub on `AbstractLattice` + implementations on reference lattices (PRs #1, #3, #4)
- The lazy-friendly I/F principle (pinpoint `position(lat, i)` / `neighbors(lat, i)`, iterator-returning `positions(lat)` / `bonds(lat)` — PRs #1, #3)

Local test run: **771 / 771 pass**.

## Version: 0.6.0 → 0.7.0 (additive minor bump)

## check list
- [x] test駆動をしたか — contract check + mock infinite lattice + runnable materialize example