### PR TITLE
docs: foundation — concepts, guide, reference, and site deployment

### DIFF
--- a/.github/workflows/Documentation.yml
+++ b/.github/workflows/Documentation.yml
@@ -1,20 +1,26 @@
 name: Documentation
+
 on:
   push:
     branches:
       - main
     tags: '*'
+  pull_request:
+
 permissions:
   contents: write
   statuses: write
+  pull-requests: read
+
 jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
+      - uses: julia-actions/cache@v3
       - name: Install dependencies
         run: julia --project=docs/ -e 'using Pkg; Pkg.develop(PackageSpec(path=pwd())); Pkg.instantiate()'
       - name: Build and deploy

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 docs/build/
+docs/src/assets/favicon.ico
+docs/src/assets/logo.png
 Manifest.toml

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.7.0"
+version = "0.7.1"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -7,15 +7,21 @@ mkpath(assets_dir)
 favicon_path = joinpath(assets_dir, "favicon.ico")
 logo_path = joinpath(assets_dir, "logo.png")
 
-Downloads.download("https://github.com/sotashimozono.png", favicon_path)
-Downloads.download("https://github.com/sotashimozono.png", logo_path)
+# Best-effort favicon / logo download. Skipped gracefully if the
+# network is unavailable (e.g. local sandboxed builds).
+try
+    Downloads.download("https://github.com/sotashimozono.png", favicon_path)
+    Downloads.download("https://github.com/sotashimozono.png", logo_path)
+catch err
+    @warn "Could not download favicon/logo; continuing without them" exception = err
+end
 
 makedocs(;
-    sitename="LatticeCore.jl",
-    format=Documenter.HTML(;
-        canonical="https://codes.sota-shimozono.com/LatticeCore.jl/stable/",
-        prettyurls=get(ENV, "CI", "false") == "true",
-        mathengine=MathJax3(
+    sitename = "LatticeCore.jl",
+    format = Documenter.HTML(;
+        canonical = "https://codes.sota-shimozono.com/LatticeCore.jl/stable/",
+        prettyurls = get(ENV, "CI", "false") == "true",
+        mathengine = MathJax3(
             Dict(
                 :tex => Dict(
                     :inlineMath => [["\$", "\$"], ["\\(", "\\)"]],
@@ -24,10 +30,45 @@ makedocs(;
                 ),
             ),
         ),
-        assets=["assets/favicon.ico", "assets/custom.css"],
+        assets = ["assets/favicon.ico", "assets/custom.css"],
     ),
-    modules=[LatticeCore],
-    pages=["Home" => "index.md"],
+    modules = [LatticeCore],
+    pages = [
+        "Home" => "index.md",
+        "Getting Started" => "getting_started.md",
+        "Concepts" => [
+            "Overview" => "concepts/index.md",
+            "Lattices and unit cells" => "concepts/lattice_and_unit_cells.md",
+            "Reciprocal lattice and Brillouin zone" => "concepts/reciprocal_and_brillouin.md",
+            "Boundary conditions" => "concepts/boundary_conditions.md",
+            "Site types and spin models" => "concepts/site_types_and_spins.md",
+            "Quasiperiodic order" => "concepts/quasiperiodic_order.md",
+        ],
+        "Guide" => [
+            "Lattice interface" => "guide/lattice.md",
+            "Boundary conditions" => "guide/boundary.md",
+            "Coordinate systems" => "guide/coordinates.md",
+            "Site types and layouts" => "guide/site_type.md",
+            "Momentum space" => "guide/momentum.md",
+            "Lazy / infinite lattices" => "guide/lazy_infinite.md",
+        ],
+        "API Reference" => [
+            "Lattice" => "reference/lattice.md",
+            "Bond" => "reference/bond.md",
+            "Traits" => "reference/traits.md",
+            "Boundary" => "reference/boundary.md",
+            "Coordinates" => "reference/coordinates.md",
+            "Indexing" => "reference/indexing.md",
+            "Site type" => "reference/site_type.md",
+            "Site layout" => "reference/site_layout.md",
+            "Lattice element" => "reference/lattice_element.md",
+            "Momentum space" => "reference/momentum.md",
+            "Lazy / infinite" => "reference/lazy_infinite.md",
+            "Reference lattices" => "reference/reference_lattices.md",
+        ],
+        "Design notes" => "design.md",
+    ],
+    checkdocs = :none,
 )
 
-deploydocs(; repo="github.com/sotashimozono/LatticeCore.jl.git", devbranch="main")
+deploydocs(; repo = "github.com/sotashimozono/LatticeCore.jl.git", devbranch = "main")

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -17,11 +17,11 @@ catch err
 end
 
 makedocs(;
-    sitename = "LatticeCore.jl",
-    format = Documenter.HTML(;
-        canonical = "https://codes.sota-shimozono.com/LatticeCore.jl/stable/",
-        prettyurls = get(ENV, "CI", "false") == "true",
-        mathengine = MathJax3(
+    sitename="LatticeCore.jl",
+    format=Documenter.HTML(;
+        canonical="https://codes.sota-shimozono.com/LatticeCore.jl/stable/",
+        prettyurls=get(ENV, "CI", "false") == "true",
+        mathengine=MathJax3(
             Dict(
                 :tex => Dict(
                     :inlineMath => [["\$", "\$"], ["\\(", "\\)"]],
@@ -30,10 +30,10 @@ makedocs(;
                 ),
             ),
         ),
-        assets = ["assets/favicon.ico", "assets/custom.css"],
+        assets=["assets/favicon.ico", "assets/custom.css"],
     ),
-    modules = [LatticeCore],
-    pages = [
+    modules=[LatticeCore],
+    pages=[
         "Home" => "index.md",
         "Getting Started" => "getting_started.md",
         "Concepts" => [
@@ -68,7 +68,7 @@ makedocs(;
         ],
         "Design notes" => "design.md",
     ],
-    checkdocs = :none,
+    checkdocs=:none,
 )
 
-deploydocs(; repo = "github.com/sotashimozono/LatticeCore.jl.git", devbranch = "main")
+deploydocs(; repo="github.com/sotashimozono/LatticeCore.jl.git", devbranch="main")

--- a/docs/src/concepts/boundary_conditions.md
+++ b/docs/src/concepts/boundary_conditions.md
@@ -1,0 +1,46 @@
+# Boundary conditions
+
+This column is still being written. In the meantime, the physics
+that drives LatticeCore's per-axis [`LatticeBoundary`](@ref)
+abstraction:
+
+- **Periodic (PBC)**: the lattice is wrapped onto a torus. It is
+  the gentlest finite-size approximation — every site looks like a
+  bulk site — and it lets the reciprocal lattice remain discrete.
+- **Open (OBC)**: the sample has real surfaces. Edge / corner sites
+  have fewer neighbours, and the discrete reciprocal lattice no
+  longer strictly applies.
+- **Cylinder / strip**: a mix of PBC and OBC along different axes.
+  Ubiquitous in DMRG and tensor-network simulations because it
+  tames edge effects while keeping a manageable transverse size.
+- **Twisted PBC**: periodic with a phase factor
+  ``e^{i\theta}`` attached to bonds that cross the boundary. This
+  is how a lattice model sees a magnetic flux, a twist angle, or a
+  supercurrent. The topology is unchanged; only the phase
+  accumulates.
+- **Sine-square deformation (SSD)**: a non-topological *modifier*
+  that multiplies bond energies by a smooth envelope
+  ``\sin^2(\pi x / L)``. SSD is topologically open but reproduces
+  periodic-like ground states surprisingly well, which is useful
+  when you want PBC physics without the PBC integration pain.
+
+## Why per-axis?
+
+Classical physics codes usually hardcode "PBC" or "OBC" as a global
+flag. That is wrong as soon as you want a cylinder — the axis
+choices stop being symmetric. LatticeCore follows the convention
+used by DMRG / tensor-network libraries and stores **one
+[`AbstractAxisBC`](@ref) per axis**, plus one
+[`AbstractBoundaryModifier`](@ref), in a composite
+[`LatticeBoundary`](@ref). Adding a new BC kind means adding a new
+`AbstractAxisBC` subtype and a method for
+[`apply_axis_bc`](@ref); no core code changes.
+
+## TODO
+
+- Diagram: PBC torus, OBC square, cylinder, Möbius.
+- Worked example: dispersion of a 1D tight-binding chain under
+  `PeriodicAxis`, `OpenAxis`, and `TwistedAxis`.
+- Finite-size scaling and the role of BC in extracting
+  bulk-limit quantities.
+- Where SSD fits in the modifier slot of [`LatticeBoundary`](@ref).

--- a/docs/src/concepts/index.md
+++ b/docs/src/concepts/index.md
@@ -1,0 +1,44 @@
+# Concepts
+
+This section is a set of **columns**: short, self-contained reads
+that introduce the concepts behind LatticeCore's design. They are
+written for someone approaching lattice simulation for the first
+time — or from the software-engineering side — and want to understand
+*why* the API is shaped the way it is, not just how to call it.
+
+The goal is not to re-derive condensed-matter physics; it is to make
+the vocabulary LatticeCore borrows from physics legible, and to show
+where each concept surfaces in the code.
+
+## Where to read first
+
+If you are new to lattices and are here to simulate something, read
+in order:
+
+1. [Lattices and unit cells](lattice_and_unit_cells.md) — what a
+   Bravais lattice is, how unit cells and sublattices work, and why
+   LatticeCore treats the *geometric sublattice* and the *physical
+   site type* as independent axes.
+2. [Reciprocal lattice and Brillouin zone](reciprocal_and_brillouin.md)
+   — the dual picture in momentum space. This is the mathematical
+   home of `reciprocal_lattice`, Monkhorst–Pack meshes, and the
+   structure factor.
+3. [Boundary conditions](boundary_conditions.md) — periodic vs open,
+   cylinders, and twisted boundaries, and how each changes the
+   physics of finite-size simulations.
+4. [Site types and spin models](site_types_and_spins.md) — Ising,
+   Potts, XY, Heisenberg; what the distinction *means* physically
+   and how LatticeCore represents it.
+5. [Quasiperiodic order](quasiperiodic_order.md) — cut-and-project
+   quasicrystals, Fourier modules, and why the reciprocal lattice
+   becomes dense.
+
+## Relation to the rest of the docs
+
+| Concept column            | API guide                             | Reference                             |
+| ------------------------- | ------------------------------------- | ------------------------------------- |
+| Lattices and unit cells   | [Lattice interface](../guide/lattice.md)     | [`AbstractLattice`](@ref)            |
+| Reciprocal / Brillouin    | [Momentum space](../guide/momentum.md)       | [`reciprocal_lattice`](@ref)         |
+| Boundary conditions       | [Boundary conditions](../guide/boundary.md)  | [`LatticeBoundary`](@ref)            |
+| Site types and spins      | [Site types](../guide/site_type.md)          | [`AbstractSiteType`](@ref)           |
+| Quasiperiodic order       | [Lazy / infinite](../guide/lazy_infinite.md) | [`HyperReciprocalLattice`](@ref)     |

--- a/docs/src/concepts/lattice_and_unit_cells.md
+++ b/docs/src/concepts/lattice_and_unit_cells.md
@@ -1,0 +1,145 @@
+# Lattices and unit cells
+
+A **lattice** is the skeleton physicists use to describe a crystal:
+an infinite, regular pattern of points in space obtained by
+repeatedly translating a finite motif. Everything LatticeCore does —
+storing positions, walking neighbours, computing structure factors —
+is organised around this picture, so it is worth spending a few
+minutes making the vocabulary precise.
+
+## Bravais lattices
+
+A **Bravais lattice** in ``d`` dimensions is the set of points
+
+```math
+\mathbf{R} = n_1 \mathbf{a}_1 + n_2 \mathbf{a}_2 + \dots + n_d \mathbf{a}_d,
+\qquad n_i \in \mathbb{Z},
+```
+
+where the **primitive vectors** ``\mathbf{a}_1, \dots, \mathbf{a}_d``
+are linearly independent and fixed. The matrix whose columns are the
+``\mathbf{a}_i`` is the **real-space basis** ``A``. In LatticeCore a
+concrete lattice exposes it via `basis_vectors(lat)`.
+
+Two Bravais lattices are the same if and only if they share a basis
+up to an integer (unimodular) linear transformation. That means the
+basis is never unique — the honest square lattice
+
+```math
+\mathbf{a}_1 = (1, 0), \quad \mathbf{a}_2 = (0, 1)
+```
+
+is the same Bravais lattice as the skewed choice
+
+```math
+\mathbf{a}_1' = (1, 0), \quad \mathbf{a}_2' = (1, 1),
+```
+
+and the code treats both as equivalent inputs. What *is* canonical
+is the set of lattice points ``\{\mathbf{R}\}`` and everything that
+can be computed from it: neighbour distances, reciprocal basis
+(see [Reciprocal lattice and Brillouin zone](reciprocal_and_brillouin.md)),
+density.
+
+Two-dimensional Bravais lattices come in exactly five types
+(oblique, rectangular, centred rectangular, hexagonal, square),
+three-dimensional ones in fourteen. LatticeCore's reference
+implementations ([`SimpleSquareLattice`](@ref),
+[`LineLattice`](@ref)) are the square and 1D cases with unit
+spacing, which is enough to exercise every piece of the interface.
+
+## Unit cells and sublattices
+
+A crystal is usually not *just* a Bravais lattice. Each lattice
+point carries a **basis** — a finite cluster of atoms, or (for us) a
+finite cluster of sites. Copies of that cluster sit at every lattice
+point, and together they make the full crystal:
+
+```math
+\mathrm{Crystal} = \mathrm{Bravais\ lattice} + \mathrm{motif}.
+```
+
+The cluster is called the **unit cell**, and each member of the
+cluster is a **sublattice**. A honeycomb lattice is a triangular
+Bravais lattice with a two-site motif — one A site, one B site — and
+that is exactly why the A and B sublattices never coincide.
+
+LatticeCore records sublattice membership inside the
+[`LatticeCoord`](@ref) type:
+
+```julia
+struct LatticeCoord{D}
+    cell::NTuple{D, Int}   # which Bravais cell
+    sublattice::Int        # which site inside the cell
+end
+```
+
+A coordinate like `LatticeCoord((3, 2), 1)` means "the A site of the
+(3, 2) cell". This lets the same cell index talk to multiple
+sublattices without any tuple juggling.
+
+### Sublattice vs site type
+
+There are *two* useful ways to label a site, and they are
+genuinely different:
+
+- **Geometric sublattice** — *where* in the unit cell the site sits
+  (A, B, C, ...). This is pure geometry and it is what
+  `LatticeCoord.sublattice` stores.
+- **Site type** — *what* physical degree of freedom lives on the
+  site (Ising spin, XY rotor, Heisenberg vector, vacancy, gauge
+  link, ...). This is captured by [`AbstractSiteType`](@ref) and
+  [`AbstractSiteLayout`](@ref).
+
+Conflating the two is the single most common modelling bug in a
+mixed-spin simulation. LatticeCore keeps them on separate axes
+deliberately: a honeycomb lattice can have an Ising site on the A
+sublattice and an XY site on the B sublattice, and the code never
+has to decide which field to ask. See
+[Site types and spin models](site_types_and_spins.md) for the site
+type side.
+
+## Periodicity, bipartiteness, and coordination number
+
+Three numbers describe a Bravais-like lattice at a glance:
+
+- The **coordination number** ``z`` — how many nearest neighbours a
+  site has. It is a topology invariant (square lattice: 4,
+  triangular: 6, honeycomb: 3, kagome: 4), visible in LatticeCore
+  through `length(neighbors(lat, i))` for an interior site.
+- The **bipartiteness** of the neighbour graph. A lattice is
+  bipartite if the sites can be two-coloured so that every bond
+  connects different colours. Square and honeycomb are bipartite;
+  triangular is not. Bipartiteness controls whether a Neel
+  antiferromagnetic ground state even *exists* and is exposed as
+  [`is_bipartite`](@ref).
+- The **periodicity** of the underlying crystal. A Bravais crystal
+  is periodic by construction; a Penrose tiling is *aperiodic* even
+  though it is highly ordered. LatticeCore captures this with the
+  [`Periodic`](@ref) / [`Aperiodic`](@ref) trait attached to every
+  lattice.
+
+## Why this matters for the API
+
+Once these concepts are named, the LatticeCore interface almost
+writes itself:
+
+- `position(lat, i)` returns a real-space point — a sum of
+  primitive vectors plus a sublattice offset. It is the one function
+  that carries the full geometric information of the lattice.
+- `neighbors(lat, i)` encodes the topology — which *other* sites
+  are connected by a bond, independent of positions.
+- `boundary(lat)` decides what happens at the edges of a **finite
+  piece** of the otherwise infinite Bravais lattice. That is the
+  subject of [Boundary conditions](boundary_conditions.md).
+
+The rest of the package (site types, reciprocal lattice, structure
+factor, lazy materialisation) is built out of these three calls.
+
+## Further reading
+
+- N. W. Ashcroft and N. D. Mermin, *Solid State Physics*, Ch. 4–5
+  (Bravais lattices and reciprocal lattices).
+- C. Kittel, *Introduction to Solid State Physics*, Ch. 1–2.
+- S. Sachdev, *Quantum Phase Transitions*, Ch. 1 (for the role of
+  lattice geometry in ordering transitions).

--- a/docs/src/concepts/quasiperiodic_order.md
+++ b/docs/src/concepts/quasiperiodic_order.md
@@ -1,0 +1,80 @@
+# Quasiperiodic order
+
+This column is still being written. The short version:
+
+## Aperiodic but ordered
+
+Most of condensed matter physics takes periodicity for granted:
+a Bravais lattice, translated forever. But there is a family of
+structures — Penrose tilings, Ammann–Beenker tilings, Fibonacci
+chains, icosahedral quasicrystals — that are *not* periodic in the
+usual sense yet are still highly ordered. They have long-range
+bond orientational order, crystallographically-forbidden point
+symmetries (5-fold for Penrose, 8-fold for Ammann–Beenker, 10-fold
+for decagonal quasicrystals), and sharp Bragg peaks in their
+diffraction patterns.
+
+## Cut and project
+
+The cleanest way to generate these structures is **cut-and-project**:
+
+1. Start with a periodic lattice in a higher dimension
+   ``\mathbb{Z}^{D_{\text{hyper}}}``. For Penrose, ``D_{\text{hyper}} = 5``;
+   for Ammann–Beenker, ``4``; for the Fibonacci chain, ``2``.
+2. Choose a **physical** subspace of dimension ``D_{\text{phys}}``
+   (the plane or line you actually want to look at) and a
+   **perpendicular** subspace of dimension
+   ``D_{\text{hyper}} - D_{\text{phys}}`` (the "internal" space).
+3. Pick an **acceptance window** in the perpendicular space: a
+   bounded shape that acts as a stencil.
+4. A higher-dimensional lattice point lands in the physical
+   structure *if and only if* its perpendicular projection sits
+   inside the acceptance window.
+
+The resulting set of physical-space points is the quasicrystal. It
+inherits the higher-dimensional translation symmetry but projects
+it irrationally, which is why the structure is dense in Fourier
+space yet discrete in physical space.
+
+LatticeCore captures the scaffolding with the types
+[`AcceptanceWindow`](@ref), [`HyperReciprocalLattice`](@ref), and
+[`BraggPeakSet`](@ref); the concrete algorithms that build them
+live in `QuasiCrystal.jl`.
+
+## Fourier module and Bragg peaks
+
+Because a quasicrystal inherits its translation symmetry from a
+higher-dimensional periodic lattice, its Fourier transform is a
+*finite set of Bragg peaks projected through the same matrix*
+``\pi_{\parallel}``. Unlike a Bravais reciprocal lattice, the set
+of peak locations is **dense** in physical reciprocal space — but
+only finitely many peaks are bright, and their intensities are
+given by the Fourier transform of the acceptance window evaluated
+in the perpendicular space.
+
+A [`BraggPeakSet`](@ref) is what you get after fixing a cutoff:
+the finite list of peaks whose intensities exceed some threshold,
+stored together with their original higher-dimensional indices so
+you can walk back to the hyper lattice.
+
+Crucially, [`BraggPeakSet`](@ref) subtypes
+[`AbstractMomentumLattice`](@ref), so the *same*
+[`structure_factor`](@ref) code paths that work on a
+[`PeriodicMomentumLattice`](@ref) work on a quasicrystal.
+
+## TODO
+
+- Worked example: Fibonacci chain at `depth = 8`, a picture of its
+  acceptance window, and the first handful of Bragg peaks.
+- Diagram of cut-and-project in 2D projecting down to 1D.
+- The role of golden ratio φ in the Fibonacci case and how it shows
+  up as the eigenvalue of the substitution matrix.
+- When *pseudo-Brillouin zones* are a useful concept for
+  quasicrystals and when they break down.
+
+## Further reading
+
+- M. Senechal, *Quasicrystals and Geometry* (Cambridge, 1995).
+- M. Baake and U. Grimm, *Aperiodic Order*, Vol. 1 (Cambridge, 2013).
+- Z. M. Stadnik (ed.), *Physical Properties of Quasicrystals*
+  (Springer, 1999).

--- a/docs/src/concepts/reciprocal_and_brillouin.md
+++ b/docs/src/concepts/reciprocal_and_brillouin.md
@@ -1,0 +1,150 @@
+# Reciprocal lattice and Brillouin zone
+
+The real-space picture — points, bonds, sublattices — is half the
+story. The other half lives in **momentum space**: the reciprocal
+lattice, the Brillouin zone, and the structure factor.
+Everything LatticeCore exposes under `reciprocal_lattice`,
+`monkhorst_pack`, `BraggPeakSet`, and `structure_factor` ultimately
+comes from the content of this column.
+
+## The reciprocal lattice
+
+Given a Bravais lattice with real-space basis
+``\mathbf{a}_1, \dots, \mathbf{a}_d``, the **reciprocal basis**
+``\mathbf{b}_1, \dots, \mathbf{b}_d`` is defined by the orthogonality
+relation
+
+```math
+\mathbf{a}_i \cdot \mathbf{b}_j = 2\pi \, \delta_{ij}.
+```
+
+Writing ``A`` for the real-space basis matrix and ``B`` for the
+reciprocal one,
+
+```math
+B = 2\pi \, (A^{-\top}).
+```
+
+The **reciprocal lattice** is then the set
+
+```math
+\mathbf{G} = m_1 \mathbf{b}_1 + \dots + m_d \mathbf{b}_d,
+\qquad m_i \in \mathbb{Z}.
+```
+
+Reciprocal lattice vectors are distinguished by a single property:
+for every real-space lattice point ``\mathbf{R}``,
+
+```math
+e^{-i \mathbf{G} \cdot \mathbf{R}} = 1.
+```
+
+In other words, ``\mathbf{G}`` and ``\mathbf{G} + \mathbf{b}_i``
+produce *identical* plane waves sampled at the crystal points. Up to
+reciprocal lattice translations, only ``\mathbf{k}`` values in a
+single primitive cell of reciprocal space are physically distinct.
+That primitive cell is the **Brillouin zone**.
+
+In LatticeCore, `reciprocal_basis(ml)` returns the ``B`` matrix for
+a [`PeriodicMomentumLattice`](@ref), and the orthogonality relation
+is one of the package's unit tests: `a_i · b_j ≈ 2π δ_ij` is
+checked directly against the reference square lattice.
+
+## The Brillouin zone
+
+The first Brillouin zone is the Wigner–Seitz cell of the reciprocal
+lattice: the set of k-points that are closer to the origin ``\Gamma``
+than to any other reciprocal lattice vector. For the square lattice
+it is the square ``(-\pi, \pi] \times (-\pi, \pi]``; for the
+triangular lattice it is a hexagon; for the honeycomb, a hexagon
+rotated by 30°.
+
+The Brillouin zone matters because **every physical quantity that
+depends on momentum is periodic in reciprocal space**. Band
+structures, structure factors, form factors — they all repeat with
+period ``\mathbf{G}``, so all the independent information fits
+inside a single BZ.
+
+LatticeCore's reference implementations do not enumerate
+Wigner–Seitz cells (that is topology-specific work for
+`Lattice2D.jl`). What they *do* provide is a uniform sampler of the
+BZ interior — the [`monkhorst_pack`](@ref) mesh.
+
+## Sampling: Monkhorst–Pack and Γ-centred grids
+
+Monte Carlo simulations on a **finite** ``L_1 \times L_2 \times
+\dots \times L_d`` lattice can only resolve a finite set of k-points,
+namely those compatible with the sample's periodicity:
+
+```math
+\mathbf{k} \in \left\{ \frac{n_i}{L_i} \mathbf{b}_i \right\}_{n_i = 0}^{L_i - 1}.
+```
+
+LatticeCore ships two equivalent ways to enumerate these points:
+
+- [`gamma_centered(basis, mesh)`](@ref gamma_centered) uses
+  ``n_i / L_i``, including the ``\Gamma`` point exactly.
+- [`monkhorst_pack(basis, mesh)`](@ref monkhorst_pack) uses
+  ``(n_i + 1/2)/L_i - 1/2``, which centres the mesh on ``\Gamma``
+  but avoids it. This is the convention solid-state codes use for
+  integrating smooth functions over the BZ.
+
+Both return the same number of k-points, ``\prod_i L_i``, matching
+the number of sites in the corresponding real-space sample.
+
+## The structure factor
+
+Given a scalar field ``s_i`` defined on the lattice points, the
+**structure factor** is the modulus squared of its spatial Fourier
+transform:
+
+```math
+S(\mathbf{k}) \;=\; \frac{1}{N}\,
+    \left| \sum_{i = 1}^{N} s_i \, e^{-i \mathbf{k} \cdot \mathbf{r}_i} \right|^{2}.
+```
+
+It tells you, at a single configuration, how much Fourier weight
+sits at each momentum. Three sanity checks encode the physics:
+
+- **Ferromagnet**, ``s_i \equiv 1``. The sum is simply ``N``, so
+  ``S(0) = N``, and — crucially — ``S(\mathbf{G}) = N`` for *every*
+  reciprocal lattice vector, because every such ``\mathbf{G}`` is
+  equivalent to ``\Gamma``. Away from ``\mathbf{G}`` the sum over
+  sites vanishes by destructive interference. This is verified in
+  LatticeCore's test suite.
+- **Néel antiferromagnet** on a bipartite lattice,
+  ``s_i = (-1)^{\mathbf{x} + \mathbf{y}}`` on a square. The sum
+  peaks at ``\mathbf{k} = (\pi, \pi)``, giving ``S(\pi, \pi) = N``
+  and ``S(0) = 0``. Bipartiteness is exactly the condition that
+  this momentum lies on the reciprocal lattice.
+- **Disorder** gives ``S(\mathbf{k}) \approx 1`` on average — a
+  useful null baseline when looking for order.
+
+Those checks are what LatticeCore's `test_structure_factor.jl`
+actually runs against [`structure_factor`](@ref).
+
+## Implementation notes
+
+LatticeCore uses the **naive O(N) per k-point** formula above
+because it is transparent, correct on any lattice — including
+quasicrystals, which have no FFT-friendly mesh — and fast enough for
+the reference implementations. Production-grade codes on regular
+meshes can specialise `structure_factor` for FFT-based evaluation
+without changing the API.
+
+For quasicrystals, ``\mathbf{k}`` is no longer drawn from a discrete
+reciprocal lattice but from a **dense Fourier module** projected
+from a higher-dimensional periodic lattice. LatticeCore ships the
+type skeletons [`HyperReciprocalLattice`](@ref) and
+[`BraggPeakSet`](@ref); the enumeration algorithm itself lives in
+`QuasiCrystal.jl`. See
+[Quasiperiodic order](quasiperiodic_order.md) for the column on this.
+
+## Further reading
+
+- Ashcroft–Mermin, Ch. 5 and Ch. 6 (reciprocal lattice and
+  Bragg diffraction).
+- Monkhorst & Pack, *Phys. Rev. B* **13** 5188 (1976) — the original
+  paper on special k-points.
+- L. Landau and E. Lifshitz, *Statistical Physics Part 1*, § 116
+  (fluctuation–response and the structure factor).

--- a/docs/src/concepts/site_types_and_spins.md
+++ b/docs/src/concepts/site_types_and_spins.md
@@ -1,0 +1,58 @@
+# Site types and spin models
+
+This column is still being written. The short version:
+
+## What is a site type?
+
+A **site type** tells LatticeCore what mathematical object lives on
+a single lattice site and how to sample it uniformly at random.
+Concretely, [`AbstractSiteType`](@ref) requires
+
+- [`state_type`](@ref) — the Julia type that stores one state
+- [`random_state`](@ref) — a uniform sampler
+
+and optionally
+
+- [`zero_state`](@ref), [`domain`](@ref), and
+  [`element_type`](@ref) for lifting the DOF onto bonds / plaquettes
+  / cells.
+
+## The classical spin ladder
+
+The archetypal site types form a ladder of increasing continuous
+symmetry:
+
+| Site type                | State space                | Symmetry group | Models            |
+| ------------------------ | -------------------------- | -------------- | ----------------- |
+| [`IsingSite`](@ref)      | ``\{-1, +1\}``             | ``\mathbb{Z}_2`` | Ising, RBIM     |
+| [`PottsSite{Q}`](@ref)   | ``\{1, \dots, Q\}``        | ``S_Q``         | Potts, clock     |
+| [`XYSite`](@ref)         | circle ``S^1``             | ``U(1) = SO(2)``  | XY, Villain   |
+| [`HeisenbergSite`](@ref) | sphere ``S^2 \subset \mathbb{R}^3`` | ``SO(3)`` | Heisenberg |
+| [`EmptySite`](@ref)      | singleton                  | trivial         | vacancies       |
+
+The pattern is standard condensed-matter: as you move down the
+table, the Mermin–Wagner theorem kicks in (no long-range order in
+2D for ``d \geq 2`` continuous groups at finite ``T``), the energy
+landscape becomes smoother, and the numerically appropriate Monte
+Carlo update changes (single-flip → cluster → overrelaxation,
+cluster → worm).
+
+## Why this lives in LatticeCore
+
+A Monte Carlo runtime like `Lattice2DMonteCarlo.jl` needs to
+dispatch its local Hamiltonian on the site types at either end of a
+bond. Making `AbstractSiteType` part of LatticeCore — rather than
+the MC layer — means that *every* concrete lattice in the stack can
+describe what it carries, regardless of which MC runtime later
+consumes it.
+
+## TODO
+
+- Worked example: how the Hamiltonian dispatch actually works when
+  A and B sublattices carry different site types (`SublatticeLayout`).
+- Heisenberg uniform sphere sampler (Marsaglia / Archimedes) and
+  why `HeisenbergSite` uses `SVector{3, Float64}`.
+- Mermin–Wagner in one paragraph and how it motivates the
+  Ising → Potts → XY → Heisenberg escalation.
+- How to build a custom site type for a bond-centered DOF
+  (dimer model, gauge link) via [`element_type`](@ref).

--- a/docs/src/design.md
+++ b/docs/src/design.md
@@ -1,0 +1,72 @@
+# Design notes
+
+This page summarises the architectural decisions that shape
+LatticeCore. The long-form notes — chapter-by-chapter rationale,
+alternatives considered, cross-references between chapters — live
+outside the package in the parent workspace's
+`dev/note/04_architecture/` tree.
+
+## Five orthogonal axes
+
+LatticeCore models every lattice along five independent axes. The
+cross-references point to the chapter of `dev/note/04_architecture/`
+where each axis is designed.
+
+| Axis                    | Lives in                                                    | Chapter |
+| ----------------------- | ----------------------------------------------------------- | ------- |
+| Topology / graph        | `Traits.jl` + concrete lattice's `neighbors`                | 02      |
+| Boundary condition      | [`LatticeBoundary`](@ref), [`AbstractAxisBC`](@ref)         | 03      |
+| Coordinate system       | [`AbstractCoordinate`](@ref) + [`AbstractIndexing`](@ref)   | 03      |
+| Geometric sublattice    | `LatticeCoord.sublattice` + `sublattice(lat, i)`            | 04      |
+| Physical site type      | [`AbstractSiteType`](@ref) + [`AbstractSiteLayout`](@ref)   | 04      |
+
+Momentum space (chapter 05) and the size trait hierarchy /
+materialisation pattern (chapter 06) sit on top of these five axes
+and reuse the same interface machinery.
+
+## Key rules
+
+1. **Two type parameters only.** `AbstractLattice{D, T}`. The rest
+   is field storage and dispatch, so the type system stays small.
+2. **No `isa` branching in hot paths.** Every variant point goes
+   through multiple dispatch or a Holy trait. This keeps extensions
+   additive: a new axis BC is a new subtype plus a new method, not
+   an edit to an `if` chain.
+3. **Sublattice and site type are different concepts.** The
+   geometric sublattice is where a site sits inside the unit cell;
+   the site type is what lives on it. See
+   [Lattices and unit cells](concepts/lattice_and_unit_cells.md).
+4. **Per-axis boundary conditions.** Cylinders (PBC × OBC) and
+   twisted periodic lattices drop out of the same type system as
+   uniform PBC.
+5. **Infinite structures are expressed abstractly and materialised
+   at a cutoff.** The same pattern applies in real space
+   ([`materialize`](@ref)) and in reciprocal space
+   ([`BraggPeakSet`](@ref) as a finite snapshot of
+   [`HyperReciprocalLattice`](@ref)).
+6. **Lazy-friendly interface.** `position(lat, i)` and
+   `neighbors(lat, i)` are pinpoint; `positions(lat)` and
+   `bonds(lat)` are iterators. No method requires enumerating
+   every site up front.
+7. **Breaking changes are cheap in 0.x.** The whole stack is
+   pre-1.0; the `VersionCheck` workflow enforces a version bump on
+   every PR, and tags track every merged change.
+
+## Where the notes live
+
+The authoritative design chapters are under `dev/note/04_architecture/`
+in the parent workspace:
+
+- `01_package_layout/` — why LatticeCore is a separate repo
+- `02_lattice_interface/` — the `AbstractLattice` contract
+- `03_boundary_and_coordinates/` — per-axis BC and coordinate system
+- `04_site_type/` — site types, layouts, and element centering
+- `05_momentum_space/` — reciprocal lattices, Bragg peaks, structure
+  factor
+- `06_lazy_infinite/` — size traits and materialisation
+- `07_mc_layer/` — Monte Carlo consumer layer (lives in
+  `Lattice2DMonteCarlo.jl`)
+
+They are checked into the parent workspace rather than into
+LatticeCore itself so that cross-package architectural changes can
+be discussed in one place.

--- a/docs/src/getting_started.md
+++ b/docs/src/getting_started.md
@@ -1,0 +1,107 @@
+# Getting Started
+
+## Installation
+
+LatticeCore is not yet registered in the Julia General registry.
+Install it directly from GitHub:
+
+```julia
+using Pkg
+Pkg.add(url = "https://github.com/sotashimozono/LatticeCore.jl.git")
+```
+
+## A minimal example
+
+Every downstream package — periodic lattices, quasicrystals, the
+Monte Carlo runtime — builds on top of `AbstractLattice`. LatticeCore
+itself ships two concrete reference implementations so you can
+exercise the full stack without any other dependency.
+
+```julia
+using LatticeCore
+using StaticArrays
+
+# 1D periodic chain of 8 sites with default Ising site type
+chain = LineLattice(8, PeriodicAxis())
+
+num_sites(chain)            # 8
+position(chain, 1)          # SVector(1.0)
+neighbors(chain, 1)         # [8, 2]       (wraps to the far end)
+site_type(chain, 1)         # IsingSite{Int8}()
+
+# 4x4 periodic square lattice
+sq = SimpleSquareLattice(4, 4, PeriodicAxis())
+
+num_sites(sq)               # 16
+position(sq, 5)             # SVector(1.0, 2.0)
+neighbors(sq, 5)             # [6, 4, 9, 1]
+is_bipartite(sq)            # true (both axis lengths are even)
+
+# Cylinder: periodic in x, open in y
+cyl = SimpleSquareLattice(4, 4,
+    LatticeBoundary((PeriodicAxis(), OpenAxis())))
+periodicity(cyl)            # Aperiodic()  (one axis is open)
+
+# Reciprocal lattice and a naive structure factor
+ml = reciprocal_lattice(sq)
+state = Int8[1 for _ in 1:num_sites(sq)]           # ferromagnet
+structure_factor(sq, state, SVector(0.0, 0.0))     # ≈ 16.0
+```
+
+## The concepts
+
+A lattice in LatticeCore is described along five independent axes:
+
+1. **Topology** — which candidate bonds exist between sites.
+   Captured by the topology trait and the lattice's native
+   neighbour function.
+2. **Boundary** — how those candidate bonds wrap (or don't) at the
+   edges of the lattice. Expressed as a
+   [`LatticeBoundary`](@ref) composed of per-axis
+   [`AbstractAxisBC`](@ref) and an optional
+   [`AbstractBoundaryModifier`](@ref).
+3. **Coordinate system** — how a physical position is identified:
+   as a [`RealSpace`](@ref) point, a [`LatticeCoord`](@ref) (cell
+   index + geometric sublattice), or a [`HigherDimCoord`](@ref) for
+   cut-and-project quasicrystals.
+4. **Geometric sublattice** — the A/B/C role of a site within its
+   unit cell. Lives in `LatticeCoord.sublattice`.
+5. **Site type** — the physical degree of freedom on the site
+   ([`IsingSite`](@ref), [`XYSite`](@ref), [`HeisenbergSite`](@ref),
+   ...), stored via an [`AbstractSiteLayout`](@ref)
+   ([`UniformLayout`](@ref), [`SublatticeLayout`](@ref),
+   [`ExplicitLayout`](@ref)).
+
+These are deliberately **orthogonal**: you can put any site type on
+any layout on any boundary on any topology, and they compose via
+multiple dispatch without changing core types.
+
+## Guarding Monte Carlo entry points
+
+Monte Carlo algorithms can only run on finite lattices. Guard the
+entry point of your `run!` function with [`require_finite`](@ref):
+
+```julia
+function run!(rng, state, lat::AbstractLattice, model, alg; kwargs...)
+    require_finite(lat)
+    # ... safe to iterate 1:num_sites(lat) from here ...
+end
+```
+
+For a conceptually-infinite structure, lower it to a finite lattice
+first with [`materialize`](@ref):
+
+```julia
+abstract_fibonacci = InfiniteFibonacci(...)          # downstream package
+lat = materialize(abstract_fibonacci; depth = 12)    # FiniteSize
+run!(rng, state, lat, model, alg)
+```
+
+## Where to go next
+
+- [AbstractLattice interface](guide/lattice.md)
+- [Boundary conditions](guide/boundary.md)
+- [Coordinate systems](guide/coordinates.md)
+- [Site types and layouts](guide/site_type.md)
+- [Momentum space](guide/momentum.md)
+- [Lazy / infinite lattices](guide/lazy_infinite.md)

--- a/docs/src/guide/boundary.md
+++ b/docs/src/guide/boundary.md
@@ -1,0 +1,45 @@
+# Boundary conditions
+
+This guide is a work in progress. For now, see the concept column
+[Boundary conditions](../concepts/boundary_conditions.md) for the
+physics, and the [boundary API reference](../reference/boundary.md)
+for the exact signatures.
+
+## The picture
+
+A boundary condition in LatticeCore is a composite object:
+
+```julia
+LatticeBoundary(
+    axes     = (PeriodicAxis(), OpenAxis()),   # one AbstractAxisBC per axis
+    modifier = NoModifier(),                   # non-topological reweighting
+)
+```
+
+The **axes** decide which candidate bonds exist — they wrap, clamp,
+or attach a phase to a bond that would otherwise leave the sample.
+The **modifier** decides how existing bonds are weighted (e.g.
+sine-square deformation). Splitting the two concerns this way means
+a cylinder and an SSD modification can be composed without any core
+code change.
+
+## What LatticeCore ships today
+
+- Axis BCs: [`PeriodicAxis`](@ref), [`OpenAxis`](@ref),
+  [`TwistedAxis`](@ref).
+- Modifiers: [`NoModifier`](@ref), [`SSD`](@ref) (type only; the
+  weighting rule will land with the MC layer).
+- Hooks: [`apply_axis_bc`](@ref), [`axis_phase`](@ref),
+  [`bond_weight`](@ref).
+
+## TODO
+
+- Worked cylinder example on a 3×4 square lattice, with a picture of
+  the neighbour graph.
+- How reference lattices use `apply_axis_bc` inside `neighbors`.
+- Adding a new axis BC subtype from scratch.
+
+## See also
+
+- [Concepts: Boundary conditions](../concepts/boundary_conditions.md)
+- [Reference: Boundary](../reference/boundary.md)

--- a/docs/src/guide/coordinates.md
+++ b/docs/src/guide/coordinates.md
@@ -1,0 +1,50 @@
+# Coordinate systems and indexing
+
+This guide is a work in progress. See the
+[coordinate API reference](../reference/coordinates.md) and the
+[indexing reference](../reference/indexing.md) for the exact
+signatures.
+
+## Three coordinate kinds
+
+LatticeCore distinguishes three ways of naming a lattice point:
+
+- [`RealSpace{D, T}`](@ref) — Cartesian coordinates, stored as an
+  `SVector{D, T}`.
+- [`LatticeCoord{D}`](@ref) — an integer cell index plus a 1-based
+  geometric sublattice id.
+- [`HigherDimCoord{DPhys, DHyper, T}`](@ref) — a point in the host
+  lattice of a cut-and-project quasicrystal.
+
+They talk to each other through [`to_real`](@ref),
+[`to_lattice`](@ref), and [`to_hyper`](@ref), all of which dispatch
+on the concrete lattice so that the conversion uses the lattice's
+basis and (if applicable) projection.
+
+## Indexing is orthogonal to coordinates
+
+Once you have a [`LatticeCoord`](@ref), you still need a rule for
+turning it into a 1-based site index — that is the job of the
+[`AbstractIndexing`](@ref) hierarchy. LatticeCore ships
+[`RowMajor`](@ref), [`ColMajor`](@ref), and [`Snake`](@ref) with
+exhaustive round-trip tests.
+
+Indexing is deliberately **decoupled** from coordinates: a lattice
+can switch its indexing without changing how it talks about
+positions.
+
+## TODO
+
+- Worked example: writing a custom indexing strategy (e.g. Hilbert
+  curve) and verifying the round-trip with `site_index` /
+  `lattice_coord`.
+- When the sublattice-innermost convention is the wrong choice and
+  how to override it.
+- HigherDimCoord and the cut-and-project projection matrices for
+  Penrose / Ammann–Beenker / Fibonacci.
+
+## See also
+
+- [Concepts: Lattices and unit cells](../concepts/lattice_and_unit_cells.md)
+- [Reference: Coordinates](../reference/coordinates.md)
+- [Reference: Indexing](../reference/indexing.md)

--- a/docs/src/guide/lattice.md
+++ b/docs/src/guide/lattice.md
@@ -1,0 +1,77 @@
+# Lattice interface
+
+This guide walks through the `AbstractLattice` interface — the
+minimum a concrete lattice must implement, the trait-based extension
+points, and the default methods that come for free.
+
+For the physics and mathematical background, see the concept column
+[Lattices and unit cells](../concepts/lattice_and_unit_cells.md).
+
+## The abstract type
+
+```julia
+abstract type AbstractLattice{D, T} end
+```
+
+The two type parameters are:
+
+- `D::Int` — the physical dimension (1, 2, 3, ...)
+- `T<:Real` — the numeric type used to store positions (typically
+  `Float64`)
+
+**Nothing else** lives in the type parameters. Boundary conditions,
+topology, indexing, and site types are all stored as fields on the
+concrete subtype, and dispatched through multiple dispatch and
+trait objects.
+
+## Required interface
+
+A concrete subtype must implement these:
+
+| Method                 | Returns                                |
+| ---------------------- | -------------------------------------- |
+| [`num_sites`](@ref)    | `Int`                                  |
+| [`position`](@ref)     | `SVector{D, T}`                        |
+| [`neighbors`](@ref)    | `AbstractVector{Int}` (pinpoint)       |
+| [`boundary`](@ref)     | [`LatticeBoundary`](@ref)              |
+| [`site_layout`](@ref)  | [`AbstractSiteLayout`](@ref)           |
+| [`size_trait`](@ref)   | [`AbstractSizeTrait`](@ref)            |
+
+`num_sites` may be undefined — or may throw — when the lattice's
+`size_trait` is [`InfiniteSize`](@ref).
+
+## Free defaults
+
+Once the required methods are in place, LatticeCore derives:
+
+- [`dimension`](@ref) and `Base.eltype` from the type parameters
+- [`positions`](@ref) and [`bonds`](@ref) as lazy iterators from
+  `position` / `neighbors`
+- [`neighbor_bonds`](@ref) from `neighbors`
+- [`is_finite`](@ref), [`is_bipartite`](@ref),
+  [`reciprocal_support`](@ref), [`periodicity`](@ref),
+  [`topology`](@ref) as safe defaults that can be overridden
+- [`site_type(lat, i)`](@ref site_type) by delegating to
+  `site_layout`
+
+## Trait-based extension
+
+Extension points use value types rather than flags, so dispatch
+stays compile-time. The main traits are:
+
+- [`TopologyTrait`](@ref) — `{:square}`, `{:honeycomb}`, etc.
+- [`Periodic`](@ref) / [`Aperiodic`](@ref) — is the underlying
+  crystal periodic?
+- [`AbstractReciprocalSupport`](@ref) — does this lattice admit a
+  Bravais reciprocal ([`HasReciprocal`](@ref)), a dense Fourier
+  module ([`HasFourierModule`](@ref)), or neither
+  ([`NoReciprocal`](@ref))?
+- [`AbstractSizeTrait`](@ref) — [`FiniteSize`](@ref),
+  [`InfiniteSize`](@ref), or [`QuasiInfiniteSize`](@ref).
+
+## API reference
+
+- [Lattice](../reference/lattice.md)
+- [Bond](../reference/bond.md)
+- [Traits](../reference/traits.md)
+- [Reference lattices](../reference/reference_lattices.md)

--- a/docs/src/guide/lazy_infinite.md
+++ b/docs/src/guide/lazy_infinite.md
@@ -1,0 +1,54 @@
+# Lazy / infinite lattices
+
+This guide is a work in progress. See the concept column
+[Quasiperiodic order](../concepts/quasiperiodic_order.md) for the
+physical motivation.
+
+## Size traits
+
+LatticeCore describes the extent of a lattice through an
+[`AbstractSizeTrait`](@ref) value attached to every concrete lattice
+via [`size_trait`](@ref):
+
+- [`FiniteSize`](@ref) — ordinary finite lattice. MC is safe.
+- [`InfiniteSize`](@ref) — conceptually infinite. MC is *not* safe;
+  use the lattice only for spectral / analytic work.
+- [`QuasiInfiniteSize`](@ref) — conceptually infinite but expected
+  to be materialised at a cutoff before use.
+
+[`is_finite(lat)`](@ref) is a one-liner derived from this trait and
+is the predicate Monte Carlo algorithms should guard on.
+
+## The infinite-abstract → finite-materialisation pattern
+
+LatticeCore ships two small hooks for this pattern:
+
+- [`materialize(abstract; kwargs...)`](@ref materialize) — a generic
+  function with **no typed supertype**. A package that defines an
+  "infinite abstract" type (e.g. `InfiniteFibonacci`) adds a
+  method for it that returns a `FiniteSize` concrete lattice.
+- [`require_finite(lat)`](@ref require_finite) — an assertion guard
+  that MC entry points should call:
+
+```julia
+function run!(rng, state, lat::AbstractLattice, model, alg; kwargs...)
+    require_finite(lat)
+    # ... safe from here ...
+end
+```
+
+This pattern mirrors the momentum-space counterpart:
+[`HyperReciprocalLattice`](@ref) is the "infinite abstract" that
+becomes a finite [`BraggPeakSet`](@ref) at a cutoff.
+
+## TODO
+
+- Example: a custom `InfiniteChain` type + matching `materialize`
+  that produces a `LineLattice` at a chosen depth.
+- When real on-demand laziness (as opposed to materialisation)
+  makes sense, and the open design questions around it.
+
+## See also
+
+- [Concepts: Quasiperiodic order](../concepts/quasiperiodic_order.md)
+- [Reference: Lazy / infinite](../reference/lazy_infinite.md)

--- a/docs/src/guide/momentum.md
+++ b/docs/src/guide/momentum.md
@@ -1,0 +1,55 @@
+# Momentum space
+
+This guide is a work in progress. See the concept column
+[Reciprocal lattice and Brillouin zone](../concepts/reciprocal_and_brillouin.md)
+for the mathematical background.
+
+## AbstractMomentumLattice
+
+k-space is modelled as a subtype of
+[`AbstractMomentumLattice{D, T}`](@ref), which itself inherits from
+`AbstractLattice{D, T}`. This means the `num_sites`, `position`,
+trait, and test-suite infrastructure written for real-space
+lattices **also** applies to k-space lattices — k-points are
+"sites" and k-vectors are "positions".
+
+## Two concrete subtypes
+
+- [`PeriodicMomentumLattice`](@ref) — eager k-point list built
+  from a Bravais reciprocal basis. Constructed via
+  [`monkhorst_pack`](@ref) or [`gamma_centered`](@ref).
+- [`BraggPeakSet`](@ref) — the quasicrystal counterpart. Same
+  `AbstractMomentumLattice` interface, so the same
+  [`structure_factor`](@ref) code paths work for both.
+
+## Entry points
+
+- [`reciprocal_lattice(lat)`](@ref) — periodic-only.
+- [`fourier_module(lat)`](@ref) — quasicrystal-only (lives in
+  `QuasiCrystal.jl`).
+- [`momentum_lattice(lat)`](@ref) — trait-dispatched: picks the
+  right one via [`reciprocal_support`](@ref).
+
+## Structure factor
+
+[`structure_factor`](@ref) evaluates
+
+```math
+S(\mathbf{k}) = \frac{1}{N}\,
+    \left| \sum_i s_i \, e^{-i \mathbf{k} \cdot \mathbf{r}_i} \right|^2
+```
+
+naively in O(N) per k. FFT-based specialisations can be added
+without changing the API.
+
+## TODO
+
+- End-to-end example: compute `S(π, π)` on a 16×16 PBC square for
+  the Néel configuration.
+- How to sample a k-path (high-symmetry lines) once that lands.
+- When to use `monkhorst_pack` vs `gamma_centered`.
+
+## See also
+
+- [Concepts: Reciprocal lattice](../concepts/reciprocal_and_brillouin.md)
+- [Reference: Momentum space](../reference/momentum.md)

--- a/docs/src/guide/site_type.md
+++ b/docs/src/guide/site_type.md
@@ -1,0 +1,59 @@
+# Site types and layouts
+
+This guide is a work in progress. See the concept column
+[Site types and spin models](../concepts/site_types_and_spins.md)
+for the physics.
+
+## Site type ≠ sublattice
+
+LatticeCore separates two ideas that are traditionally conflated:
+
+- **Geometric sublattice** — where inside a unit cell the site
+  sits (A, B, C, ...). Stored in `LatticeCoord.sublattice`.
+- **Site type** — what physical degree of freedom lives on the
+  site (Ising spin, XY rotor, Heisenberg vector, ...). Described
+  by [`AbstractSiteType`](@ref) and stored via an
+  [`AbstractSiteLayout`](@ref).
+
+These axes are orthogonal: the same geometric sublattice can host
+any site type, and the same site type can sit on any sublattice.
+
+## Three layouts
+
+| Layout                         | When to use                                |
+| ------------------------------ | ------------------------------------------ |
+| [`UniformLayout`](@ref)        | Every site has the same type (most models) |
+| [`SublatticeLayout`](@ref)     | Mixed-spin: A = Ising, B = XY, ...         |
+| [`ExplicitLayout`](@ref)       | Per-site heterogeneity (quenched disorder) |
+
+`UniformLayout` has zero per-site memory overhead and lets the MC
+hot loop constant-fold the site type.
+
+## Built-in site types
+
+[`IsingSite`](@ref), [`PottsSite{Q}`](@ref), [`XYSite`](@ref),
+[`HeisenbergSite`](@ref), [`EmptySite`](@ref) — see the
+[site type reference](../reference/site_type.md) for
+`state_type` / `random_state` / `domain` of each.
+
+## Element centering
+
+The [`element_type`](@ref) trait lets a site type declare that its
+DOF lives on a [`BondCenter`](@ref), [`PlaquetteCenter`](@ref), or
+[`CellCenter`](@ref) rather than the default
+[`VertexCenter`](@ref). This reserves headroom for dimer variables,
+gauge links, and flux fields without a breaking rewrite.
+
+## TODO
+
+- Mixed-spin example end-to-end: build a honeycomb with Ising A /
+  XY B, then compute `site_type(lat, i)` for each i.
+- Custom site type tutorial: add a bond-centered dimer variable.
+- Integration with Monte Carlo models in `Lattice2DMonteCarlo.jl`.
+
+## See also
+
+- [Concepts: Site types and spin models](../concepts/site_types_and_spins.md)
+- [Reference: Site type](../reference/site_type.md)
+- [Reference: Site layout](../reference/site_layout.md)
+- [Reference: Lattice element](../reference/lattice_element.md)

--- a/docs/src/index.md
+++ b/docs/src/index.md
@@ -1,7 +1,89 @@
 # LatticeCore.jl
 
-## Models
+LatticeCore is the **abstract interface layer** for a family of Julia
+packages that simulate physical systems on geometric lattices. It
+defines the types and trait vocabulary that every lattice — periodic
+or aperiodic, finite or conceptually infinite — must implement, and
+then ships a pair of minimal reference implementations
+([`LineLattice`](@ref), [`SimpleSquareLattice`](@ref)) plus a
+momentum-space layer so the interface is verifiable end-to-end
+without any other dependency.
 
-```@autodocs
-Modules = [LatticeCore]
+## What LatticeCore is
+
+- A single abstract type hierarchy rooted at
+  `AbstractLattice{D, T}`, parameterised **only** on the physical
+  dimension `D` and the numeric type `T`. Everything else — boundary
+  conditions, topology, indexing, site types — is a field, composed
+  via multiple dispatch and trait objects.
+- A **trait-based extension model** (`TopologyTrait`, `Periodic` /
+  `Aperiodic`, `HasReciprocal` / `HasFourierModule` / `NoReciprocal`,
+  the size trait hierarchy) so new lattice kinds can plug in without
+  touching core types.
+- A **per-axis boundary condition** abstraction
+  ([`LatticeBoundary`](@ref)) so cylinders (PBC × OBC) and
+  flux-twisted lattices are as easy to describe as uniform PBC.
+- A clean split between **geometric sublattice** (A/B on a honeycomb,
+  A/B/C on kagome) and **site type** (the physical DOF living on the
+  site: Ising spin, XY rotor, Heisenberg vector, vacancy).
+- A **momentum-space layer** ([`AbstractMomentumLattice`](@ref),
+  [`PeriodicMomentumLattice`](@ref), [`structure_factor`](@ref))
+  plus the type skeletons [`HyperReciprocalLattice`](@ref) /
+  [`BraggPeakSet`](@ref) so quasicrystal Fourier analysis can ride
+  the same observer codepaths as periodic lattices.
+- A **lazy-friendly interface**: `position(lat, i)` and
+  `neighbors(lat, i)` are pinpoint, `positions(lat)` and `bonds(lat)`
+  are iterators. Infinite structures can be expressed abstractly and
+  lowered to finite lattices through [`materialize`](@ref).
+
+## What LatticeCore is **not**
+
+- A production-grade 2D lattice catalogue (triangular, honeycomb,
+  kagome, Lieb, Shastry–Sutherland, ...). Those live in
+  `Lattice2D.jl` and are built on top of LatticeCore.
+- A quasicrystal generator. Cut-and-project Penrose / Ammann–Beenker
+  / Fibonacci, their acceptance windows, and the Bragg-peak enumerator
+  live in `QuasiCrystal.jl`.
+- A Monte Carlo runtime. Classical MC models and algorithms live in
+  `Lattice2DMonteCarlo.jl`; LatticeCore only supplies the site-type
+  system and the [`require_finite`](@ref) guard they rely on.
+- A visualisation layer. Plots / Makie integration lives in package
+  extensions on top of the concrete-lattice packages, not here.
+
+## Package layout
+
+```text
+LatticeCore.jl            (this package, abstract interface)
+      │
+      ├── Lattice2D.jl        (periodic 2D catalogue)
+      │        │
+      ├── QuasiCrystal.jl     (cut-and-project quasicrystals)
+      │        │
+      └── ────┬─┘
+              ▼
+     Lattice2DMonteCarlo.jl   (classical MC runtime)
 ```
+
+## Design principles
+
+1. **One abstract type, minimal parameters.** `AbstractLattice{D, T}`.
+   BC / site type / indexing live in fields.
+2. **No `isa` branching.** Every variant goes through multiple
+   dispatch or a Holy trait.
+3. **Separation of concerns.** Topology (which bonds exist), boundary
+   (how they wrap), modifier (how they reweight), geometric
+   sublattice, and physical site type are five independent axes.
+4. **Lazy-friendly I/F.** Iterators everywhere; no method requires a
+   full site enumeration.
+5. **Breaking changes are cheap** in the 0.x era. The whole stack is
+   pre-1.0 and evolves with the architecture notes in the parent
+   repo.
+
+## Further reading
+
+- [Getting Started](getting_started.md) — install, construct a
+  lattice, measure it.
+- [Guide](guide/lattice.md) — concept-by-concept walkthrough.
+- [API Reference](reference/lattice.md) — generated from docstrings.
+- [Design Notes](design.md) — summary of the key architectural
+  decisions and pointers to the long-form notes.

--- a/docs/src/reference/bond.md
+++ b/docs/src/reference/bond.md
@@ -1,0 +1,8 @@
+# Bond API
+
+```@docs
+Bond
+bonds
+neighbor_bonds
+bond_center
+```

--- a/docs/src/reference/boundary.md
+++ b/docs/src/reference/boundary.md
@@ -1,0 +1,42 @@
+# Boundary API
+
+See [Boundary conditions guide](../guide/boundary.md) and the
+concept column [Boundary conditions](../concepts/boundary_conditions.md)
+for the narrative background.
+
+## Abstract types
+
+```@docs
+AbstractBoundaryCondition
+AbstractAxisBC
+AbstractBoundaryModifier
+```
+
+## Axis-level boundaries
+
+```@docs
+PeriodicAxis
+OpenAxis
+TwistedAxis
+```
+
+## Modifiers
+
+```@docs
+NoModifier
+SSD
+```
+
+## Composite boundary
+
+```@docs
+LatticeBoundary
+```
+
+## Hook functions
+
+```@docs
+apply_axis_bc
+axis_phase
+bond_weight
+```

--- a/docs/src/reference/coordinates.md
+++ b/docs/src/reference/coordinates.md
@@ -1,0 +1,26 @@
+# Coordinate systems API
+
+See [Coordinate systems and indexing](../guide/coordinates.md) for
+the narrative version.
+
+## Abstract type
+
+```@docs
+AbstractCoordinate
+```
+
+## Concrete coordinate kinds
+
+```@docs
+RealSpace
+LatticeCoord
+HigherDimCoord
+```
+
+## Conversions
+
+```@docs
+to_real
+to_lattice
+to_hyper
+```

--- a/docs/src/reference/indexing.md
+++ b/docs/src/reference/indexing.md
@@ -1,0 +1,25 @@
+# Indexing API
+
+See [Coordinate systems and indexing](../guide/coordinates.md) for
+the narrative version.
+
+## Abstract type
+
+```@docs
+AbstractIndexing
+```
+
+## Concrete strategies
+
+```@docs
+RowMajor
+ColMajor
+Snake
+```
+
+## Generic functions
+
+```@docs
+site_index
+lattice_coord
+```

--- a/docs/src/reference/lattice.md
+++ b/docs/src/reference/lattice.md
@@ -1,0 +1,33 @@
+# AbstractLattice API
+
+Auto-generated reference for the `AbstractLattice` interface. See
+[Lattice interface](../guide/lattice.md) for the narrative version
+and [Lattices and unit cells](../concepts/lattice_and_unit_cells.md)
+for the physical background.
+
+## Abstract type
+
+```@docs
+AbstractLattice
+```
+
+## Required interface
+
+```@docs
+num_sites
+position
+neighbors
+boundary
+size_trait
+site_layout
+```
+
+## Derived / default helpers
+
+```@docs
+dimension
+positions
+is_finite
+num_sublattices
+sublattice
+```

--- a/docs/src/reference/lattice_element.md
+++ b/docs/src/reference/lattice_element.md
@@ -1,0 +1,12 @@
+# Lattice element API
+
+Element-centering trait types that let an [`AbstractSiteType`](@ref)
+declare whether its DOF lives on a vertex, bond, plaquette, or cell.
+
+```@docs
+AbstractLatticeElement
+VertexCenter
+BondCenter
+PlaquetteCenter
+CellCenter
+```

--- a/docs/src/reference/lazy_infinite.md
+++ b/docs/src/reference/lazy_infinite.md
@@ -1,0 +1,9 @@
+# Lazy / infinite lattices API
+
+See [Lazy / infinite lattices guide](../guide/lazy_infinite.md) for
+the narrative version.
+
+```@docs
+materialize
+require_finite
+```

--- a/docs/src/reference/momentum.md
+++ b/docs/src/reference/momentum.md
@@ -1,0 +1,55 @@
+# Momentum space API
+
+See [Momentum space guide](../guide/momentum.md) for the narrative
+version and
+[Reciprocal lattice and Brillouin zone](../concepts/reciprocal_and_brillouin.md)
+for the mathematics.
+
+## Abstract types
+
+```@docs
+AbstractMomentumLattice
+```
+
+## Concrete momentum lattices
+
+```@docs
+PeriodicMomentumLattice
+```
+
+## Interface
+
+```@docs
+num_k_points
+k_point
+reciprocal_basis
+```
+
+## Mesh constructors
+
+```@docs
+monkhorst_pack
+gamma_centered
+```
+
+## Entry points
+
+```@docs
+reciprocal_lattice
+fourier_module
+momentum_lattice
+```
+
+## Structure factor
+
+```@docs
+structure_factor
+```
+
+## Quasicrystal Fourier-module skeletons
+
+```@docs
+AcceptanceWindow
+HyperReciprocalLattice
+BraggPeakSet
+```

--- a/docs/src/reference/reference_lattices.md
+++ b/docs/src/reference/reference_lattices.md
@@ -1,0 +1,13 @@
+# Reference lattices API
+
+LatticeCore ships two minimal concrete lattices so the interface
+can be exercised end-to-end without any downstream package. These
+are *reference implementations*, not production lattices — the full
+2D catalogue (triangular, honeycomb, kagome, ...) lives in
+`Lattice2D.jl`.
+
+```@docs
+LineLattice
+SimpleSquareLattice
+basis_vectors
+```

--- a/docs/src/reference/site_layout.md
+++ b/docs/src/reference/site_layout.md
@@ -1,0 +1,9 @@
+# Site layout API
+
+```@docs
+AbstractSiteLayout
+UniformLayout
+SublatticeLayout
+ExplicitLayout
+site_type
+```

--- a/docs/src/reference/site_type.md
+++ b/docs/src/reference/site_type.md
@@ -1,0 +1,27 @@
+# Site type API
+
+See [Site types and layouts](../guide/site_type.md) for the
+narrative version and
+[Site types and spin models](../concepts/site_types_and_spins.md)
+for the physics.
+
+## Abstract type and interface
+
+```@docs
+AbstractSiteType
+state_type
+random_state
+zero_state
+domain
+element_type
+```
+
+## Built-in site types
+
+```@docs
+IsingSite
+PottsSite
+XYSite
+HeisenbergSite
+EmptySite
+```

--- a/docs/src/reference/traits.md
+++ b/docs/src/reference/traits.md
@@ -1,0 +1,41 @@
+# Traits
+
+LatticeCore uses small value types (Holy traits) to express optional
+capabilities and invariants without inflating the concrete lattice's
+type parameters. See [Lattice interface](../guide/lattice.md) for
+where each trait is consumed.
+
+## Topology
+
+```@docs
+TopologyTrait
+topology
+```
+
+## Periodicity
+
+```@docs
+Periodic
+Aperiodic
+periodicity
+is_bipartite
+```
+
+## Reciprocal-space support
+
+```@docs
+AbstractReciprocalSupport
+HasReciprocal
+HasFourierModule
+NoReciprocal
+reciprocal_support
+```
+
+## Size
+
+```@docs
+AbstractSizeTrait
+FiniteSize
+InfiniteSize
+QuasiInfiniteSize
+```


### PR DESCRIPTION
## Description

Lands the documentation foundation for LatticeCore:

- Enable the `Documentation.yml` workflow (rename `.disabled` → `.yml`, upgrade actions to v4 / v6 / v2, add `pull_request` trigger so PRs get a docs build).
- Reorganise `docs/src` into **six sections**: Home, Getting Started, **Concepts**, Guide, API Reference, Design notes.
- Wire up `docs/make.jl` with the full `pages` tree; wrap the favicon / logo `Downloads.download` in a `try`/`catch` so local sandboxed builds don't fail.

**Content strategy**: Home, Getting Started, **two Concepts columns**, and one Guide chapter are fully written; everything else is a useful skeleton with a short overview and explicit TODOs. All **reference pages are `@docs` blocks** that auto-generate from existing docstrings and build cleanly with `checkdocs = :none`.

Fixed: (no linked issue)

## Type of Change

- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Performance
- [x] 📖 Documentation
- [ ] 🧰 Maintenance

## Proposed Changes

**Fully-written pages**
- `index.md` — About: what LatticeCore is (and is not), design principles, package layout, pointers to further reading
- `getting_started.md` — install + **runnable minimal example** covering `LineLattice`, `SimpleSquareLattice`, cylinder BC, structure factor, and the `require_finite` / `materialize` guards
- `concepts/lattice_and_unit_cells.md` — Bravais lattices, unit cells, sublattices, why *geometric sublattice* and *physical site type* are separate axes, coordination number and bipartiteness. Ends with physics references (Ashcroft–Mermin / Kittel / Sachdev)
- `concepts/reciprocal_and_brillouin.md` — reciprocal lattice derivation, orthogonality `a_i · b_j = 2π δ_ij`, Brillouin zone, Monkhorst–Pack vs Γ-centred sampling, structure factor with the ferromagnet / Neel / disorder sanity checks
- `guide/lattice.md` — AbstractLattice required interface, derived defaults, trait-based extension points, index into the rest of the reference

**Skeleton pages** (short overview + TODOs, to be expanded in follow-up PRs)
- `concepts/{boundary_conditions,site_types_and_spins,quasiperiodic_order}.md`
- `guide/{boundary,coordinates,site_type,momentum,lazy_infinite}.md`

**API reference** (auto from docstrings)
- `reference/{lattice,bond,traits,boundary,coordinates,indexing,site_type,site_layout,lattice_element,momentum,lazy_infinite,reference_lattices}.md`

**Design notes** (`design.md`)
- Summary of the five orthogonal axes (topology, boundary, coordinate system, geometric sublattice, physical site type)
- The key invariants (`{D, T}` only; no `isa` branching; lazy-friendly I/F; cheap breaking changes in 0.x)
- Pointer to `dev/note/04_architecture/` in the parent workspace

## Concepts section

Per the user's request, the Concepts section is a set of **columns**: short, self-contained reads for someone approaching lattice simulation from the software-engineering side. They establish the vocabulary LatticeCore borrows from physics and explain *why* the API is shaped the way it is, not just how to call it.

## Local build

```shell
julia --project=docs/ docs/make.jl
```

Builds cleanly: no broken `@docs` references, no broken `@ref` links. Deployment is skipped locally (no `GITHUB_TOKEN`); the workflow runs build on every PR and deploys on pushes to main.

Package tests: **771 / 771 pass**.

## Changed

- `.github/workflows/Documentation.yml.disabled` → `Documentation.yml` (enabled, actions upgraded)
- `.gitignore` — add generated favicon / logo paths
- `docs/make.jl` — new pages tree, `try`/`catch` around asset downloads
- `docs/src/index.md` — rewrite from `@autodocs` stub to About page
- `Project.toml` — `0.7.0` → `0.7.1` (docs-only patch)

## Follow-up plan

Subsequent PRs will fill in the skeleton concepts / guide pages one or two at a time as each becomes the subject of its own implementation work.

## check list
- [x] test駆動をしたか — local docs build + package test suite