### PR TITLE
docs: fill the remaining concept columns and guide pages

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.7.1"
+version = "0.7.2"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/docs/src/concepts/boundary_conditions.md
+++ b/docs/src/concepts/boundary_conditions.md
@@ -1,46 +1,200 @@
 # Boundary conditions
 
-This column is still being written. In the meantime, the physics
-that drives LatticeCore's per-axis [`LatticeBoundary`](@ref)
-abstraction:
+Every lattice simulation you will ever run is finite. The real
+crystal you are approximating, on the other hand, is almost always
+huge compared to your sample — so the *boundary* of your sample is
+where the approximation bleeds through. Picking a boundary condition
+is picking the way that bleed is controlled, and it changes both the
+physics you measure and the numerics you use to measure it.
 
-- **Periodic (PBC)**: the lattice is wrapped onto a torus. It is
-  the gentlest finite-size approximation — every site looks like a
-  bulk site — and it lets the reciprocal lattice remain discrete.
-- **Open (OBC)**: the sample has real surfaces. Edge / corner sites
-  have fewer neighbours, and the discrete reciprocal lattice no
-  longer strictly applies.
-- **Cylinder / strip**: a mix of PBC and OBC along different axes.
-  Ubiquitous in DMRG and tensor-network simulations because it
-  tames edge effects while keeping a manageable transverse size.
-- **Twisted PBC**: periodic with a phase factor
-  ``e^{i\theta}`` attached to bonds that cross the boundary. This
-  is how a lattice model sees a magnetic flux, a twist angle, or a
-  supercurrent. The topology is unchanged; only the phase
-  accumulates.
-- **Sine-square deformation (SSD)**: a non-topological *modifier*
-  that multiplies bond energies by a smooth envelope
-  ``\sin^2(\pi x / L)``. SSD is topologically open but reproduces
-  periodic-like ground states surprisingly well, which is useful
-  when you want PBC physics without the PBC integration pain.
+LatticeCore's answer is to give you enough vocabulary to pick the
+right one on purpose, and to compose it axis by axis.
+
+## The four regimes
+
+Four boundary conditions appear over and over again in lattice
+simulations. They differ in how the lattice graph is closed off
+(topology) and in whether the bonds that close it carry a phase or
+a weight.
+
+### Periodic (torus)
+
+Identify each axis with its opposite edge. The sample becomes a
+torus, the neighbour graph is translation-invariant, and every site
+looks locally identical to a bulk site. This is the gentlest finite-
+size approximation for ground-state physics:
+
+- Translation symmetry is preserved, so crystal momentum is a good
+  quantum number and the **discrete reciprocal lattice** is exact.
+- Finite-size corrections decay like ``1/L^d`` or better for
+  gapped systems — the Polyakov loops of the problem still wrap,
+  but their effect is uniform across the sample.
+- Monte Carlo algorithms integrate the ergodic sector directly, no
+  edge carve-outs required.
+
+In LatticeCore, `PeriodicAxis()` on every axis plus `NoModifier()`
+is what `SimpleSquareLattice(Lx, Ly)` gives you out of the box.
+
+### Open (real surface)
+
+Don't close the axis at all. Edge and corner sites have fewer
+neighbours than bulk sites, the translation symmetry is broken, and
+the system *has* a genuine surface — with all the surface physics
+that entails:
+
+- Open sample calculations carry surface free energies and surface
+  modes that are physically real and often interesting in their
+  own right (surface plasmons, edge states, Kondo surface effects).
+- Friedel oscillations near the boundary mean that "bulk" averages
+  should be taken over an interior window, not the whole sample.
+- DMRG / tensor-network algorithms converge much faster on OBC
+  than on PBC in 1D because the ends of the chain have low
+  entanglement.
+
+`OpenAxis()` on every axis switches the reference lattices into
+this regime.
+
+### Cylinders and strips
+
+Mix the two: periodic along one axis, open along another. On a
+square you get a cylinder, on a cubic system you get a tube. This
+is the workhorse geometry for tensor networks because it combines
+the small edge effects of PBC along one direction with the clean
+finite-width convergence of OBC along the orthogonal one. It is
+also the natural choice for studying 1D-like quasi-long-range
+order on top of a 2D lattice:
+
+- Momentum along the periodic axis remains a good quantum number;
+  momentum along the open axis does not.
+- The circumference `Lx` sets the IR cutoff along the periodic axis
+  (gaps close like `1/Lx` in gapless phases).
+- On a honeycomb cylinder, the choice of circumferential axis
+  (zigzag vs armchair) changes the edge physics qualitatively.
+
+LatticeCore's `LatticeBoundary((PeriodicAxis(), OpenAxis()))` on a
+`SimpleSquareLattice` is an explicit cylinder.
+
+### Twisted periodic (flux and Bloch phases)
+
+Close the sample like a torus, but attach a phase ``e^{i\theta}``
+to any bond that crosses the boundary. Physically, this is **what a
+lattice model sees of a magnetic flux**: the Peierls substitution
+that takes a hopping integral ``t_{ij}`` to
+``t_{ij} e^{i \oint \mathbf{A} \cdot d\mathbf{\ell}}`` localises the
+flux on the boundary-crossing bonds of a sufficiently clever gauge
+choice. The lattice topology is identical to PBC — every site has
+the same number of neighbours — but the Hamiltonian is different.
+
+Twisted BC are how lattice simulations talk about:
+
+- Magnetic flux quantisation (Byers–Yang). Threading a flux
+  ``\theta = \pi/2, \pi, 3\pi/2`` and tracking the ground-state
+  energy picks out a superfluid response or a topological
+  invariant.
+- Finite-size extrapolation to zero-temperature conductance in
+  tight-binding chains.
+- Averaging over Bloch phases as a stand-in for momentum integration.
+
+`TwistedAxis(θ)` stores the twist angle. The connectivity function
+[`apply_axis_bc`](@ref) treats it identically to `PeriodicAxis`
+(the neighbour graph is the same), while [`axis_phase`](@ref)
+returns the phase factor that bond evaluation picks up.
 
 ## Why per-axis?
 
-Classical physics codes usually hardcode "PBC" or "OBC" as a global
-flag. That is wrong as soon as you want a cylinder — the axis
-choices stop being symmetric. LatticeCore follows the convention
-used by DMRG / tensor-network libraries and stores **one
-[`AbstractAxisBC`](@ref) per axis**, plus one
-[`AbstractBoundaryModifier`](@ref), in a composite
-[`LatticeBoundary`](@ref). Adding a new BC kind means adding a new
-`AbstractAxisBC` subtype and a method for
-[`apply_axis_bc`](@ref); no core code changes.
+Many physics codes expose boundary conditions as a single global
+flag: "PBC" or "OBC". That design breaks as soon as you want a
+cylinder or a twisted flux — the axes stop being symmetric, and
+you have to introduce per-axis escape hatches anyway.
 
-## TODO
+LatticeCore follows the convention used by DMRG and tensor-network
+libraries: store **one [`AbstractAxisBC`](@ref) per axis**, plus an
+optional [`AbstractBoundaryModifier`](@ref) that reweights bonds
+non-topologically, in a composite [`LatticeBoundary`](@ref). The
+reference square lattice dispatches through each axis independently:
 
-- Diagram: PBC torus, OBC square, cylinder, Möbius.
-- Worked example: dispersion of a 1D tight-binding chain under
-  `PeriodicAxis`, `OpenAxis`, and `TwistedAxis`.
-- Finite-size scaling and the role of BC in extracting
-  bulk-limit quantities.
-- Where SSD fits in the modifier slot of [`LatticeBoundary`](@ref).
+```julia
+function neighbors(l::SimpleSquareLattice, i::Int)
+    x, y = _site_to_xy(l, i)
+    bx, by = l.boundary.axes
+
+    ns = Int[]
+    # +x direction
+    nx, ok = apply_axis_bc(bx, x + 1, l.Lx)
+    ok && push!(ns, _xy_to_site(l, nx, y))
+    # ... and so on for −x, +y, −y
+    return ns
+end
+```
+
+Because `apply_axis_bc` dispatches on the axis BC's concrete type,
+the compiler strips away the wrong-BC branches and the code is
+specialised for the specific combination you actually use.
+
+## Modifiers, and why SSD lives outside the axis tuple
+
+Topological boundary conditions (the axis tuple) decide which
+bonds *exist*. **Modifiers** are the other story: a non-topological
+reweighting applied on top of an existing bond graph.
+
+The archetypal modifier is **sine-square deformation** (SSD),
+introduced in Gendiar, Krcmar & Nishino (2009). It multiplies
+every bond's contribution to the Hamiltonian by the envelope
+
+```math
+f(\mathbf{r}) = \sin^2\!\left(\pi \, \frac{|\mathbf{r} - \mathbf{r}_{\text{centre}}|}{L}\right),
+```
+
+which is zero at the sample edges and maximal in the bulk. Open
+boundary conditions dressed with an SSD envelope reproduce the
+ground-state correlation functions of *periodic* systems almost
+perfectly, because the smooth envelope suppresses surface
+excitations before they can contaminate the bulk. This is
+surprising and extremely useful; it is also obviously not a
+wrapping rule.
+
+LatticeCore's [`NoModifier`](@ref) and [`SSD`](@ref) live in a
+separate slot of [`LatticeBoundary`](@ref). You can combine any
+axis-level BC with any modifier without touching the core code:
+
+```julia
+LatticeBoundary((PeriodicAxis(), OpenAxis()), SSD(10.0))
+```
+
+(The `SSD` weighting function itself is currently a type-level
+placeholder; the concrete envelope evaluation lands with the MC
+layer.)
+
+## Finite-size scaling and BC choice
+
+A boundary condition is not just a technicality — it changes the
+leading finite-size corrections to everything you measure. Three
+rules of thumb:
+
+1. **Gapped phases** have exponentially small PBC corrections and
+   algebraic OBC corrections. Use PBC if you want to extract the
+   bulk gap from a small sample.
+2. **Critical points** have universal finite-size scaling. Usually
+   you want PBC because it preserves translation symmetry, but
+   cylinders are standard in 2D because they give you a natural
+   bond dimension cutoff for DMRG.
+3. **Surface physics** — edge modes, surface magnetism, surface
+   plasmons — obviously needs OBC. Cylinders let you isolate one
+   direction of surface physics at a time.
+
+The [`periodicity`](@ref) trait on a LatticeCore lattice reports
+`Periodic()` iff *every* axis wraps, and `Aperiodic()` otherwise.
+[`is_bipartite`](@ref) accounts for odd cycles introduced by PBC
+with odd-length axes, so the `(-1)^{x+y}` Néel state only reports
+as a valid ground state on lattices where it actually is one.
+
+## Further reading
+
+- K. Binder, D. W. Heermann, *Monte Carlo Simulation in Statistical
+  Physics*, Ch. 2 (finite-size scaling and BC choice).
+- U. Schollwöck, *The density-matrix renormalisation group in the
+  age of matrix product states*, Rev. Mod. Phys. **77** (2011).
+- A. Gendiar, R. Krcmar, T. Nishino, *Prog. Theor. Phys.* **122**
+  (2009) — the original SSD paper.
+- N. Byers, C. N. Yang, *Phys. Rev. Lett.* **7** 46 (1961) —
+  twisted BC and flux quantisation.

--- a/docs/src/concepts/quasiperiodic_order.md
+++ b/docs/src/concepts/quasiperiodic_order.md
@@ -1,80 +1,215 @@
 # Quasiperiodic order
 
-This column is still being written. The short version:
+Most of condensed-matter physics takes **periodicity** for granted.
+Crystals are invariant under a Bravais lattice of translations, and
+almost every technique — Bloch theorem, band structure, reciprocal
+lattices — is a consequence. But in 1982 Shechtman's diffraction
+measurements of a rapidly cooled Al–Mn alloy showed a pattern with
+sharp Bragg peaks *and* 10-fold rotational symmetry, which is
+forbidden for any 2D or 3D crystallographic space group. The
+discovery of **quasicrystals** (Nobel Prize in Chemistry, 2011)
+forced physics to accept a structural regime that is neither
+periodic nor disordered: long-range order without translation
+symmetry.
 
-## Aperiodic but ordered
+LatticeCore is designed to host these structures on the same
+footing as Bravais crystals. This column is the physics story; the
+construction and Fourier analysis algorithms live in
+`QuasiCrystal.jl` and are exposed here through the type skeletons
+[`HyperReciprocalLattice`](@ref), [`AcceptanceWindow`](@ref), and
+[`BraggPeakSet`](@ref).
 
-Most of condensed matter physics takes periodicity for granted:
-a Bravais lattice, translated forever. But there is a family of
-structures — Penrose tilings, Ammann–Beenker tilings, Fibonacci
-chains, icosahedral quasicrystals — that are *not* periodic in the
-usual sense yet are still highly ordered. They have long-range
-bond orientational order, crystallographically-forbidden point
-symmetries (5-fold for Penrose, 8-fold for Ammann–Beenker, 10-fold
-for decagonal quasicrystals), and sharp Bragg peaks in their
-diffraction patterns.
+## What "quasiperiodic" means
+
+A point set ``\mathcal{L} \subset \mathbb{R}^d`` is **quasiperiodic**
+if its autocorrelation function — equivalently, its diffraction
+pattern — is a **pure point measure** supported on a *dense*
+countable set:
+
+```math
+\mathcal{F}[\rho](\mathbf{k}) = \sum_{\mathbf{k}_n \in M^\ast}
+    I(\mathbf{k}_n)\, \delta(\mathbf{k} - \mathbf{k}_n).
+```
+
+Periodic crystals are a special case where the support
+``M^\ast`` is a discrete Bravais reciprocal lattice. For a
+quasicrystal, ``M^\ast`` is still countable but **dense** in
+``\mathbb{R}^d``: you can find a Bragg peak arbitrarily close to
+any ``\mathbf{k}``, yet only countably many peaks carry non-zero
+intensity. The resulting diffraction pattern is sharp but
+inexhaustible.
+
+The intensities ``I(\mathbf{k}_n)`` are not uniform. They fall off
+with a form factor, leaving a finite number of *bright* peaks at
+any intensity threshold — which is exactly the finite set
+LatticeCore stores in a [`BraggPeakSet`](@ref).
 
 ## Cut and project
 
-The cleanest way to generate these structures is **cut-and-project**:
+The cleanest way to generate a quasicrystal is **cut-and-project**.
+The recipe:
 
-1. Start with a periodic lattice in a higher dimension
-   ``\mathbb{Z}^{D_{\text{hyper}}}``. For Penrose, ``D_{\text{hyper}} = 5``;
-   for Ammann–Beenker, ``4``; for the Fibonacci chain, ``2``.
-2. Choose a **physical** subspace of dimension ``D_{\text{phys}}``
-   (the plane or line you actually want to look at) and a
-   **perpendicular** subspace of dimension
-   ``D_{\text{hyper}} - D_{\text{phys}}`` (the "internal" space).
-3. Pick an **acceptance window** in the perpendicular space: a
-   bounded shape that acts as a stencil.
-4. A higher-dimensional lattice point lands in the physical
-   structure *if and only if* its perpendicular projection sits
-   inside the acceptance window.
+1. Pick a host **periodic** lattice in a higher dimension
+   ``D_{\text{hyper}}``. For the Fibonacci chain, ``D_{\text{hyper}} = 2``;
+   for the Penrose tiling, ``D_{\text{hyper}} = 5``; for the
+   Ammann–Beenker tiling, ``D_{\text{hyper}} = 4``.
+2. Choose a **physical subspace** ``E_\parallel`` of dimension
+   ``D_{\text{phys}}`` inside ``\mathbb{R}^{D_{\text{hyper}}}``.
+   The embedding must be irrational — that is, ``E_\parallel`` is
+   not spanned by any rational basis of the hyper lattice — so
+   that its parallel projection lands *densely* in ``E_\parallel``
+   without ever repeating.
+3. Choose a **perpendicular subspace** ``E_\perp`` of dimension
+   ``D_{\text{hyper}} - D_{\text{phys}}``, orthogonal to
+   ``E_\parallel``.
+4. Choose an **acceptance window** ``W \subset E_\perp`` — a
+   bounded region that acts as a stencil.
+5. Project every hyper lattice point ``\mathbf{n} \in
+   \mathbb{Z}^{D_{\text{hyper}}}`` whose **perpendicular**
+   projection sits inside ``W`` onto the physical subspace. The
+   resulting set of physical-space points
 
-The resulting set of physical-space points is the quasicrystal. It
-inherits the higher-dimensional translation symmetry but projects
-it irrationally, which is why the structure is dense in Fourier
-space yet discrete in physical space.
+```math
+   \mathcal{L} = \{\, \pi_\parallel(\mathbf{n}) :
+                      \mathbf{n} \in \mathbb{Z}^{D_{\text{hyper}}},
+                      \pi_\perp(\mathbf{n}) \in W \,\}
+```
 
-LatticeCore captures the scaffolding with the types
-[`AcceptanceWindow`](@ref), [`HyperReciprocalLattice`](@ref), and
-[`BraggPeakSet`](@ref); the concrete algorithms that build them
-live in `QuasiCrystal.jl`.
+is the quasicrystal.
 
-## Fourier module and Bragg peaks
+The acceptance window is where all the structure hides. A
+rectangular window in 2D gives you a Fibonacci chain. Five
+pentagonal windows arranged with 5-fold symmetry (one per
+perpendicular-space slab of the Penrose lifting) give you the
+Penrose P3 tiling. Octagonal windows give Ammann–Beenker.
 
-Because a quasicrystal inherits its translation symmetry from a
-higher-dimensional periodic lattice, its Fourier transform is a
-*finite set of Bragg peaks projected through the same matrix*
-``\pi_{\parallel}``. Unlike a Bravais reciprocal lattice, the set
-of peak locations is **dense** in physical reciprocal space — but
-only finitely many peaks are bright, and their intensities are
-given by the Fourier transform of the acceptance window evaluated
-in the perpendicular space.
+LatticeCore captures the three ingredients as type skeletons:
 
-A [`BraggPeakSet`](@ref) is what you get after fixing a cutoff:
-the finite list of peaks whose intensities exceed some threshold,
-stored together with their original higher-dimensional indices so
-you can walk back to the hyper lattice.
+```julia
+abstract type AcceptanceWindow end
 
-Crucially, [`BraggPeakSet`](@ref) subtypes
-[`AbstractMomentumLattice`](@ref), so the *same*
-[`structure_factor`](@ref) code paths that work on a
-[`PeriodicMomentumLattice`](@ref) work on a quasicrystal.
+struct HyperReciprocalLattice{DPhys, DHyper, DPerp, T, W <: AcceptanceWindow}
+    hyper_basis::SMatrix{DHyper, DHyper, T}
+    parallel_proj::SMatrix{DPhys, DHyper, T}
+    perp_proj::SMatrix{DPerp, DHyper, T}
+    window::W
+end
+```
 
-## TODO
+Concrete window types (`PolygonalWindow`, `IntervalWindow`, ...)
+and the construction of projection matrices live in
+`QuasiCrystal.jl`. The shape lives here because it is the contract
+every downstream consumer agrees on.
 
-- Worked example: Fibonacci chain at `depth = 8`, a picture of its
-  acceptance window, and the first handful of Bragg peaks.
-- Diagram of cut-and-project in 2D projecting down to 1D.
-- The role of golden ratio φ in the Fibonacci case and how it shows
-  up as the eigenvalue of the substitution matrix.
-- When *pseudo-Brillouin zones* are a useful concept for
-  quasicrystals and when they break down.
+## Fibonacci in full
+
+The Fibonacci chain is the simplest non-trivial example, small
+enough to do by hand:
+
+- Hyper lattice: ``\mathbb{Z}^2``.
+- Physical subspace: the line with slope ``1/\varphi`` where
+  ``\varphi = (1 + \sqrt{5})/2`` is the golden ratio.
+- Perpendicular subspace: the orthogonal line with slope
+  ``-\varphi``.
+- Acceptance window: an interval of length ``\sqrt{1 + \varphi^2}``
+  on the perpendicular line.
+
+Project every integer point ``(m, n) \in \mathbb{Z}^2`` whose
+perpendicular projection lies in the window, and you get a
+sequence of "long" (``L``) and "short" (``S``) intervals on the
+physical line. Asymptotically the ratio ``|L|/|S| = \varphi``, and
+the substitution rule ``L \to LS``, ``S \to L`` iterated from a
+single ``L`` generates the same sequence.
+
+The substitution matrix
+
+```math
+M = \begin{pmatrix} 1 & 1 \\ 1 & 0 \end{pmatrix}
+```
+
+has eigenvalues ``\varphi`` and ``-1/\varphi``. The leading
+eigenvalue ``\varphi`` is the **inflation factor**: every
+substitution step stretches the sequence by ``\varphi``. This
+simple fact — an algebraic integer lurking in a hyperbolic map —
+is what makes Fibonacci quasicrystals so tractable analytically.
+
+## The Fourier module and Bragg peaks
+
+Because a quasicrystal inherits its translation symmetry from the
+host periodic lattice, its Fourier transform is supported on the
+**projected reciprocal lattice** of the host:
+
+```math
+M^\ast = \pi_\parallel (\mathbb{Z}^{D_{\text{hyper}}})^\ast.
+```
+
+This projected set is countable (it is the image of a countable
+set) and, crucially, **dense** in ``\mathbb{R}^{D_{\text{phys}}}``
+— because the projection is irrational. The set ``M^\ast`` is the
+**Fourier module** of the quasicrystal. Unlike a Bravais
+reciprocal lattice, ``M^\ast`` is not discrete.
+
+The intensity carried by each projected peak is the Fourier
+transform of the acceptance window evaluated in the perpendicular
+space:
+
+```math
+I(\mathbf{k}_n) \propto \bigl|\, \hat{W}(\pi_\perp(\mathbf{g}_n))\, \bigr|^2,
+```
+
+where ``\mathbf{g}_n \in (\mathbb{Z}^{D_{\text{hyper}}})^\ast`` is
+the higher-dimensional reciprocal lattice vector that
+``\mathbf{k}_n = \pi_\parallel(\mathbf{g}_n)`` projects from. For
+an interval window of width ``a``,
+``\hat{W}(q) \propto \mathrm{sinc}(qa/2)``; for a polygonal
+window, the window Fourier transform is a sum of sinc factors
+coming from the polygon's vertices.
+
+The practical consequence is that **only a finite number of
+peaks exceed any given intensity threshold**. Pick a cutoff, list
+those peaks, and you have a [`BraggPeakSet`](@ref):
+
+```julia
+struct BraggPeakSet{DPhys, DHyper, T} <: AbstractMomentumLattice{DPhys, T}
+    peaks::Vector{SVector{DPhys, T}}
+    intensities::Vector{T}
+    hyper_indices::Vector{NTuple{DHyper, Int}}
+end
+```
+
+This is a subtype of [`AbstractMomentumLattice`](@ref), so the
+*same* [`structure_factor`](@ref) code paths that work on a
+[`PeriodicMomentumLattice`](@ref) work on a quasicrystal. In the
+words of the 05 momentum-space chapter, a Bragg peak set is the
+quasicrystal's answer to a Monkhorst–Pack mesh.
+
+## Why this matters for LatticeCore
+
+You could, in principle, stick a quasicrystal generator on its own
+hierarchy and never share interfaces with periodic lattices. That
+is what most of the existing quasicrystal literature does. The
+argument for the LatticeCore approach — one `AbstractLattice`
+hierarchy, one `AbstractMomentumLattice` hierarchy, one structure
+factor — is that **you want to run the same Monte Carlo on both**.
+A diluted antiferromagnet on a Penrose tiling wants the same
+observer stack as the same model on a square lattice: the trait
+machinery picks the right reciprocal-space object through
+[`momentum_lattice`](@ref), the structure factor iterates over it
+with exactly the same code, and the physics stays comparable.
+
+The cut-and-project recipe is how the hierarchy is populated; the
+interface is what makes the comparison cheap.
 
 ## Further reading
 
-- M. Senechal, *Quasicrystals and Geometry* (Cambridge, 1995).
-- M. Baake and U. Grimm, *Aperiodic Order*, Vol. 1 (Cambridge, 2013).
-- Z. M. Stadnik (ed.), *Physical Properties of Quasicrystals*
-  (Springer, 1999).
+- D. Shechtman *et al.*, *Phys. Rev. Lett.* **53** 1951 (1984) —
+  the paper that identified icosahedral quasicrystals.
+- M. Senechal, *Quasicrystals and Geometry*, Cambridge (1995).
+- M. Baake, U. Grimm, *Aperiodic Order*, Vol. 1, Cambridge (2013)
+  — the definitive reference on cut-and-project constructions and
+  their Fourier analysis.
+- N. G. de Bruijn, *Algebraic theory of Penrose's non-periodic
+  tilings*, Kon. Neder. Akad. Wetensch. Proc. Ser. A **84** (1981)
+  — the original 5D lift of the Penrose tiling.
+- Z. M. Stadnik (ed.), *Physical Properties of Quasicrystals*,
+  Springer (1999) — the experimental side.

--- a/docs/src/concepts/site_types_and_spins.md
+++ b/docs/src/concepts/site_types_and_spins.md
@@ -1,58 +1,180 @@
 # Site types and spin models
 
-This column is still being written. The short version:
+A lattice tells you where things live. A **site type** tells you
+what lives there. LatticeCore keeps the two on separate axes so
+that the same geometric skeleton can host an Ising spin, an XY
+rotor, a Heisenberg vector, a vacancy, or — in due course — a gauge
+link. This column explains the physics that motivates the choices
+and points at the code that implements them.
 
-## What is a site type?
+## Why separate site type from geometry?
 
-A **site type** tells LatticeCore what mathematical object lives on
-a single lattice site and how to sample it uniformly at random.
-Concretely, [`AbstractSiteType`](@ref) requires
+In textbook condensed matter the "site" is usually identified with
+the whole package: "a site on the square lattice carries an Ising
+spin". That shortcut breaks as soon as you want a **mixed-spin
+model** (Ising on A, XY on B), a **diluted** model (a site might be
+empty), or a **heterogeneous** model where disorder is attached to
+individual sites. Every time you conflate the two, your
+Hamiltonian has to reach into a tuple index and remember which
+sublattice this position belongs to, and you introduce bugs.
 
-- [`state_type`](@ref) — the Julia type that stores one state
-- [`random_state`](@ref) — a uniform sampler
+LatticeCore makes the separation explicit:
 
-and optionally
+- The geometric sublattice lives in
+  [`LatticeCoord`](@ref).`sublattice` — A, B, C, ... of the unit
+  cell, a property of *position*.
+- The physical degree of freedom lives in an
+  [`AbstractSiteType`](@ref) reached through
+  [`site_layout(lat)`](@ref) and [`site_type(lat, i)`](@ref) — a
+  property of *content*.
 
-- [`zero_state`](@ref), [`domain`](@ref), and
-  [`element_type`](@ref) for lifting the DOF onto bonds / plaquettes
-  / cells.
+An [`AbstractSiteLayout`](@ref) is the bridge. The three layouts
+LatticeCore ships ([`UniformLayout`](@ref),
+[`SublatticeLayout`](@ref), [`ExplicitLayout`](@ref)) cover the
+three natural ways that content can be homogeneous, sublattice-
+uniform, or fully heterogeneous.
 
 ## The classical spin ladder
 
 The archetypal site types form a ladder of increasing continuous
-symmetry:
+symmetry. Each rung makes physical sense in its own right and they
+all compose with the same lattice geometry:
 
-| Site type                | State space                | Symmetry group | Models            |
-| ------------------------ | -------------------------- | -------------- | ----------------- |
-| [`IsingSite`](@ref)      | ``\{-1, +1\}``             | ``\mathbb{Z}_2`` | Ising, RBIM     |
-| [`PottsSite{Q}`](@ref)   | ``\{1, \dots, Q\}``        | ``S_Q``         | Potts, clock     |
-| [`XYSite`](@ref)         | circle ``S^1``             | ``U(1) = SO(2)``  | XY, Villain   |
-| [`HeisenbergSite`](@ref) | sphere ``S^2 \subset \mathbb{R}^3`` | ``SO(3)`` | Heisenberg |
-| [`EmptySite`](@ref)      | singleton                  | trivial         | vacancies       |
+| Site type                | State space                  | Symmetry group       | Canonical model         |
+| ------------------------ | ---------------------------- | -------------------- | ----------------------- |
+| [`IsingSite`](@ref)      | ``\{-1, +1\}``               | ``\mathbb{Z}_2``     | Ising, Edwards–Anderson |
+| [`PottsSite{Q}`](@ref)   | ``\{1, \dots, Q\}``          | ``S_Q``              | ``Q``-state Potts       |
+| [`XYSite`](@ref)         | ``S^1``                      | ``U(1) \cong SO(2)`` | XY, Villain, BKT        |
+| [`HeisenbergSite`](@ref) | ``S^2 \subset \mathbb{R}^3`` | ``SO(3)``            | Heisenberg, J1–J2       |
 
-The pattern is standard condensed-matter: as you move down the
-table, the Mermin–Wagner theorem kicks in (no long-range order in
-2D for ``d \geq 2`` continuous groups at finite ``T``), the energy
-landscape becomes smoother, and the numerically appropriate Monte
-Carlo update changes (single-flip → cluster → overrelaxation,
-cluster → worm).
+As you move down the table:
 
-## Why this lives in LatticeCore
+- The state space goes from two points, to a small discrete set,
+  to a circle, to a sphere. The **configuration space grows**, and
+  so does the typical cost of a Monte Carlo update.
+- The symmetry group gets bigger and becomes continuous. Continuous
+  symmetries are protected by **Mermin–Wagner** in 2D at finite
+  temperature: they cannot be spontaneously broken, so the ordered
+  phase gives way to a *critical* phase (XY below the
+  Berezinskii–Kosterlitz–Thouless point) or to no ordered phase
+  at all (Heisenberg in 2D).
+- The numerically appropriate update changes: single-flip for
+  Ising, cluster for XY (Wolff), overrelaxation / cluster for
+  Heisenberg, worm for vertex models, and so on.
 
-A Monte Carlo runtime like `Lattice2DMonteCarlo.jl` needs to
-dispatch its local Hamiltonian on the site types at either end of a
-bond. Making `AbstractSiteType` part of LatticeCore — rather than
-the MC layer — means that *every* concrete lattice in the stack can
-describe what it carries, regardless of which MC runtime later
-consumes it.
+LatticeCore's [`random_state`](@ref) for each site type is the
+uniform sampler on the relevant state space:
 
-## TODO
+- `IsingSite`: a random element of ``\{-1, +1\}``.
+- `PottsSite{Q}`: a uniform integer in ``1..Q``.
+- `XYSite`: a uniform angle in ``[0, 2\pi)``.
+- `HeisenbergSite`: a uniform unit vector on ``S^2``, generated by
+  the Marsaglia (``z \sim U(-1, 1)``,
+  ``\phi \sim U(0, 2\pi)``) construction so no poles are
+  oversampled.
 
-- Worked example: how the Hamiltonian dispatch actually works when
-  A and B sublattices carry different site types (`SublatticeLayout`).
-- Heisenberg uniform sphere sampler (Marsaglia / Archimedes) and
-  why `HeisenbergSite` uses `SVector{3, Float64}`.
-- Mermin–Wagner in one paragraph and how it motivates the
-  Ising → Potts → XY → Heisenberg escalation.
-- How to build a custom site type for a bond-centered DOF
-  (dimer model, gauge link) via [`element_type`](@ref).
+## Storage types: why parameterise?
+
+Each spin flavour is parameterised on a storage type. `IsingSite{T}`
+defaults to `T = Int8` because a signed byte easily holds ``\pm 1``
+and gives 8× less memory pressure than `Int`. `XYSite{T}` defaults
+to `T = Float64`; `HeisenbergSite{T}` defaults to `SVector{3, T}`
+with `T = Float64`.
+
+The parameterisation exists because downstream MC code is often
+memory-bound on large lattices, and choosing the storage type
+per-lattice rather than per-package lets you trade memory against
+precision without forking the site type hierarchy. For a honest
+2D Ising sweep on a 1024 × 1024 lattice, `Int8` saves 3 MiB of
+resident memory per snapshot compared to `Int`, which is enough
+to fit one more observable in cache.
+
+## EmptySite and diluted models
+
+Not every site has a degree of freedom. Quenched vacancies, random
+dilution, and diluted Ising / XY / Heisenberg models all want a
+"no DOF here" site type. LatticeCore gives that a name:
+
+```julia
+struct EmptySite <: AbstractSiteType end
+state_type(::EmptySite) = Nothing
+random_state(::Any, ::EmptySite) = nothing
+```
+
+Paired with a [`SublatticeLayout`](@ref) or an
+[`ExplicitLayout`](@ref), an `EmptySite` carries zero state and
+lets the MC layer skip that index entirely. This composition —
+"an Ising site on most sites, `EmptySite` on the rest" — is the
+right way to express disorder in LatticeCore; the geometry is
+unchanged, only the content of individual sites is.
+
+## Element centering: bonds, plaquettes, and beyond
+
+A handful of models put their degrees of freedom somewhere other
+than the vertices:
+
+- **Dimer models** live on bonds. Every bond either carries a dimer
+  or doesn't.
+- **Lattice gauge theories** put gauge link variables on bonds and
+  matter fields on vertices. The two *coexist* on the same lattice.
+- **Vertex models** (ice rule, six-vertex, eight-vertex) put
+  oriented arrows on bonds with constraints at vertices.
+- **Flux / height models** put variables on plaquettes and enforce
+  rules on vertices or on bonds.
+
+LatticeCore reserves space for these without forcing them on users
+who only care about vertex-centred spins. Every
+[`AbstractSiteType`](@ref) carries an [`element_type`](@ref) trait,
+which defaults to [`VertexCenter`](@ref). A custom bond-centred
+type looks like
+
+```julia
+struct DimerVariable <: AbstractSiteType end
+LatticeCore.element_type(::DimerVariable) = BondCenter()
+LatticeCore.state_type(::DimerVariable) = Bool
+LatticeCore.random_state(rng, ::DimerVariable) = rand(rng, Bool)
+```
+
+and can be plugged into the standard [`UniformLayout`](@ref) as
+long as the MC runtime knows to read the `element_type` trait.
+For the homogeneous classical spin models that dominate this
+package's existing tests, this is invisible overhead.
+
+## Dispatch in the MC layer (preview)
+
+Classical Monte Carlo ultimately wants a method like
+
+```julia
+interaction(model, st_i::AbstractSiteType, st_j::AbstractSiteType,
+            bond::Bond, s_i, s_j) → Real
+```
+
+where `st_i` and `st_j` are the site types at each end of a bond.
+A uniform Ising model lives in the single-method world
+
+```julia
+interaction(m::IsingModel, ::IsingSite, ::IsingSite, b, s_i, s_j) =
+    -m.J * s_i * s_j
+```
+
+whereas a mixed-spin model picks out heterogeneous bonds via
+ordinary multiple dispatch
+
+```julia
+interaction(m::MixedSpinModel, ::IsingSite, ::XYSite, b, s, θ) =
+    -m.J_AB * s * cos(θ)
+```
+
+with no `if` ladders and no runtime tuple juggling. That is the
+payoff of keeping site types in a dedicated axis.
+
+## Further reading
+
+- K. Binder, *Monte Carlo Methods in Statistical Physics*,
+  Chapters on Ising, Potts, and XY models.
+- N. D. Mermin, H. Wagner, *Phys. Rev. Lett.* **17** 1133 (1966) —
+  the Mermin–Wagner theorem.
+- J. M. Kosterlitz, D. J. Thouless, *J. Phys. C* **6** 1181 (1973)
+  — the BKT transition in XY.
+- U. Wolff, *Phys. Rev. Lett.* **62** 361 (1989) — the cluster
+  algorithm used for O(N) models.

--- a/docs/src/guide/boundary.md
+++ b/docs/src/guide/boundary.md
@@ -1,43 +1,159 @@
 # Boundary conditions
 
-This guide is a work in progress. For now, see the concept column
-[Boundary conditions](../concepts/boundary_conditions.md) for the
-physics, and the [boundary API reference](../reference/boundary.md)
-for the exact signatures.
+LatticeCore describes a boundary condition as a composite of two
+things: a tuple of **axis boundary conditions** (one per spatial
+axis) and a single non-topological **modifier**. Axis BCs decide
+which candidate bonds exist; modifiers decide how existing bonds
+are weighted.
 
-## The picture
+For the physics behind the taxonomy, see the concept column
+[Boundary conditions](../concepts/boundary_conditions.md). This
+guide is the "how to use it" side.
 
-A boundary condition in LatticeCore is a composite object:
+## The composite
 
 ```julia
 LatticeBoundary(
-    axes     = (PeriodicAxis(), OpenAxis()),   # one AbstractAxisBC per axis
-    modifier = NoModifier(),                   # non-topological reweighting
+    axes     = (PeriodicAxis(), OpenAxis()),
+    modifier = NoModifier(),
 )
 ```
 
-The **axes** decide which candidate bonds exist — they wrap, clamp,
-or attach a phase to a bond that would otherwise leave the sample.
-The **modifier** decides how existing bonds are weighted (e.g.
-sine-square deformation). Splitting the two concerns this way means
-a cylinder and an SSD modification can be composed without any core
-code change.
+- `axes::NTuple{D, <:AbstractAxisBC}` — exactly one per physical
+  axis. Legal values: [`PeriodicAxis`](@ref), [`OpenAxis`](@ref),
+  [`TwistedAxis(θ)`](@ref TwistedAxis).
+- `modifier::AbstractBoundaryModifier` — defaults to
+  [`NoModifier`](@ref); [`SSD`](@ref) is the other type LatticeCore
+  currently ships.
 
-## What LatticeCore ships today
+A uniform choice is usually easier to read:
 
-- Axis BCs: [`PeriodicAxis`](@ref), [`OpenAxis`](@ref),
-  [`TwistedAxis`](@ref).
-- Modifiers: [`NoModifier`](@ref), [`SSD`](@ref) (type only; the
-  weighting rule will land with the MC layer).
-- Hooks: [`apply_axis_bc`](@ref), [`axis_phase`](@ref),
-  [`bond_weight`](@ref).
+```julia
+LatticeBoundary((PeriodicAxis(), PeriodicAxis()))    # 2D torus
+LatticeBoundary((OpenAxis(), OpenAxis()))            # 2D open sample
+```
 
-## TODO
+and the reference lattice constructors even accept a single
+`AbstractAxisBC` as shorthand, which they broadcast to every axis:
 
-- Worked cylinder example on a 3×4 square lattice, with a picture of
-  the neighbour graph.
-- How reference lattices use `apply_axis_bc` inside `neighbors`.
-- Adding a new axis BC subtype from scratch.
+```julia
+SimpleSquareLattice(3, 3, PeriodicAxis())   # 3×3 torus
+SimpleSquareLattice(3, 3, OpenAxis())       # 3×3 open sample
+```
+
+Mixed BCs have to go through `LatticeBoundary` explicitly.
+
+## Worked example: a 3×4 cylinder
+
+A cylinder is periodic along one axis and open along the other.
+Here we make a 3×4 square cylinder with PBC along `x` and OBC
+along `y`, and we read the neighbours of every site:
+
+```julia
+using LatticeCore
+
+cyl = SimpleSquareLattice(3, 4,
+    LatticeBoundary((PeriodicAxis(), OpenAxis())))
+
+for i in 1:num_sites(cyl)
+    println(i, "  →  ", neighbors(cyl, i))
+end
+```
+
+What comes out:
+
+```text
+1  →  [2, 3, 4]          # corner: +x, -x wraps to site 3, +y
+2  →  [3, 1, 5]
+3  →  [1, 2, 6]          # right edge: +x wraps to site 1
+4  →  [5, 6, 7, 1]       # interior x-edge, still boundary in y
+5  →  [6, 4, 8, 2]
+6  →  [4, 5, 9, 3]
+7  →  [8, 9, 10, 4]
+8  →  [9, 7, 11, 5]
+9  →  [7, 8, 12, 6]
+10 →  [11, 12, 7]        # top-row corner: no +y neighbour
+11 →  [12, 10, 8]
+12 →  [10, 11, 9]
+```
+
+Along ``x`` every site has exactly two neighbours (the wrap
+closes it into a 3-cycle). Along ``y`` only the interior rows
+have both neighbours; the top and bottom rows drop the
+out-of-range neighbour. This is what a cylinder looks like from
+the neighbour list.
+
+[`periodicity`](@ref) reports `Aperiodic()` for the same lattice
+because the overall structure is not fully translation-invariant,
+even though one axis wraps. If you want a predicate on a single
+axis, look directly at `cyl.boundary.axes[i]`.
+
+## Checking wrapped bond vectors
+
+PBC is subtle when you care about the displacement vector of a
+boundary-crossing bond. The reference lattices override
+[`neighbor_bonds`](@ref) so that a wrapped bond carries the
+**shortest** displacement (``\pm 1`` in each axis), not the raw
+``\mathrm{position}(j) - \mathrm{position}(i)``:
+
+```julia
+lat = SimpleSquareLattice(3, 3, PeriodicAxis())
+nb1 = collect(neighbor_bonds(lat, 1))
+
+wrap_x = first(b for b in nb1 if b.j == 3)      # wraps in x
+wrap_x.vector                                    # SVector(-1.0, 0.0)
+
+wrap_y = first(b for b in nb1 if b.j == 7)      # wraps in y
+wrap_y.vector                                    # SVector(0.0, -1.0)
+```
+
+Without the override the displacements would be `(2, 0)` and
+`(0, 2)`, which breaks bond-centred observables and SSD weights.
+If you write a custom lattice, overriding `neighbor_bonds` to emit
+the wrapped vector is the canonical thing to do.
+
+## The hook layer
+
+Every axis BC is a dispatch point for two generic functions:
+
+- [`apply_axis_bc(axis_bc, idx, L)`](@ref apply_axis_bc) —
+  returns `(wrapped, is_valid)`. The connectivity hook.
+- [`axis_phase(axis_bc, idx, L)`](@ref axis_phase) — returns a
+  `ComplexF64`. Only [`TwistedAxis`](@ref) returns a non-unit
+  phase; the classical MC code paths are free to ignore it.
+
+Modifiers dispatch through [`bond_weight(modifier, lat, i, j)`](@ref
+bond_weight). [`NoModifier`](@ref) returns `1.0` unconditionally;
+[`SSD`](@ref)'s weighting function is a stub until the MC layer
+lands a `center(lat)` accessor.
+
+## Adding a new axis BC
+
+Adding a BC kind is three short methods — you do not edit any
+existing LatticeCore file. For instance, an **anti-periodic**
+boundary (``\theta = \pi``) is just
+
+```julia
+struct AntiPeriodicAxis <: LatticeCore.AbstractAxisBC end
+
+LatticeCore.apply_axis_bc(::AntiPeriodicAxis, idx::Int, L::Int) =
+    (mod1(idx, L), true)
+
+LatticeCore.axis_phase(::AntiPeriodicAxis, idx::Int, L::Int) =
+    (idx < 1 || idx > L) ? complex(-1.0, 0.0) : complex(1.0, 0.0)
+```
+
+You can then feed it straight into `LatticeBoundary`:
+
+```julia
+LatticeBoundary((AntiPeriodicAxis(), PeriodicAxis()))
+```
+
+and every concrete lattice that walks its bonds through
+`apply_axis_bc` — including the reference square lattice — picks
+it up without any further code change. This is the extension
+mechanism the architecture assumes: one new type, one or two
+method definitions, no core edits.
 
 ## See also
 

--- a/docs/src/guide/coordinates.md
+++ b/docs/src/guide/coordinates.md
@@ -1,47 +1,204 @@
 # Coordinate systems and indexing
 
-This guide is a work in progress. See the
-[coordinate API reference](../reference/coordinates.md) and the
-[indexing reference](../reference/indexing.md) for the exact
-signatures.
+LatticeCore distinguishes two related-but-independent concerns:
 
-## Three coordinate kinds
+1. **Coordinate systems** — how a site's *position* is described.
+   A point has three natural descriptions: Cartesian real-space,
+   lattice-cell + sublattice, and higher-dimensional hyper
+   coordinates (for cut-and-project quasicrystals).
+2. **Indexing** — how a coordinate is linearised into a 1-based
+   integer site index. This is the rule that says "the A site of
+   cell (2, 3) is site number 7".
 
-LatticeCore distinguishes three ways of naming a lattice point:
+Keeping them separate means a lattice can switch its indexing
+without touching its coordinate representation, and vice versa.
 
-- [`RealSpace{D, T}`](@ref) — Cartesian coordinates, stored as an
-  `SVector{D, T}`.
-- [`LatticeCoord{D}`](@ref) — an integer cell index plus a 1-based
-  geometric sublattice id.
-- [`HigherDimCoord{DPhys, DHyper, T}`](@ref) — a point in the host
-  lattice of a cut-and-project quasicrystal.
+## The three coordinate kinds
 
-They talk to each other through [`to_real`](@ref),
-[`to_lattice`](@ref), and [`to_hyper`](@ref), all of which dispatch
-on the concrete lattice so that the conversion uses the lattice's
-basis and (if applicable) projection.
+```julia
+abstract type AbstractCoordinate{D} end
+```
 
-## Indexing is orthogonal to coordinates
+Every concrete subtype describes a point in the same ``D``-
+dimensional physical space — just in a different chart.
 
-Once you have a [`LatticeCoord`](@ref), you still need a rule for
-turning it into a 1-based site index — that is the job of the
-[`AbstractIndexing`](@ref) hierarchy. LatticeCore ships
-[`RowMajor`](@ref), [`ColMajor`](@ref), and [`Snake`](@ref) with
-exhaustive round-trip tests.
+### RealSpace
 
-Indexing is deliberately **decoupled** from coordinates: a lattice
-can switch its indexing without changing how it talks about
-positions.
+Cartesian coordinates, backed by `StaticArrays.SVector`:
 
-## TODO
+```julia
+rs = RealSpace((1.5, 2.0))          # from a Tuple
+rs = RealSpace(SVector(1.5, 2.0))   # from an SVector
+rs.x                                 # SVector{2, Float64}([1.5, 2.0])
+```
 
-- Worked example: writing a custom indexing strategy (e.g. Hilbert
-  curve) and verifying the round-trip with `site_index` /
-  `lattice_coord`.
-- When the sublattice-innermost convention is the wrong choice and
-  how to override it.
-- HigherDimCoord and the cut-and-project projection matrices for
-  Penrose / Ammann–Beenker / Fibonacci.
+`RealSpace{D, T}` is parameterised on the storage type so you can
+choose `Float32` for memory pressure or `BigFloat` for precision.
+
+### LatticeCoord
+
+Integer cell index plus a 1-based **geometric** sublattice id:
+
+```julia
+lc = LatticeCoord((3, 4))           # sublattice defaults to 1
+lc = LatticeCoord((3, 4), 2)        # explicit sublattice (B site)
+lc.cell         # (3, 4)
+lc.sublattice   # 2
+```
+
+The sublattice field is **geometric** — where in the unit cell the
+site sits — not physical. A honeycomb A/B distinction uses this
+field; a mixed-spin Ising-on-A / XY-on-B model separately uses
+[`SublatticeLayout`](@ref) to attach site types to these sublattices.
+See [Site types and layouts](site_type.md).
+
+### HigherDimCoord
+
+For cut-and-project quasicrystals, the natural description of a
+point is as a lattice point in a *higher*-dimensional host
+lattice:
+
+```julia
+h = HigherDimCoord{2}(SVector(1.0, 2.0, 3.0, 4.0, 5.0))   # Penrose: 5D → 2D
+h isa HigherDimCoord{2, 5, Float64}   # true
+```
+
+`DPhys` (the first type parameter) is the physical dimension;
+`DHyper` is the host-lattice dimension. The projection from
+`DHyper` to `DPhys` is the lattice's responsibility — it lives in
+the quasicrystal implementation, not in the coordinate type.
+
+## Conversions
+
+All three kinds talk to each other through three generic
+functions, each dispatched on the concrete lattice type:
+
+```julia
+to_real(lat, coord)     # → RealSpace
+to_lattice(lat, coord)  # → LatticeCoord
+to_hyper(lat, coord)    # → HigherDimCoord
+```
+
+Example on the reference square lattice:
+
+```julia
+lat = SimpleSquareLattice(3, 3)
+
+rs = to_real(lat, LatticeCoord((2, 3)))
+rs.x                                    # SVector(2.0, 3.0)
+
+lc = to_lattice(lat, RealSpace((2.0, 3.0)))
+lc.cell                                 # (2, 3)
+lc.sublattice                           # 1
+
+# Round-trip
+to_lattice(lat, to_real(lat, LatticeCoord((2, 3))))
+# → LatticeCoord((2, 3), 1)
+```
+
+Identity conversions are defined for every coordinate kind, so
+you can call `to_real(lat, coord)` blindly even if `coord` is
+already a `RealSpace` — it will be returned unchanged.
+
+For lattices that do not live in a higher-dimensional host (every
+periodic lattice), `to_hyper` simply is not defined and calling it
+will raise `MethodError`. The reciprocal is also true: a
+quasicrystal may not implement `to_lattice(lat, ::RealSpace)` if
+the map is not unique.
+
+## Indexing strategies
+
+LatticeCore ships three indexings out of the box, all under
+[`AbstractIndexing`](@ref):
+
+- [`RowMajor`](@ref) — C-style. `x` is the fast axis within a row.
+- [`ColMajor`](@ref) — Fortran-style. `y` is the fast axis.
+- [`Snake`](@ref) — row-major but with alternating row direction.
+
+Each ships with `site_index` and `lattice_coord` methods for 1D
+and 2D. The sublattice is the **innermost** index, so `nsub = 1`
+reduces to the usual single-sublattice formulas and can be read
+at a glance.
+
+### RowMajor on a 3 × 2 lattice
+
+```julia
+# Layout:
+#   row y=1:  sites 1 2 3
+#   row y=2:  sites 4 5 6
+site_index(RowMajor(), (3, 2), 1, LatticeCoord((1, 1)))   # 1
+site_index(RowMajor(), (3, 2), 1, LatticeCoord((3, 1)))   # 3
+site_index(RowMajor(), (3, 2), 1, LatticeCoord((1, 2)))   # 4
+site_index(RowMajor(), (3, 2), 1, LatticeCoord((3, 2)))   # 6
+
+lattice_coord(RowMajor(), (3, 2), 1, 4).cell   # (1, 2)
+```
+
+### ColMajor on the same dims
+
+```julia
+# Layout:
+#   col x=1:  sites 1 2
+#   col x=2:  sites 3 4
+#   col x=3:  sites 5 6
+site_index(ColMajor(), (3, 2), 1, LatticeCoord((1, 1)))   # 1
+site_index(ColMajor(), (3, 2), 1, LatticeCoord((1, 2)))   # 2
+site_index(ColMajor(), (3, 2), 1, LatticeCoord((2, 1)))   # 3
+```
+
+### Snake
+
+Row-major with every second row walked backwards. For a 3 × 3
+snake, the cell index inside each row is flipped when `y` is
+even:
+
+```text
+y = 1 (forward):   1 2 3
+y = 2 (reverse):   6 5 4
+y = 3 (forward):   7 8 9
+```
+
+```julia
+site_index(Snake(), (3, 3), 1, LatticeCoord((1, 1)))   # 1
+site_index(Snake(), (3, 3), 1, LatticeCoord((3, 2)))   # 4
+site_index(Snake(), (3, 3), 1, LatticeCoord((1, 2)))   # 6
+```
+
+Snake is useful when physical adjacency between neighbouring
+indices matters — serialisation layouts, cache-friendly sweeps,
+some SIMD-friendly scheduling tricks.
+
+## Round-trip correctness
+
+`site_index` and `lattice_coord` are **exact inverses** for
+every indexing: the LatticeCore test suite runs an exhaustive
+check for every `(indexing, dims, nsub)` combination, hitting
+every site index exactly once. That is the contract for every new
+indexing you might write.
+
+## Adding a custom indexing
+
+Adding a new indexing strategy is two method definitions:
+
+```julia
+struct HilbertOrder <: LatticeCore.AbstractIndexing end
+
+function LatticeCore.site_index(
+    ::HilbertOrder, dims::NTuple{2, Int}, nsub::Int, coord::LatticeCoord{2}
+)
+    # ... map (cx, cy) into Hilbert curve coordinate, then a 1-based index ...
+end
+
+function LatticeCore.lattice_coord(
+    ::HilbertOrder, dims::NTuple{2, Int}, nsub::Int, i::Int
+)
+    # ... inverse Hilbert curve map ...
+end
+```
+
+Once those are in place, any lattice that routes its cell
+bookkeeping through `site_index` / `lattice_coord` can switch
+indexing strategies by instance.
 
 ## See also
 

--- a/docs/src/guide/lazy_infinite.md
+++ b/docs/src/guide/lazy_infinite.md
@@ -1,54 +1,140 @@
 # Lazy / infinite lattices
 
-This guide is a work in progress. See the concept column
-[Quasiperiodic order](../concepts/quasiperiodic_order.md) for the
-physical motivation.
+LatticeCore has two small hooks for working with lattices that are
+conceptually infinite, or that need to be materialised at a chosen
+cutoff before use:
+
+- [`materialize`](@ref) — an infinite-abstract-to-finite-lattice
+  generic function.
+- [`require_finite`](@ref) — a guard that throws if a lattice is
+  not finite.
+
+Together with the size trait hierarchy (see
+[Traits reference](../reference/traits.md)), they cover the
+lattice-side half of chapter 06 of the architecture notes. The
+concept-side story lives in
+[Quasiperiodic order](../concepts/quasiperiodic_order.md).
 
 ## Size traits
 
-LatticeCore describes the extent of a lattice through an
-[`AbstractSizeTrait`](@ref) value attached to every concrete lattice
-via [`size_trait`](@ref):
+Every `AbstractLattice` advertises its extent through
+[`size_trait(lat)`](@ref), which returns one of:
 
-- [`FiniteSize`](@ref) — ordinary finite lattice. MC is safe.
-- [`InfiniteSize`](@ref) — conceptually infinite. MC is *not* safe;
-  use the lattice only for spectral / analytic work.
-- [`QuasiInfiniteSize`](@ref) — conceptually infinite but expected
-  to be materialised at a cutoff before use.
+- [`FiniteSize{D}`](@ref) — an ordinary finite lattice with
+  known per-axis cell counts. Safe for Monte Carlo.
+- [`InfiniteSize`](@ref) — a lattice that is infinite in the
+  honest sense. You can compute with it spectrally (tight binding
+  on a translationally invariant chain, for instance), but you
+  cannot run a Monte Carlo sweep on it.
+- [`QuasiInfiniteSize{T}`](@ref) — infinite in principle, meant
+  to be lowered to a finite lattice through
+  [`materialize`](@ref) before being consumed. `T` is the
+  numeric type of the cutoff parameter.
 
-[`is_finite(lat)`](@ref) is a one-liner derived from this trait and
-is the predicate Monte Carlo algorithms should guard on.
+The predicate [`is_finite(lat)`](@ref) is a one-liner derived
+from this trait:
 
-## The infinite-abstract → finite-materialisation pattern
+```julia
+is_finite(lat) = size_trait(lat) isa FiniteSize
+```
 
-LatticeCore ships two small hooks for this pattern:
+Reference lattices always return a `FiniteSize`, so
+`is_finite(LineLattice(5))` and
+`is_finite(SimpleSquareLattice(3, 3))` are both `true`.
 
-- [`materialize(abstract; kwargs...)`](@ref materialize) — a generic
-  function with **no typed supertype**. A package that defines an
-  "infinite abstract" type (e.g. `InfiniteFibonacci`) adds a
-  method for it that returns a `FiniteSize` concrete lattice.
-- [`require_finite(lat)`](@ref require_finite) — an assertion guard
-  that MC entry points should call:
+## Guarding Monte Carlo entry points
+
+Monte Carlo algorithms walk every site, so running them on a
+non-finite lattice is a bug. The canonical guard is
+[`require_finite(lat)`](@ref), which throws `ArgumentError` if
+[`is_finite`](@ref) is false:
 
 ```julia
 function run!(rng, state, lat::AbstractLattice, model, alg; kwargs...)
     require_finite(lat)
-    # ... safe from here ...
+    # ... safe to iterate 1:num_sites(lat) from here ...
 end
 ```
 
-This pattern mirrors the momentum-space counterpart:
-[`HyperReciprocalLattice`](@ref) is the "infinite abstract" that
-becomes a finite [`BraggPeakSet`](@ref) at a cutoff.
+The error message mentions the offending lattice's `size_trait`
+and hints at `materialize`, so a user who passes an infinite
+abstract lattice by mistake gets a pointer to the fix.
 
-## TODO
+## The infinite-abstract → finite-materialisation pattern
 
-- Example: a custom `InfiniteChain` type + matching `materialize`
-  that produces a `LineLattice` at a chosen depth.
-- When real on-demand laziness (as opposed to materialisation)
-  makes sense, and the open design questions around it.
+The pattern LatticeCore encourages for any "infinite" structure is
+to keep the abstract description as its own type and implement a
+method of [`materialize`](@ref) that turns it into a `FiniteSize`
+lattice. `materialize` is a generic function with **no typed
+supertype**, so packages can plug in without inheriting from a
+LatticeCore hierarchy.
+
+A minimal example for a hypothetical infinite Fibonacci chain:
+
+```julia
+struct InfiniteFibonacci
+    rules::Dict{Char, String}
+    axiom::Char
+end
+
+function LatticeCore.materialize(inf::InfiniteFibonacci; depth::Int)
+    word = inf.axiom |> Ref |> string    # start from the axiom
+    for _ in 1:depth
+        word = join(get(inf.rules, c, string(c)) for c in word)
+    end
+    n = length(word)                     # number of physical sites
+    return LineLattice(n, PeriodicAxis())   # returns a FiniteSize lattice
+end
+```
+
+The user's code then looks like
+
+```julia
+inf = InfiniteFibonacci(Dict('L' => "LS", 'S' => "L"), 'L')
+lat = materialize(inf; depth = 10)         # LineLattice{Float64, ...}
+require_finite(lat)                         # safe
+
+run!(Random.default_rng(), initial_state(lat), lat, model, alg)
+```
+
+The same pattern applies in reciprocal space:
+[`HyperReciprocalLattice`](@ref) is the "infinite abstract"
+description of a cut-and-project quasicrystal's Fourier module,
+and [`BraggPeakSet`](@ref) is its finite materialisation at a
+cutoff. Both patterns are two halves of the same design rule:
+infinite structures live as abstract types; finite slices of them
+are subtypes of the main lattice hierarchy.
+
+## Cutoff conventions
+
+The cutoff keyword argument is **implementation-defined**. You
+can make it anything that parameterises your structure, as long
+as you document it clearly. Common choices:
+
+- `depth::Int` — substitution depth (Fibonacci, L-system).
+- `radius::Real` — spatial radius (Penrose cut-and-project).
+- `dims::NTuple{D, Int}` — explicit per-axis sizes (generic
+  rectangular sampling).
+
+`materialize` is just a stable name; the semantics belong to each
+concrete infinite abstract type.
+
+## Unhandled cases
+
+`materialize` has **no default implementation**, so calling it on
+a type that has not specialised it raises `MethodError`:
+
+```julia
+materialize("not an infinite lattice"; depth = 1)   # MethodError
+```
+
+That is a deliberate choice: a default fallback would either
+silently succeed (dangerous) or always fail with a misleading
+error. `MethodError` tells the user exactly which type needs a
+new method.
 
 ## See also
 
 - [Concepts: Quasiperiodic order](../concepts/quasiperiodic_order.md)
 - [Reference: Lazy / infinite](../reference/lazy_infinite.md)
+- [Reference: Traits](../reference/traits.md) — size traits

--- a/docs/src/guide/momentum.md
+++ b/docs/src/guide/momentum.md
@@ -1,34 +1,103 @@
 # Momentum space
 
-This guide is a work in progress. See the concept column
-[Reciprocal lattice and Brillouin zone](../concepts/reciprocal_and_brillouin.md)
-for the mathematical background.
+LatticeCore's momentum-space layer is designed to be usable
+*without* thinking about whether your lattice is periodic or
+quasiperiodic. A periodic lattice produces a
+[`PeriodicMomentumLattice`](@ref); a quasicrystal produces a
+[`BraggPeakSet`](@ref). Both subtype
+[`AbstractMomentumLattice`](@ref), and both are themselves
+`AbstractLattice{D, T}` — so every observable that walks
+`num_sites` / `position` on a real-space lattice transparently
+walks `num_k_points` / `k_point` on a momentum lattice.
 
-## AbstractMomentumLattice
+For the physics background, see
+[Reciprocal lattice and Brillouin zone](../concepts/reciprocal_and_brillouin.md).
 
-k-space is modelled as a subtype of
-[`AbstractMomentumLattice{D, T}`](@ref), which itself inherits from
-`AbstractLattice{D, T}`. This means the `num_sites`, `position`,
-trait, and test-suite infrastructure written for real-space
-lattices **also** applies to k-space lattices — k-points are
-"sites" and k-vectors are "positions".
+## The trait-dispatched entry point
 
-## Two concrete subtypes
+Any `AbstractLattice` declares its k-space capability through the
+[`reciprocal_support`](@ref) trait:
 
-- [`PeriodicMomentumLattice`](@ref) — eager k-point list built
-  from a Bravais reciprocal basis. Constructed via
-  [`monkhorst_pack`](@ref) or [`gamma_centered`](@ref).
-- [`BraggPeakSet`](@ref) — the quasicrystal counterpart. Same
-  `AbstractMomentumLattice` interface, so the same
-  [`structure_factor`](@ref) code paths work for both.
-
-## Entry points
-
-- [`reciprocal_lattice(lat)`](@ref) — periodic-only.
-- [`fourier_module(lat)`](@ref) — quasicrystal-only (lives in
+- [`HasReciprocal`](@ref) — Bravais reciprocal lattice available;
+  call [`reciprocal_lattice(lat)`](@ref).
+- [`HasFourierModule`](@ref) — a cut-and-project quasicrystal,
+  call [`fourier_module(lat)`](@ref) (implemented in
   `QuasiCrystal.jl`).
-- [`momentum_lattice(lat)`](@ref) — trait-dispatched: picks the
-  right one via [`reciprocal_support`](@ref).
+- [`NoReciprocal`](@ref) — no k-space representation.
+
+The unified helper is [`momentum_lattice(lat)`](@ref), which
+dispatches on the trait and throws `ArgumentError` for
+`NoReciprocal`:
+
+```julia
+lat = SimpleSquareLattice(4, 4, PeriodicAxis())
+reciprocal_support(lat)      # HasReciprocal()
+ml = momentum_lattice(lat)   # PeriodicMomentumLattice{2, Float64}
+
+obc = SimpleSquareLattice(4, 4, OpenAxis())
+reciprocal_support(obc)      # NoReciprocal()
+momentum_lattice(obc)        # throws ArgumentError
+```
+
+For a periodic lattice, `momentum_lattice` returns the same object
+as `reciprocal_lattice(lat)`.
+
+## Building a mesh from a basis
+
+If you know the reciprocal basis and you want to sample the BZ
+directly, use [`monkhorst_pack`](@ref) or [`gamma_centered`](@ref).
+
+```julia
+using StaticArrays
+B = SMatrix{2, 2, Float64}(2π, 0.0,
+                           0.0, 2π)
+
+mp = monkhorst_pack(B, (4, 4))          # 16 Monkhorst–Pack k-points
+mp isa PeriodicMomentumLattice{2, Float64}
+
+γ = gamma_centered(B, (4, 4))           # 16 Γ-inclusive k-points
+```
+
+Both return a `PeriodicMomentumLattice{D, T}` that behaves like
+any other lattice: `num_sites(mp)` is 16, `position(mp, 1)` is a
+k-vector, and `boundary(mp)` is a uniform periodic wrap (k-space
+repeats modulo the reciprocal basis).
+
+The difference between the two is where the mesh sits relative
+to Γ:
+
+- `gamma_centered((3, 3))` produces fractions `{0, 1/3, 2/3}` on
+  each axis — Γ is one of the sampled points.
+- `monkhorst_pack((3, 3))` produces fractions
+  `{(n + 0.5)/3 - 0.5} = {-1/3, 0, 1/3}` — the mesh is centred on
+  Γ but offset by half a step, which is the convention
+  solid-state codes use when integrating smooth functions over
+  the BZ.
+
+## Reference-lattice reciprocals
+
+`LineLattice` and `SimpleSquareLattice` both implement
+[`basis_vectors`](@ref) (the unit-spacing identity) and
+[`reciprocal_lattice`](@ref), which constructs
+``B = 2\pi A^{-\top}`` and feeds it through `monkhorst_pack`. On a
+square lattice that gives you ``B = 2\pi \, \mathrm{I}_2`` and a
+mesh whose density matches the real-space sample:
+
+```julia
+lat = SimpleSquareLattice(4, 4, PeriodicAxis())
+A = basis_vectors(lat)                   # SMatrix{2, 2, Float64}(1, 0, 0, 1)
+ml = reciprocal_lattice(lat)
+B = reciprocal_basis(ml)                  # 2π * I
+
+# Orthogonality: a_i · b_j = 2π δ_ij
+using LinearAlgebra
+[dot(A[:, i], B[:, j]) for i in 1:2, j in 1:2]
+# → [2π 0; 0 2π]
+```
+
+Non-periodic boundaries (OBC or cylinders) throw
+`ArgumentError` from `reciprocal_lattice`, matching the
+`reciprocal_support` trait.
 
 ## Structure factor
 
@@ -39,17 +108,84 @@ S(\mathbf{k}) = \frac{1}{N}\,
     \left| \sum_i s_i \, e^{-i \mathbf{k} \cdot \mathbf{r}_i} \right|^2
 ```
 
-naively in O(N) per k. FFT-based specialisations can be added
+for a scalar configuration `state`. The implementation is naive
+O(N) per k-point; FFT-based specialisations can be added later
 without changing the API.
 
-## TODO
+Three canonical checks:
 
-- End-to-end example: compute `S(π, π)` on a 16×16 PBC square for
-  the Néel configuration.
-- How to sample a k-path (high-symmetry lines) once that lands.
-- When to use `monkhorst_pack` vs `gamma_centered`.
+### Ferromagnet: S(0) = N
+
+```julia
+lat = SimpleSquareLattice(4, 4, PeriodicAxis())
+state = ones(Int8, num_sites(lat))
+structure_factor(lat, state, SVector(0.0, 0.0))   # 16.0
+```
+
+### Ferromagnet vanishes at BZ-interior k
+
+```julia
+# k = (π/2, 0) is inside the BZ, so Σ_x exp(-i(π/2)x) = 0 for x=1..4
+structure_factor(lat, state, SVector(π / 2, 0.0))  # ≈ 0
+```
+
+Note that `S` does **not** vanish at `(2π, 0)` — that is a
+reciprocal-lattice vector, hence Γ-equivalent, and the
+ferromagnetic signal concentrates there too.
+
+### Néel antiferromagnet: S(π, π) = N
+
+```julia
+lat = SimpleSquareLattice(4, 4, PeriodicAxis())
+N = num_sites(lat)
+neel = Int8[
+    (-1)^(Int(position(lat, i)[1]) + Int(position(lat, i)[2]))
+    for i in 1:N
+]
+
+structure_factor(lat, neel, SVector(π, π))    # 16.0
+structure_factor(lat, neel, SVector(0.0, 0.0)) # ≈ 0
+```
+
+Bipartiteness is exactly the condition that this momentum lies
+on the reciprocal lattice of the sample; the 4 × 4 square is
+bipartite (both axes even), so the signal is clean.
+
+## Sweeping a whole momentum lattice
+
+You can pass a momentum lattice in place of a single k-vector and
+LatticeCore will evaluate the structure factor at every k-point
+in the mesh:
+
+```julia
+ml = reciprocal_lattice(lat)
+Sks = structure_factor(lat, neel, ml)        # Vector{Float64}, length num_sites(ml)
+argmax(Sks)                                   # the k-index where the peak lives
+```
+
+The result is a plain `Vector{Float64}` of the same length as
+`num_k_points(ml)`, indexed the same way as `k_point(ml, i)`.
+
+## Quasicrystal Fourier modules (preview)
+
+Everything above generalises: a [`BraggPeakSet`](@ref) subtypes
+[`AbstractMomentumLattice`](@ref), exposes
+`num_k_points(bps) = length(bps.peaks)`, and answers
+`position(bps, i) = bps.peaks[i]`. That means the *same*
+`structure_factor(lat, state, ml)` code path works for a
+quasicrystal — there is no "quasi" branch in the observer. You
+iterate over the Bragg peaks and each one returns a plain
+`Float64`.
+
+The generation algorithm — choosing an acceptance window, walking
+the higher-dimensional reciprocal lattice, computing the window
+Fourier transform — lives in `QuasiCrystal.jl`, not here.
+LatticeCore ships the type skeletons
+[`HyperReciprocalLattice`](@ref) and [`AcceptanceWindow`](@ref)
+so downstream packages have a stable interface to target.
 
 ## See also
 
-- [Concepts: Reciprocal lattice](../concepts/reciprocal_and_brillouin.md)
+- [Concepts: Reciprocal lattice and Brillouin zone](../concepts/reciprocal_and_brillouin.md)
+- [Concepts: Quasiperiodic order](../concepts/quasiperiodic_order.md)
 - [Reference: Momentum space](../reference/momentum.md)

--- a/docs/src/guide/site_type.md
+++ b/docs/src/guide/site_type.md
@@ -1,55 +1,202 @@
 # Site types and layouts
 
-This guide is a work in progress. See the concept column
-[Site types and spin models](../concepts/site_types_and_spins.md)
-for the physics.
+A **site type** is a value-level description of the physical
+degree of freedom living on a lattice site. A **site layout** is
+how those site types are stored per-lattice. LatticeCore keeps the
+two concerns distinct from the *geometric* sublattice
+(`LatticeCoord.sublattice`) so mixed-spin and diluted models
+compose naturally.
 
-## Site type ≠ sublattice
+For the physics behind the taxonomy, see the concept column
+[Site types and spin models](../concepts/site_types_and_spins.md).
 
-LatticeCore separates two ideas that are traditionally conflated:
+## The built-in site types
 
-- **Geometric sublattice** — where inside a unit cell the site
-  sits (A, B, C, ...). Stored in `LatticeCoord.sublattice`.
-- **Site type** — what physical degree of freedom lives on the
-  site (Ising spin, XY rotor, Heisenberg vector, ...). Described
-  by [`AbstractSiteType`](@ref) and stored via an
-  [`AbstractSiteLayout`](@ref).
+All of the classical spin flavours are available out of the box:
 
-These axes are orthogonal: the same geometric sublattice can host
-any site type, and the same site type can sit on any sublattice.
+| Site type                | State                    | Default storage     |
+| ------------------------ | ------------------------ | ------------------- |
+| [`IsingSite`](@ref)      | ``\pm 1``                | `Int8`              |
+| [`PottsSite{Q}`](@ref)   | `1..Q`                   | `Int8`              |
+| [`XYSite`](@ref)         | angle in `[0, 2π)`       | `Float64`           |
+| [`HeisenbergSite`](@ref) | unit vector on ``S^2``   | `SVector{3, Float64}` |
+| [`EmptySite`](@ref)      | `Nothing`                | `Nothing`           |
 
-## Three layouts
+Each one is constructed by calling the struct with no arguments
+for the default storage type:
 
-| Layout                         | When to use                                |
-| ------------------------------ | ------------------------------------------ |
-| [`UniformLayout`](@ref)        | Every site has the same type (most models) |
-| [`SublatticeLayout`](@ref)     | Mixed-spin: A = Ising, B = XY, ...         |
-| [`ExplicitLayout`](@ref)       | Per-site heterogeneity (quenched disorder) |
+```julia
+IsingSite()           # IsingSite{Int8}()
+IsingSite{Int}()      # Int storage (more memory, wider range)
 
-`UniformLayout` has zero per-site memory overhead and lets the MC
-hot loop constant-fold the site type.
+PottsSite(3)          # 3-state Potts, Int8 storage
+XYSite()              # Float64 angle
+HeisenbergSite()      # SVector{3, Float64} unit vector
+EmptySite()           # vacancy
+```
 
-## Built-in site types
+The required interface on every site type is
 
-[`IsingSite`](@ref), [`PottsSite{Q}`](@ref), [`XYSite`](@ref),
-[`HeisenbergSite`](@ref), [`EmptySite`](@ref) — see the
-[site type reference](../reference/site_type.md) for
-`state_type` / `random_state` / `domain` of each.
+```julia
+state_type(st)                  # the Julia type storing one state
+random_state(rng, st)           # uniform sampler for initialisation
+```
+
+plus the optional
+
+```julia
+zero_state(st)      # canonical zero state, if meaningful
+domain(st)          # finite iterator over the state space, for discrete types
+```
+
+and the element-centering trait
+
+```julia
+element_type(st)    # default VertexCenter()
+```
+
+which is covered in more detail below.
+
+## Picking a layout
+
+Sites with site types are stored in the lattice's
+[`AbstractSiteLayout`](@ref). Three concrete layouts ship:
+
+### UniformLayout — every site the same
+
+```julia
+sq = SimpleSquareLattice(4, 4)                 # defaults to IsingSite
+site_layout(sq)                                # UniformLayout{IsingSite{Int8}}
+site_type(sq, 1) === site_type(sq, 16)         # true
+
+# Swap in a different site type via the keyword argument
+heis = SimpleSquareLattice(4, 4; layout = UniformLayout(HeisenbergSite()))
+site_type(heis, 1)                              # HeisenbergSite{Float64}()
+```
+
+`UniformLayout` has **zero per-site memory overhead** — the single
+site type is stored once on the lattice, so the MC hot loop can
+treat `site_type(lat, i)` as a loop-invariant and constant-fold it.
+This is the layout you want for homogeneous Ising / XY / Heisenberg
+models, i.e. the overwhelming majority.
+
+### SublatticeLayout — one site type per geometric sublattice
+
+```julia
+# 6 sites with the A/B/A/B/A/B pattern of a chain
+mixed = SublatticeLayout(
+    (IsingSite(), XYSite()),      # per-sublattice site types
+    [1, 2, 1, 2, 1, 2],           # sublattice id of each site
+)
+
+site_type(mixed, 1) isa IsingSite   # true
+site_type(mixed, 2) isa XYSite      # true
+site_type(mixed, 5) isa IsingSite   # true
+```
+
+The first field is an `NTuple` of site type instances, one per
+geometric sublattice. The second is a `Vector{Int}` mapping every
+site index to its sublattice id. Downstream code can then write
+polymorphic interactions:
+
+```julia
+interaction(m::MixedSpinModel, ::IsingSite, ::XYSite, bond, s, θ) =
+    -m.J_AB * s * cos(θ)
+```
+
+and the multiple-dispatch mechanism picks out every A–B bond
+automatically.
+
+### ExplicitLayout — quenched per-site heterogeneity
+
+```julia
+types = AbstractSiteType[IsingSite(), IsingSite(), XYSite(), HeisenbergSite()]
+disorder = ExplicitLayout(types)
+
+site_type(disorder, 1) isa IsingSite       # true
+site_type(disorder, 3) isa XYSite          # true
+site_type(disorder, 4) isa HeisenbergSite  # true
+```
+
+`ExplicitLayout` stores one site type per site, which is the right
+representation for quenched disorder, defect models, or any
+configuration where the pattern cannot factor through a small
+sublattice tuple. The per-site storage cost is the trade-off.
+
+## A custom site type from scratch
+
+Custom site types are what you add when the existing flavours do
+not fit — for instance, a Blume–Capel spin (``S = 1``), a
+``U(1)`` clock rotor, a Kitaev bond variable, or a dimer variable.
+The required steps are
+
+1. Define a subtype of [`AbstractSiteType`](@ref).
+2. Implement `state_type` and `random_state`.
+3. (Optional) implement `zero_state`, `domain`, `element_type`.
+
+A three-state Blume–Capel example:
+
+```julia
+using Random
+
+struct BlumeCapelSite <: LatticeCore.AbstractSiteType end
+
+LatticeCore.state_type(::BlumeCapelSite) = Int8
+LatticeCore.random_state(rng, ::BlumeCapelSite) =
+    Int8(rand(rng, (-1, 0, 1)))
+LatticeCore.zero_state(::BlumeCapelSite) = Int8(0)
+LatticeCore.domain(::BlumeCapelSite) = (Int8(-1), Int8(0), Int8(1))
+```
+
+It plugs straight into the existing layouts:
+
+```julia
+lat = SimpleSquareLattice(4, 4; layout = UniformLayout(BlumeCapelSite()))
+site_type(lat, 1) isa BlumeCapelSite     # true
+```
 
 ## Element centering
 
-The [`element_type`](@ref) trait lets a site type declare that its
-DOF lives on a [`BondCenter`](@ref), [`PlaquetteCenter`](@ref), or
-[`CellCenter`](@ref) rather than the default
-[`VertexCenter`](@ref). This reserves headroom for dimer variables,
-gauge links, and flux fields without a breaking rewrite.
+Every `AbstractSiteType` carries an `element_type` trait declaring
+where its DOF lives. The default is [`VertexCenter`](@ref), but
+bond / plaquette / cell-centered variables are first-class through
+this trait:
 
-## TODO
+```julia
+struct DimerVariable <: LatticeCore.AbstractSiteType end
+LatticeCore.element_type(::DimerVariable) = BondCenter()
+LatticeCore.state_type(::DimerVariable) = Bool
+LatticeCore.random_state(rng, ::DimerVariable) = rand(rng, Bool)
+```
 
-- Mixed-spin example end-to-end: build a honeycomb with Ising A /
-  XY B, then compute `site_type(lat, i)` for each i.
-- Custom site type tutorial: add a bond-centered dimer variable.
-- Integration with Monte Carlo models in `Lattice2DMonteCarlo.jl`.
+A downstream Monte Carlo layer that wants to know whether a site
+type lives on a vertex or a bond asks `element_type(st)`. For the
+homogeneous classical spin models that currently dominate the
+LatticeCore test suite, this trait returns `VertexCenter()` and
+every code path ignores it, so adding a bond-centered type does
+not bloat vertex-only code.
+
+See [Concepts: Quasiperiodic order](../concepts/quasiperiodic_order.md)
+for why this matters when you start thinking about dimer models,
+gauge theories, and flux variables.
+
+## Querying a lattice
+
+Three accessors on `AbstractLattice` let downstream code read the
+site structure of a lattice:
+
+```julia
+site_layout(lat)              # AbstractSiteLayout
+site_type(lat, i)             # AbstractSiteType at site i
+num_sublattices(lat)          # Int, defaults to 1
+sublattice(lat, i)            # geometric sublattice id, defaults to 1
+```
+
+The default implementations of `site_type(lat, i)` delegate to
+`site_layout(lat)`, so a concrete lattice only needs to implement
+`site_layout` to get everything for free. `num_sublattices` and
+`sublattice` default to `1` — lattices with non-trivial geometric
+sublattices (honeycomb, kagome, Lieb) override them.
 
 ## See also
 


### PR DESCRIPTION
## Description

Completes the documentation skeletons left by PR #9, bringing **every narrative page** in LatticeCore's documentation to a fully-written state. After this PR the site has Home, Getting Started, **5 concept columns**, **6 guide chapters**, 12 `@docs`-backed API reference pages, and a design-notes summary, all building cleanly.

With this PR **LatticeCore is feature- and docs-complete at the package level.** Subsequent work shifts downstream: migrate `Lattice2D.jl` and `QuasiCrystal.jl` onto the new interface, and follow up on `Lattice2DMonteCarlo`'s type updates.

Fixed: (no linked issue)

## Type of Change

- [ ] ✨ Feature
- [ ] 🐛 Bug Fix
- [ ] ⚡ Performance
- [x] 📖 Documentation
- [ ] 🧰 Maintenance

## Proposed Changes

### Concepts (skeleton → full column)

- **`concepts/boundary_conditions.md`** — the physics of finite-size BCs, periodic / open / cylinder / twisted with explicit discussion of surface modes, flux quantisation (Byers–Yang), and per-axis composition. Adds a section on the SSD modifier and why it lives outside the axis tuple. References Binder–Heermann, Schollwöck (DMRG review), Gendiar–Krčmář–Nishino (SSD), Byers–Yang.
- **`concepts/site_types_and_spins.md`** — the classical spin ladder (Ising → Potts → XY → Heisenberg), Mermin–Wagner, Wolff cluster algorithms, why site type and geometric sublattice are separate axes, element centering for bond / plaquette / cell DOFs.
- **`concepts/quasiperiodic_order.md`** — cut-and-project, Fibonacci chain with the golden-ratio substitution matrix, Penrose and Ammann–Beenker, Fourier module density, window Fourier transform giving Bragg peak intensities, the finite `BraggPeakSet` cutoff. References Shechtman, Senechal, Baake–Grimm, de Bruijn.

### Guide (skeleton → walkthroughs with examples)

- **`guide/boundary.md`** — worked cylinder example on a 3×4 square with explicit neighbour listings, wrapped bond-vector check, `apply_axis_bc` / `axis_phase` / `bond_weight` hooks, and a three-method recipe for adding a custom `AntiPeriodicAxis`.
- **`guide/coordinates.md`** — `RealSpace` / `LatticeCoord` / `HigherDimCoord` construction, `to_real` / `to_lattice` / `to_hyper` conversions, `RowMajor` / `ColMajor` / `Snake` examples on 3×2 and 3×3 lattices, round-trip correctness contract, and a template for a custom `HilbertOrder` strategy.
- **`guide/site_type.md`** — built-in site type table with default storage types, `UniformLayout` / `SublatticeLayout` / `ExplicitLayout` concrete examples, a Blume–Capel custom site type tutorial, element centering via a bond-centered `DimerVariable`, and the four accessor methods on `AbstractLattice`.
- **`guide/momentum.md`** — trait-dispatched `momentum_lattice` entry point, `monkhorst_pack` vs `gamma_centered` comparison, orthogonality check `a_i · b_j = 2π δ_ij`, three canonical structure-factor sanity checks (ferromagnet `S(0) = N`, BZ-interior vanishing, Néel `S(π, π) = N`), sweeping a whole momentum lattice, and a `BraggPeakSet` preview.
- **`guide/lazy_infinite.md`** — size-trait walk-through, `require_finite` as an MC guard with a runnable `run!` example, the infinite-abstract → `materialize` pattern with a worked `InfiniteFibonacci` example, cutoff convention guidance, and the intentional lack of a `materialize` default.

## Tests and build

- Package tests: **771 / 771 pass**.
- Docs build: **clean**, no broken `@ref` or `@docs` references.

## `Project.toml`: `0.7.1` → `0.7.2` (docs-only patch)

## check list
- [x] test駆動をしたか — local docs build + full package test suite