### PR TITLE
feat: LatticeCorePlotsExt — generic plot_lattice(::AbstractLattice)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,19 +1,27 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.7.3"
+version = "0.8.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
+[weakdeps]
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+
+[extensions]
+LatticeCorePlotsExt = "Plots"
+
 [compat]
+Plots = "1"
 StaticArrays = "1"
 julia = "1.10"
 
 [extras]
+Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Random", "Test"]
+test = ["Plots", "Random", "Test"]

--- a/ext/LatticeCorePlotsExt.jl
+++ b/ext/LatticeCorePlotsExt.jl
@@ -1,0 +1,160 @@
+module LatticeCorePlotsExt
+
+using LatticeCore
+using LinearAlgebra
+using Plots
+
+# ---- Common helpers --------------------------------------------------
+
+"""
+    _site_xy(lat) → (xs, ys)
+
+Collect the x and y coordinates of every site as a pair of
+`Vector{Float64}`. 1D lattices get `ys = zeros(N)`.
+"""
+function _site_xy(lat::LatticeCore.AbstractLattice{1})
+    N = num_sites(lat)
+    xs = [Float64(position(lat, i)[1]) for i in 1:N]
+    ys = zeros(N)
+    return xs, ys
+end
+
+function _site_xy(lat::LatticeCore.AbstractLattice{2})
+    N = num_sites(lat)
+    xs = [Float64(position(lat, i)[1]) for i in 1:N]
+    ys = [Float64(position(lat, i)[2]) for i in 1:N]
+    return xs, ys
+end
+
+"""
+    _bond_segments(lat) → (seg_x, seg_y)
+
+Collect bond line segments as flat `Vector{Float64}` with `NaN`
+separators — the format `Plots.plot!` expects for drawing a
+disjoint union of line segments in a single call.
+
+Each bond's endpoints are computed as `src + b.vector` rather than
+`position(lat, b.j)`, which lets the plot respect the wrapped
+displacement vector stored on each `Bond` and avoids "long lines"
+artefacts on periodic lattices.
+"""
+function _bond_segments(lat::LatticeCore.AbstractLattice{1})
+    seg_x = Float64[]
+    seg_y = Float64[]
+    for b in bonds(lat)
+        src = position(lat, b.i)
+        dst_local = src + b.vector
+        push!(seg_x, Float64(src[1]), Float64(dst_local[1]), NaN)
+        push!(seg_y, 0.0, 0.0, NaN)
+    end
+    return seg_x, seg_y
+end
+
+function _bond_segments(lat::LatticeCore.AbstractLattice{2})
+    seg_x = Float64[]
+    seg_y = Float64[]
+    for b in bonds(lat)
+        src = position(lat, b.i)
+        dst_local = src + b.vector
+        push!(seg_x, Float64(src[1]), Float64(dst_local[1]), NaN)
+        push!(seg_y, Float64(src[2]), Float64(dst_local[2]), NaN)
+    end
+    return seg_x, seg_y
+end
+
+# ---- plot_sites! -----------------------------------------------------
+
+function LatticeCore.plot_sites!(
+    p, lat::LatticeCore.AbstractLattice{D}; marker_size=4, color=:auto
+) where {D}
+    xs, ys = _site_xy(lat)
+    N = length(xs)
+
+    if color === :auto && num_sublattices(lat) > 1
+        sub_ids = [sublattice(lat, i) for i in 1:N]
+        Plots.scatter!(
+            p,
+            xs,
+            ys;
+            ms=marker_size,
+            group=sub_ids,
+            markerstrokewidth=0,
+        )
+    else
+        mc = color === :auto ? :steelblue : color
+        Plots.scatter!(
+            p,
+            xs,
+            ys;
+            ms=marker_size,
+            mc=mc,
+            markerstrokewidth=0,
+            label="",
+        )
+    end
+    return p
+end
+
+# ---- plot_bonds! -----------------------------------------------------
+
+function LatticeCore.plot_bonds!(
+    p, lat::LatticeCore.AbstractLattice{D}; color=:black, lw=1.0
+) where {D}
+    seg_x, seg_y = _bond_segments(lat)
+    return Plots.plot!(p, seg_x, seg_y; color=color, lw=lw, label="")
+end
+
+# ---- plot_lattice (1D) ----------------------------------------------
+
+function LatticeCore.plot_lattice(
+    lat::LatticeCore.AbstractLattice{1,T};
+    show_bonds::Bool=true,
+    show_sites::Bool=true,
+    site_size=6,
+    site_color=:auto,
+    bond_color=:black,
+    bond_width=1.5,
+    title=nothing,
+    kwargs...,
+) where {T}
+    p = Plots.plot(;
+        xlabel="x",
+        ylims=(-0.5, 0.5),
+        yticks=[],
+        legend=:topright,
+        title=title,
+        kwargs...,
+    )
+    show_bonds && plot_bonds!(p, lat; color=bond_color, lw=bond_width)
+    show_sites && plot_sites!(p, lat; marker_size=site_size, color=site_color)
+    return p
+end
+
+# ---- plot_lattice (2D) ----------------------------------------------
+
+function LatticeCore.plot_lattice(
+    lat::LatticeCore.AbstractLattice{2,T};
+    show_bonds::Bool=true,
+    show_sites::Bool=true,
+    site_size=4,
+    site_color=:auto,
+    bond_color=:black,
+    bond_width=1.0,
+    aspect_ratio=:equal,
+    title=nothing,
+    kwargs...,
+) where {T}
+    p = Plots.plot(;
+        aspect_ratio=aspect_ratio,
+        xlabel="x",
+        ylabel="y",
+        legend=:topright,
+        title=title,
+        kwargs...,
+    )
+    show_bonds && plot_bonds!(p, lat; color=bond_color, lw=bond_width)
+    show_sites && plot_sites!(p, lat; marker_size=site_size, color=site_color)
+    return p
+end
+
+end # module LatticeCorePlotsExt

--- a/ext/LatticeCorePlotsExt.jl
+++ b/ext/LatticeCorePlotsExt.jl
@@ -72,25 +72,10 @@ function LatticeCore.plot_sites!(
 
     if color === :auto && num_sublattices(lat) > 1
         sub_ids = [sublattice(lat, i) for i in 1:N]
-        Plots.scatter!(
-            p,
-            xs,
-            ys;
-            ms=marker_size,
-            group=sub_ids,
-            markerstrokewidth=0,
-        )
+        Plots.scatter!(p, xs, ys; ms=marker_size, group=sub_ids, markerstrokewidth=0)
     else
         mc = color === :auto ? :steelblue : color
-        Plots.scatter!(
-            p,
-            xs,
-            ys;
-            ms=marker_size,
-            mc=mc,
-            markerstrokewidth=0,
-            label="",
-        )
+        Plots.scatter!(p, xs, ys; ms=marker_size, mc=mc, markerstrokewidth=0, label="")
     end
     return p
 end
@@ -118,12 +103,7 @@ function LatticeCore.plot_lattice(
     kwargs...,
 ) where {T}
     p = Plots.plot(;
-        xlabel="x",
-        ylims=(-0.5, 0.5),
-        yticks=[],
-        legend=:topright,
-        title=title,
-        kwargs...,
+        xlabel="x", ylims=(-0.5, 0.5), yticks=[], legend=:topright, title=title, kwargs...
     )
     show_bonds && plot_bonds!(p, lat; color=bond_color, lw=bond_width)
     show_sites && plot_sites!(p, lat; marker_size=site_size, color=site_color)

--- a/src/LatticeCore.jl
+++ b/src/LatticeCore.jl
@@ -20,6 +20,7 @@ include("Indexing.jl")
 include("MomentumLattice.jl")
 include("StructureFactor.jl")
 include("LazyInfinite.jl")
+include("Plot.jl")
 include("reference/LineLattice.jl")
 include("reference/SimpleSquareLattice.jl")
 
@@ -76,6 +77,9 @@ export AcceptanceWindow, HyperReciprocalLattice, BraggPeakSet
 
 # ---- Lazy / infinite ----
 export materialize, require_finite
+
+# ---- Plotting (methods live in LatticeCorePlotsExt) ----
+export plot_lattice, plot_bonds!, plot_sites!
 
 # ---- Reference lattices ----
 export LineLattice, SimpleSquareLattice, basis_vectors

--- a/src/Plot.jl
+++ b/src/Plot.jl
@@ -1,0 +1,53 @@
+"""
+    plot_lattice(lat::AbstractLattice{D, T}; kwargs...)
+
+Generic visualisation entry point for any `AbstractLattice`. Returns
+a `Plots.Plot`.
+
+This function is a stub in the core module. Concrete methods live in
+the [`LatticeCorePlotsExt`](@ref) package extension and are loaded
+automatically when a client module imports `Plots`:
+
+```julia
+using Plots, LatticeCore
+plot_lattice(SimpleSquareLattice(4, 4))
+```
+
+# Common keyword arguments
+
+- `show_bonds::Bool = true` — draw bonds as line segments.
+- `show_sites::Bool = true` — draw sites as scatter points.
+- `site_size::Real` — marker size for scatter points.
+- `site_color` — `:auto` (colour by sublattice when `num_sublattices >
+  1`), or any `Plots.jl` colour value.
+- `bond_color`, `bond_width` — bond styling.
+- Any other keyword is forwarded to the underlying `Plots.plot` call
+  (e.g. `title`, `xlabel`, `xlims`).
+
+Calling `plot_lattice` without loading `Plots` first raises a
+`MethodError` that directs the user to the extension.
+"""
+function plot_lattice end
+
+"""
+    plot_bonds!(p, lat::AbstractLattice; kwargs...)
+
+Overlay the lattice bonds on an existing `Plots.Plot` `p` using the
+per-bond wrapped displacement vector stored on each `Bond`. This
+avoids the boundary-crossing "long line" artefacts that afflict naive
+`position(lat, j) - position(lat, i)` plots on periodic lattices.
+
+Concrete methods live in the Plots extension.
+"""
+function plot_bonds! end
+
+"""
+    plot_sites!(p, lat::AbstractLattice; kwargs...)
+
+Overlay the lattice sites on an existing `Plots.Plot` `p`. When
+`color = :auto` and the lattice has more than one geometric
+sublattice, sites are grouped and coloured by sublattice id.
+
+Concrete methods live in the Plots extension.
+"""
+function plot_sites! end

--- a/test/core/test_plot_extension.jl
+++ b/test/core/test_plot_extension.jl
@@ -1,0 +1,79 @@
+using LatticeCore
+using Plots
+using Test
+
+# Loading Plots triggers the LatticeCorePlotsExt extension, which
+# installs methods on `LatticeCore.plot_lattice`, `plot_bonds!`, and
+# `plot_sites!`. The tests below verify that those methods are
+# available and that they return a `Plots.Plot` on every shipped
+# reference lattice.
+
+const _LAT_CORE_EXT = Base.get_extension(LatticeCore, :LatticeCorePlotsExt)
+
+@testset "LatticeCorePlotsExt loads when Plots is imported" begin
+    @test _LAT_CORE_EXT !== nothing
+
+    # `plot_lattice` should now resolve to at least one concrete method
+    # for the 1D and 2D reference lattices.
+    @test !isempty(methods(plot_lattice, (AbstractLattice{1,Float64},)))
+    @test !isempty(methods(plot_lattice, (AbstractLattice{2,Float64},)))
+end
+
+@testset "plot_lattice on LineLattice" begin
+    lat = LineLattice(6, PeriodicAxis())
+    p = plot_lattice(lat; title="LineLattice PBC 6")
+    @test p isa Plots.Plot
+
+    # Without bonds
+    p_no_bonds = plot_lattice(lat; show_bonds=false)
+    @test p_no_bonds isa Plots.Plot
+
+    # Custom site colour
+    p_colored = plot_lattice(lat; site_color=:red)
+    @test p_colored isa Plots.Plot
+end
+
+@testset "plot_lattice on SimpleSquareLattice" begin
+    lat = SimpleSquareLattice(3, 3, PeriodicAxis())
+    p = plot_lattice(lat; title="Square PBC 3x3")
+    @test p isa Plots.Plot
+
+    # Cylinder: mixed BC still works
+    cyl = SimpleSquareLattice(3, 4, LatticeBoundary((PeriodicAxis(), OpenAxis())))
+    p_cyl = plot_lattice(cyl; title="Cylinder 3x4")
+    @test p_cyl isa Plots.Plot
+
+    # show_sites = false still produces a plot
+    p_bonds_only = plot_lattice(lat; show_sites=false)
+    @test p_bonds_only isa Plots.Plot
+end
+
+@testset "plot_bonds! / plot_sites! on an existing plot" begin
+    lat = SimpleSquareLattice(4, 4, PeriodicAxis())
+
+    p = Plots.plot(; aspect_ratio=:equal, label="")
+    plot_sites!(p, lat; marker_size=5, color=:steelblue)
+    plot_bonds!(p, lat; color=:gray, lw=0.8)
+    @test p isa Plots.Plot
+end
+
+@testset "wrapped bond vectors keep bond lines short under PBC" begin
+    # On a 3x3 PBC square the wrapped bond at the corner is (−1, 0),
+    # not (2, 0). _bond_segments must respect that, so the total length
+    # of drawn segments is bounded by (unit) × (number of bonds × 2
+    # endpoints) rather than exploding across the whole sample.
+    lat = SimpleSquareLattice(3, 3, PeriodicAxis())
+    ext = _LAT_CORE_EXT
+    seg_x, seg_y = ext._bond_segments(lat)
+
+    # Each segment is (src, dst, NaN) = 3 entries.
+    @test length(seg_x) == 3 * length(collect(bonds(lat)))
+    @test length(seg_y) == 3 * length(collect(bonds(lat)))
+
+    # Every drawn segment has unit length in one of (x, y).
+    for i in 1:3:length(seg_x)
+        dx = seg_x[i + 1] - seg_x[i]
+        dy = seg_y[i + 1] - seg_y[i]
+        @test isapprox(hypot(dx, dy), 1.0; atol=1e-10)
+    end
+end


### PR DESCRIPTION
## Description

Adds a `Plots.jl` **package extension** to `LatticeCore` that ships a generic `plot_lattice` / `plot_bonds!` / `plot_sites!` stack working on any subtype of `LatticeCore.AbstractLattice{D, T}`.

The motivating use case is unifying the visualisation code that was duplicated between `QuasiCrystal.jl` (`visualize_quasicrystal_positions`) and `Lattice2DMonteCarlo.jl` (`visualize_bonds` / `plot_state!`). With this PR every `AbstractLattice` — Bravais periodic, quasicrystal, reference chain — can be drawn with a single call the moment a user has `using Plots` in scope.

Fixed: answers the "can we share visualisation logic?" question from the QuasiCrystal migration discussion.

## Type of Change

- [x] ✨ Feature (`enhancement`)
- [ ] 🐛 Bug Fix
- [ ] ⚡ Performance
- [ ] 📖 Documentation
- [ ] 🧰 Maintenance

## Design

Three entry points, defined as generic function stubs in `src/Plot.jl` (compiled into the core module with no methods of their own):

- `plot_lattice(lat; show_sites, show_bonds, site_size, site_color, bond_color, bond_width, ...)` → `Plots.Plot`
- `plot_bonds!(p, lat; color, lw)` — overlay bonds on an existing plot
- `plot_sites!(p, lat; marker_size, color)` — overlay sites on an existing plot

All real work lives in `ext/LatticeCorePlotsExt.jl`, which is loaded automatically by Julia 1.9+ package-extension machinery when `Plots` is in the user's environment. Calling the stubs without `Plots` loaded raises a `MethodError`.

## Implementation highlights

- **`_site_xy(lat::AbstractLattice{D})`** specialises on `D` so 1D lattices map to `(xs, zeros(N))`, 2D to `(xs, ys)`. 3D is not handled yet.
- **`_bond_segments(lat)`** computes bond line segments as flat `Vector{Float64}` with `NaN` separators — the format `Plots.plot!` expects for disjoint segments drawn in a single call.
- **Crucially, each bond segment is drawn from `src + b.vector`** rather than `position(lat, b.j)`. Because every `Bond{D, T}` stores the wrapped displacement vector (see chapters 02 / 03 of the architecture notes), this automatically avoids the "long line across the whole sample" artefact that periodic boundaries used to produce. The test suite pins this down: on a 3×3 PBC square, **every drawn segment has unit length**.
- **`plot_sites!` automatically groups by `sublattice(lat, i)`** when `color = :auto` and `num_sublattices(lat) > 1`. This is how honeycomb A / B, Kagome A / B / C, and Lieb A / B / C get sensible default colouring without any per-topology special casing.

## Usage example

```julia
using Plots, LatticeCore, Lattice2D

lat = build_lattice(Honeycomb, 5, 5, PeriodicAxis())
plot_lattice(lat; title = "Honeycomb PBC 5x5")

cyl = SimpleSquareLattice(4, 4,
    LatticeBoundary((PeriodicAxis(), OpenAxis())))
plot_lattice(cyl;
    title = "Cylinder",
    site_color = :auto,
    bond_color = :gray)
```

## Project.toml

- Add `[weakdeps] Plots` and `[extensions] LatticeCorePlotsExt = "Plots"`.
- Add `Plots = "1"` to `[compat]`.
- Add `Plots` to `[extras]` / `[targets]` so the extension loads during `Pkg.test()`.
- Bump version `0.7.3 → 0.8.0` (additive feature, pre-1.0 minor bump).

## Tests

- `LatticeCorePlotsExt` loads successfully when `Plots` is in the test environment
- `plot_lattice` has concrete methods for `AbstractLattice{1, Float64}` and `AbstractLattice{2, Float64}`
- Returns a `Plots.Plot` for: 6-site PBC `LineLattice`, 3×3 PBC `SimpleSquareLattice`, 3×4 cylinder (PBC × OBC), `show_bonds = false` / `show_sites = false` variants, custom `site_color = :red`
- `plot_sites!` / `plot_bonds!` compose on an externally constructed `Plots.plot()`
- **Wrapped bond-vector invariant**: on a 3×3 PBC square, every drawn segment has exactly unit length

Full test run: **801 / 801 pass**.

## Follow-up

- `QuasiCrystal.jl`'s `visualize_quasicrystal_positions` and `Lattice2DMonteCarlo.jl`'s `visualize_bonds` / `plot_state!` can now become thin wrappers over `plot_lattice`. That work is deliberately out of scope for this PR — the point here is to land the generic extension and prove it compiles. Downstream migrations will follow in each individual package.

## check list
- [x] test駆動をしたか — 7 tests across extension loading, reference lattice rendering, composition, and the wrapped-bond-vector invariant