### PR TITLE
feat: diffraction_pattern plot extension

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.8.0"
+version = "0.8.1"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/ext/LatticeCorePlotsExt.jl
+++ b/ext/LatticeCorePlotsExt.jl
@@ -137,4 +137,103 @@ function LatticeCore.plot_lattice(
     return p
 end
 
+# ---- diffraction_pattern --------------------------------------------
+
+function _peak_arrays(ml::LatticeCore.AbstractMomentumLattice{DPhys,T}) where {DPhys,T}
+    N = num_k_points(ml)
+    ks = [k_point(ml, i) for i in 1:N]
+    Is = if ml isa LatticeCore.BraggPeakSet
+        copy(ml.intensities)
+    else
+        ones(T, N)
+    end
+    return ks, Is
+end
+
+function _intensity_for_plot(Is::AbstractVector{T}, log_intensity::Bool) where {T}
+    if !log_intensity
+        return Float64.(Is)
+    end
+    Imax = maximum(Is)
+    Imax <= 0 && return fill(-Inf, length(Is))
+    floor = 1e-6
+    return [I > 0 ? log10(max(I / Imax, floor)) : log10(floor) for I in Is]
+end
+
+# 1D diffraction pattern: stem plot of intensity vs k.
+function LatticeCore.diffraction_pattern(
+    ml::LatticeCore.AbstractMomentumLattice{1,T};
+    title="Diffraction pattern",
+    log_intensity::Bool=false,
+    color=:steelblue,
+    lw=1.5,
+    ms=4,
+    kwargs...,
+) where {T}
+    ks, Is = _peak_arrays(ml)
+    xs = [Float64(k[1]) for k in ks]
+    ys = _intensity_for_plot(Is, log_intensity)
+
+    p = Plots.plot(;
+        xlabel="k",
+        ylabel=log_intensity ? "log₁₀(I / I_max)" : "I(k)",
+        title=title,
+        legend=false,
+        kwargs...,
+    )
+    seg_x = Float64[]
+    seg_y = Float64[]
+    base = log_intensity ? minimum(ys) : 0.0
+    for (x, y) in zip(xs, ys)
+        push!(seg_x, x, x, NaN)
+        push!(seg_y, base, y, NaN)
+    end
+    Plots.plot!(p, seg_x, seg_y; color=color, lw=lw, label="")
+    Plots.scatter!(p, xs, ys; mc=color, ms=ms, markerstrokewidth=0, label="")
+    return p
+end
+
+# 2D diffraction pattern: scatter of (kx, ky) with marker size
+# proportional to intensity.
+function LatticeCore.diffraction_pattern(
+    ml::LatticeCore.AbstractMomentumLattice{2,T};
+    title="Diffraction pattern",
+    log_intensity::Bool=false,
+    marker_scale::Real=12.0,
+    color=:viridis,
+    kwargs...,
+) where {T}
+    ks, Is = _peak_arrays(ml)
+    xs = [Float64(k[1]) for k in ks]
+    ys = [Float64(k[2]) for k in ks]
+    zs = _intensity_for_plot(Is, log_intensity)
+
+    # Map intensities to marker sizes (raw or log).
+    zmax = maximum(zs)
+    zmin = minimum(zs)
+    rng = zmax - zmin
+    ms = if rng > 0
+        [1.0 + marker_scale * (z - zmin) / rng for z in zs]
+    else
+        fill(Float64(marker_scale) / 2, length(zs))
+    end
+
+    p = Plots.scatter(
+        xs,
+        ys;
+        ms=ms,
+        marker_z=zs,
+        color=color,
+        markerstrokewidth=0,
+        aspect_ratio=:equal,
+        xlabel="kₓ",
+        ylabel="k_y",
+        title=title,
+        label="",
+        colorbar_title=log_intensity ? "log₁₀(I / I_max)" : "I(k)",
+        kwargs...,
+    )
+    return p
+end
+
 end # module LatticeCorePlotsExt

--- a/src/LatticeCore.jl
+++ b/src/LatticeCore.jl
@@ -80,6 +80,7 @@ export materialize, require_finite
 
 # ---- Plotting (methods live in LatticeCorePlotsExt) ----
 export plot_lattice, plot_bonds!, plot_sites!
+export diffraction_pattern
 
 # ---- Reference lattices ----
 export LineLattice, SimpleSquareLattice, basis_vectors

--- a/src/Plot.jl
+++ b/src/Plot.jl
@@ -51,3 +51,35 @@ sublattice, sites are grouped and coloured by sublattice id.
 Concrete methods live in the Plots extension.
 """
 function plot_sites! end
+
+"""
+    diffraction_pattern(ml::AbstractMomentumLattice; kwargs...)
+
+Visualise the Fourier-space "diffraction pattern" of a momentum
+lattice. Concrete methods live in the Plots extension and dispatch
+on the physical dimension of the momentum lattice:
+
+- `DPhys = 1` → stem plot of `intensity(k)` vs `k`
+- `DPhys = 2` → scatter of peak positions in `(kₓ, k_y)` with
+  marker size (and colour) proportional to intensity
+
+Typical usage on a quasicrystal:
+
+```julia
+using Plots, LatticeCore, QuasiCrystal
+qc = generate_fibonacci_projection(20)
+peaks = bragg_peaks(qc; kmax = 20.0, intensity_cutoff = 1e-3)
+diffraction_pattern(peaks)
+```
+
+# Common keyword arguments
+
+- `title` — plot title (default: "Diffraction pattern")
+- `marker_scale::Real` — multiplier applied to marker size in 2D
+  (default picks something reasonable; tune for your cutoff)
+- `color` — `Plots.jl` colour value or gradient for 2D scatter
+- `log_intensity::Bool` — if `true`, plot `log10(I/I_max)` instead
+  of `I`. Makes weaker peaks visible alongside Γ.
+- Any other keyword is forwarded to the underlying `Plots.plot`.
+"""
+function diffraction_pattern end

--- a/test/core/test_plot_extension.jl
+++ b/test/core/test_plot_extension.jl
@@ -104,7 +104,9 @@ end
         SVector(0.0, -1.0),
     ]
     intensities_2d = [1.0, 0.5, 0.5, 0.5, 0.5]
-    hyper_indices_2d = [(0, 0, 0, 0), (1, 0, 0, 0), (-1, 0, 0, 0), (0, 1, 0, 0), (0, -1, 0, 0)]
+    hyper_indices_2d = [
+        (0, 0, 0, 0), (1, 0, 0, 0), (-1, 0, 0, 0), (0, 1, 0, 0), (0, -1, 0, 0)
+    ]
     bps2 = BraggPeakSet{2,4,Float64}(peaks_2d, intensities_2d, hyper_indices_2d)
 
     p2 = diffraction_pattern(bps2; title="2D test")

--- a/test/core/test_plot_extension.jl
+++ b/test/core/test_plot_extension.jl
@@ -1,5 +1,6 @@
 using LatticeCore
 using Plots
+using StaticArrays
 using Test
 
 # Loading Plots triggers the LatticeCorePlotsExt extension, which
@@ -76,4 +77,43 @@ end
         dy = seg_y[i + 1] - seg_y[i]
         @test isapprox(hypot(dx, dy), 1.0; atol=1e-10)
     end
+end
+
+@testset "diffraction_pattern on BraggPeakSet" begin
+    # Build a tiny synthetic 1D BraggPeakSet (3 peaks: Γ + 2 side
+    # peaks). We can do this by hand — the physics has already been
+    # exercised in the QuasiCrystal test suite; here we just want
+    # the plot method to return a `Plots.Plot`.
+    peaks_1d = [SVector(0.0), SVector(1.0), SVector(-1.0)]
+    intensities_1d = [1.0, 0.3, 0.3]
+    hyper_indices_1d = [(0, 0), (1, 0), (-1, 0)]
+    bps1 = BraggPeakSet{1,2,Float64}(peaks_1d, intensities_1d, hyper_indices_1d)
+
+    p1 = diffraction_pattern(bps1; title="1D test")
+    @test p1 isa Plots.Plot
+
+    p1_log = diffraction_pattern(bps1; log_intensity=true)
+    @test p1_log isa Plots.Plot
+
+    # 2D case — 5 peaks in a plus + Γ configuration.
+    peaks_2d = [
+        SVector(0.0, 0.0),
+        SVector(1.0, 0.0),
+        SVector(-1.0, 0.0),
+        SVector(0.0, 1.0),
+        SVector(0.0, -1.0),
+    ]
+    intensities_2d = [1.0, 0.5, 0.5, 0.5, 0.5]
+    hyper_indices_2d = [(0, 0, 0, 0), (1, 0, 0, 0), (-1, 0, 0, 0), (0, 1, 0, 0), (0, -1, 0, 0)]
+    bps2 = BraggPeakSet{2,4,Float64}(peaks_2d, intensities_2d, hyper_indices_2d)
+
+    p2 = diffraction_pattern(bps2; title="2D test")
+    @test p2 isa Plots.Plot
+
+    p2_log = diffraction_pattern(bps2; log_intensity=true, marker_scale=15.0)
+    @test p2_log isa Plots.Plot
+
+    # Uniform-intensity degenerate case: single peak at Γ.
+    bps_single = BraggPeakSet{2,4,Float64}([SVector(0.0, 0.0)], [1.0], [(0, 0, 0, 0)])
+    @test diffraction_pattern(bps_single) isa Plots.Plot
 end


### PR DESCRIPTION
## Summary
- New generic `diffraction_pattern(::AbstractMomentumLattice)` entry point in `src/Plot.jl`
- 1D impl: stem plot of intensity vs k
- 2D impl: scatter in (kₓ, k_y) with marker size and colour proportional to intensity
- Both support `log_intensity=true` for dynamic-range compression
- Tests cover both 1D and 2D `BraggPeakSet`, `log_intensity`, and the single-peak degenerate case

Works transparently with QuasiCrystal.jl's `bragg_peaks(qc)` for Fibonacci, Ammann–Beenker, and Penrose P3.

Version: 0.8.0 → 0.8.1.

## Test plan
- [x] `julia --project=. -e 'using Pkg; Pkg.test()'` — 806/806 passing locally