### PR TITLE
fix: bond_center handles PBC-wrapped bonds

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.8.1"
+version = "0.8.2"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/Bond.jl
+++ b/src/Bond.jl
@@ -25,9 +25,17 @@ end
 Geometric center (midpoint) of the bond in real space. Useful for
 bond-centered observables and for position-dependent bond modifiers
 such as sine-square deformation.
+
+Uses the bond's stored displacement `bond.vector` rather than the
+literal positions of `bond.i` and `bond.j`. This matters under
+periodic boundary conditions: the wrapped target's `position(j)` is
+on the opposite side of the sample, so `(position(i) + position(j))/2`
+would point to the sample interior instead of just outside the
+boundary. The bond carries the unwrapped displacement, so
+`position(i) + bond.vector / 2` gives the true geometric midpoint.
 """
 function bond_center(lat::AbstractLattice{D,T}, bond::Bond{D,T}) where {D,T}
-    return (position(lat, bond.i) + position(lat, bond.j)) / 2
+    return position(lat, bond.i) + bond.vector / 2
 end
 
 """

--- a/test/core/test_simple_square_lattice.jl
+++ b/test/core/test_simple_square_lattice.jl
@@ -129,6 +129,23 @@ using Test
         @test bond_center(lat, b) == SVector(1.5, 1.0)
     end
 
+    @testset "bond_center handles PBC-wrapped bonds" begin
+        # On a 4×4 fully periodic sample, the corner site (x=1, y=1) has
+        # a neighbour that wraps left to (x=4, y=1). The bond's stored
+        # displacement vector is (-1, 0); the geometric midpoint sits
+        # half a step LEFT of (1, 1) — i.e. (0.5, 1.0) — not at the
+        # arithmetic mean of the literal positions, which would land
+        # inside the sample interior at (2.5, 1.0).
+        lat = SimpleSquareLattice(4, 4, PeriodicAxis())
+        wrapped = Bond{2,Float64}(1, 4, SVector(-1.0, 0.0), :nearest)
+        @test bond_center(lat, wrapped) == SVector(0.5, 1.0)
+
+        # Sanity check on an interior bond — the new and old formulas
+        # agree there.
+        interior = Bond{2,Float64}(6, 7, SVector(1.0, 0.0), :nearest)
+        @test bond_center(lat, interior) == SVector(2.5, 2.0)
+    end
+
     @testset "coordinate conversions" begin
         lat = SimpleSquareLattice(3, 3, PeriodicAxis())
 


### PR DESCRIPTION
## Summary

`bond_center(lat, b)` previously computed `(position(b.i) + position(b.j)) / 2`. For any bond whose target wraps across a periodic axis this is silently wrong: `position(b.j)` is on the opposite side of the sample, so the arithmetic mean lands deep inside the sample interior instead of just outside the boundary.

The `Bond` struct already stores the unwrapped displacement in its `vector` field. Switch to:

```julia
bond_center(lat, b) = position(lat, b.i) + b.vector / 2
```

which is correct for both interior and PBC-wrapped bonds and identical to the old formula on interior bonds (so existing tests still pass).

### Concrete example

On a 4×4 PBC `SimpleSquareLattice`, the left neighbour of site (1,1) wraps to site (4,1). The bond's stored vector is `(-1, 0)`.

| | Old formula | New formula |
| --- | --- | --- |
| `(position(1) + position(4))/2` | `(2.5, 1.0)` ❌ | — |
| `position(1) + (-1, 0)/2` | — | `(0.5, 1.0)` ✓ |

The new midpoint sits half a step *left* of the corner, which is what every consumer of `bond_center` (bond-centered observables, SSD modifiers) expects.

## Test plan

- [x] Existing `bond_center` tests in `test/core/test_abstract_lattice.jl` and `test_simple_square_lattice.jl` still pass (interior bonds, where the formulas agree).
- [x] New regression test `bond_center handles PBC-wrapped bonds` covers the wrap case on a 4×4 `SimpleSquareLattice`.
- [x] `Pkg.test()` — 808 / 808 pass.

## Type of Change

- [ ] ✨ **Feature** (`enhancement`)
- [x] 🐛 **Bug Fix** (`bug`)
- [ ] ⚡ **Performance** (`performance`)
- [ ] 📖 **Documentation** (`documentation`)
- [ ] 🧰 **Maintenance** (`chore` or `refactor`)
- [ ] 💥 **Breaking change** (`breaking`)