### PR TITLE
feat: generic element-center API (num_elements / elements / element_position)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.8.2"
+version = "0.8.3"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/Bond.jl
+++ b/src/Bond.jl
@@ -67,3 +67,38 @@ function neighbor_bonds(lat::AbstractLattice{D,T}, i::Int) where {D,T}
         j in neighbors(lat, i)
     )
 end
+
+# ---- Generic element-center accessors --------------------------------
+#
+# These methods present a uniform API for "ask the lattice about its
+# elements of centring X" without having to remember whether the
+# concept is sites, bonds, plaquettes, or cells. Concrete lattices may
+# specialise any of them for efficiency or to support `PlaquetteCenter`
+# / `CellCenter`. The function declarations live in `LatticeElement.jl`;
+# the methods need both `AbstractLattice` and `Bond` so they live here.
+
+# num_elements ---------------------------------------------------------
+
+num_elements(lat::AbstractLattice, ::VertexCenter) = num_sites(lat)
+function num_elements(lat::AbstractLattice, ::BondCenter)
+    return count(_ -> true, bonds(lat))
+end
+
+# elements -------------------------------------------------------------
+
+elements(lat::AbstractLattice, ::VertexCenter) = 1:num_sites(lat)
+elements(lat::AbstractLattice, ::BondCenter) = bonds(lat)
+
+# element_position -----------------------------------------------------
+
+element_position(lat::AbstractLattice, ::VertexCenter, i::Int) = position(lat, i)
+function element_position(lat::AbstractLattice, ::BondCenter, i::Int)
+    bs = collect(bonds(lat))
+    return bond_center(lat, bs[i])
+end
+
+# element_positions ----------------------------------------------------
+
+function element_positions(lat::AbstractLattice, e::AbstractLatticeElement)
+    return (element_position(lat, e, i) for i in 1:num_elements(lat, e))
+end

--- a/src/LatticeCore.jl
+++ b/src/LatticeCore.jl
@@ -32,6 +32,7 @@ export site_layout, site_type, num_sublattices, sublattice
 # ---- Lattice elements ----
 export AbstractLatticeElement, VertexCenter, BondCenter, PlaquetteCenter, CellCenter
 export element_type
+export num_elements, elements, element_position, element_positions
 
 # ---- Site types ----
 export AbstractSiteType

--- a/src/LatticeElement.jl
+++ b/src/LatticeElement.jl
@@ -25,3 +25,39 @@ struct PlaquetteCenter <: AbstractLatticeElement end
 
 """Cell-centered element: the centre of a 3D (or higher) cell."""
 struct CellCenter <: AbstractLatticeElement end
+
+# ---- Generic element-center accessors --------------------------------
+# Function declarations only; the actual methods need both
+# AbstractLattice and Bond and live in `Bond.jl` (loaded after both).
+
+"""
+    num_elements(lat, e::AbstractLatticeElement) → Int
+
+Number of geometric elements of centring `e` on `lat`. See
+`Bond.jl` for the default `VertexCenter` / `BondCenter` methods.
+"""
+function num_elements end
+
+"""
+    elements(lat, e::AbstractLatticeElement)
+
+Iterator over the underlying elements of centring `e` on `lat`. See
+`Bond.jl` for the default `VertexCenter` / `BondCenter` methods.
+"""
+function elements end
+
+"""
+    element_position(lat, e::AbstractLatticeElement, i::Int)
+
+Real-space position of the `i`-th element of centring `e` on `lat`.
+See `Bond.jl` for the default `VertexCenter` / `BondCenter` methods.
+"""
+function element_position end
+
+"""
+    element_positions(lat, e::AbstractLatticeElement)
+
+Iterator over the real-space positions of every element of centring
+`e` on `lat`. See `Bond.jl` for the default implementation.
+"""
+function element_positions end

--- a/test/core/test_lattice_element.jl
+++ b/test/core/test_lattice_element.jl
@@ -1,4 +1,5 @@
 using LatticeCore
+using StaticArrays
 using Test
 
 @testset "AbstractLatticeElement" begin
@@ -12,4 +13,40 @@ using Test
     @test BondCenter() isa AbstractLatticeElement
     @test PlaquetteCenter() isa AbstractLatticeElement
     @test CellCenter() isa AbstractLatticeElement
+end
+
+@testset "Element-center generic API on SimpleSquareLattice" begin
+    lat = SimpleSquareLattice(3, 3, OpenAxis())
+    nbond = count(_ -> true, bonds(lat))
+
+    @testset "num_elements" begin
+        @test num_elements(lat, VertexCenter()) == num_sites(lat)
+        @test num_elements(lat, BondCenter()) == nbond
+        @test_throws MethodError num_elements(lat, PlaquetteCenter())
+    end
+
+    @testset "elements iterator" begin
+        verts = collect(elements(lat, VertexCenter()))
+        @test verts == 1:num_sites(lat)
+
+        bs = collect(elements(lat, BondCenter()))
+        @test length(bs) == nbond
+        @test all(b isa Bond{2,Float64} for b in bs)
+    end
+
+    @testset "element_position dispatches by centring" begin
+        @test element_position(lat, VertexCenter(), 1) == position(lat, 1)
+
+        bs = collect(bonds(lat))
+        @test element_position(lat, BondCenter(), 1) == bond_center(lat, bs[1])
+    end
+
+    @testset "element_positions iterator" begin
+        vps = collect(element_positions(lat, VertexCenter()))
+        @test vps == [position(lat, i) for i in 1:num_sites(lat)]
+
+        bps = collect(element_positions(lat, BondCenter()))
+        @test length(bps) == nbond
+        @test all(p isa SVector{2,Float64} for p in bps)
+    end
 end


### PR DESCRIPTION
## Summary

Iteration 2 of the LatticeCore-first push. Adds a uniform "ask the lattice about its elements of centring X" API on top of the existing `AbstractLatticeElement` marker types so that downstream code (Lattice2D, QuasiCrystal, MC observables) can write site / bond / plaquette / cell observables without dispatching on lattice topology.

```julia
num_elements(lat, ::VertexCenter)              # → num_sites(lat)
num_elements(lat, ::BondCenter)                # → count of bonds
elements(lat, ::VertexCenter)                  # → 1:num_sites(lat)
elements(lat, ::BondCenter)                    # → bonds(lat) iterator
element_position(lat, ::VertexCenter, i)       # → position(lat, i)
element_position(lat, ::BondCenter, i)         # → bond_center(lat, bond_i)
element_positions(lat, e::AbstractLatticeElement) # → iterator of SVector
```

`PlaquetteCenter` and `CellCenter` deliberately have **no default implementation** — concrete lattices that have a notion of plaquettes (e.g. `Lattice2D.Lattice` for Square / Triangular / Honeycomb) will opt in by overloading these four functions. Calling the unimplemented variants throws `MethodError`, which the test in this PR exercises.

### File layout

The four function declarations live in `LatticeElement.jl` (loaded early, alongside the marker types). The methods need both `AbstractLattice` and `Bond` — neither is in scope at that include point — so the actual implementations live in `Bond.jl`, which is loaded after both.

### Test plan

- [x] New "Element-center generic API on SimpleSquareLattice" testset in `test/core/test_lattice_element.jl` covering all four functions for `VertexCenter` and `BondCenter`, plus a `MethodError` check for `PlaquetteCenter`.
- [x] `Pkg.test()` — **819 / 819 pass** (was 808, +11 new assertions).

### Next iterations

- **Lattice2D**: opt in to `PlaquetteCenter` for Square / Triangular / Honeycomb / Kagome by adding per-topology plaquette enumeration.
- **QuasiCrystal**: same shape on Penrose / Ammann-Beenker rhombic tiles.

Bumps version 0.8.2 → **0.8.3**.

## Type of Change

- [x] ✨ **Feature** (`enhancement`)
- [ ] 🐛 **Bug Fix** (`bug`)
- [ ] ⚡ **Performance** (`performance`)
- [ ] 📖 **Documentation** (`documentation`)
- [ ] 🧰 **Maintenance** (`chore` or `refactor`)
- [ ] 💥 **Breaking change** (`breaking`)