### PR TITLE
feat: Plaquette types + incidence / adjacency API

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.8.3"
+version = "0.8.4"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/LatticeCore.jl
+++ b/src/LatticeCore.jl
@@ -14,6 +14,7 @@ include("SiteType.jl")
 include("SiteLayout.jl")
 include("AbstractLattice.jl")
 include("Bond.jl")
+include("Plaquette.jl")
 include("BoundaryCondition.jl")
 include("Coordinate.jl")
 include("Indexing.jl")
@@ -33,6 +34,11 @@ export site_layout, site_type, num_sublattices, sublattice
 export AbstractLatticeElement, VertexCenter, BondCenter, PlaquetteCenter, CellCenter
 export element_type
 export num_elements, elements, element_position, element_positions
+export element_neighbors, incident
+
+# ---- Plaquettes ----
+export PlaquetteRule, Plaquette
+export plaquettes, neighbor_plaquettes, plaquette_center
 
 # ---- Site types ----
 export AbstractSiteType

--- a/src/Plaquette.jl
+++ b/src/Plaquette.jl
@@ -1,0 +1,256 @@
+"""
+    PlaquetteRule
+
+Declarative description of a plaquette shape anchored in a unit cell,
+used as the input to the per-sample plaquette enumeration. A concrete
+topology stores one `PlaquetteRule` per plaquette kind (e.g. Square has
+one rule, Triangular has two — up-triangle and down-triangle, Kagome
+has three — up-triangle, down-triangle, hexagon).
+
+# Fields
+- `corners::Vector{NTuple{3, Int}}` — the boundary vertices of the
+  plaquette in **cyclic order**, each expressed as
+  `(sublattice_id, dx, dy)`. `sublattice_id` is the 1-based sublattice
+  index within the unit cell; `(dx, dy)` is the cell offset relative
+  to the anchor cell. Every rule must include at least one corner at
+  `(_, 0, 0)` (the anchor).
+- `type::Symbol` — bond-type-like tag for downstream dispatch
+  (`:square`, `:up_triangle`, `:down_triangle`, `:hexagon`, …).
+
+# Example
+
+```julia
+# Unit square on a single-sublattice square lattice:
+square_rule = PlaquetteRule(
+    [(1, 0, 0), (1, 1, 0), (1, 1, 1), (1, 0, 1)],
+    :square,
+)
+```
+
+Mirrors the `Connection` / `Bond` pattern: `PlaquetteRule` is the
+topology-level template, `Plaquette` is the per-sample materialised
+value produced by applying the rule under a boundary condition.
+"""
+struct PlaquetteRule
+    corners::Vector{NTuple{3,Int}}
+    type::Symbol
+end
+
+"""
+    Plaquette{D, T}
+
+A plaquette (face) on a concrete lattice, materialised from a
+[`PlaquetteRule`](@ref).
+
+# Fields
+- `vertices::Vector{Int}` — 1-based site indices of the boundary
+  vertices, in cyclic order
+- `center::SVector{D, T}` — real-space centroid
+- `type::Symbol` — tag inherited from the rule
+
+Obtained via `plaquettes(lat)` / `neighbor_plaquettes(lat, i)` /
+`element_position(lat, PlaquetteCenter(), p)` or the generic
+element-center API.
+"""
+struct Plaquette{D,T}
+    vertices::Vector{Int}
+    center::SVector{D,T}
+    type::Symbol
+end
+
+"""
+    plaquettes(lat::AbstractLattice)
+
+Iterator over all plaquettes on `lat`. The default implementation
+throws `MethodError` — concrete lattices that have a notion of
+plaquettes must implement this method (e.g. by walking cells ×
+`PlaquetteRule`s under their boundary condition).
+"""
+function plaquettes end
+
+"""
+    neighbor_plaquettes(lat::AbstractLattice, i::Int)
+
+Iterator over plaquettes that have site `i` on their boundary.
+Default implementation filters `plaquettes(lat)` by membership; concrete
+lattices may override for efficiency.
+"""
+function neighbor_plaquettes(lat::AbstractLattice, i::Int)
+    return (p for p in plaquettes(lat) if i in p.vertices)
+end
+
+"""
+    plaquette_center(p::Plaquette) → SVector
+
+Geometric center of the plaquette. For a materialised `Plaquette`
+this is just a field read.
+"""
+plaquette_center(p::Plaquette) = p.center
+
+# ---- Element-center defaults for PlaquetteCenter --------------------
+
+# Default: count via the plaquettes iterator. Concrete lattices may
+# override with an O(1) cell×kind formula.
+function num_elements(lat::AbstractLattice, ::PlaquetteCenter)
+    return count(_ -> true, plaquettes(lat))
+end
+
+# Default: return the iterator as-is.
+elements(lat::AbstractLattice, ::PlaquetteCenter) = plaquettes(lat)
+
+# Default: materialise and index. O(num_plaquettes) per call; concrete
+# lattices may override for O(1).
+function element_position(lat::AbstractLattice, ::PlaquetteCenter, i::Int)
+    ps = collect(plaquettes(lat))
+    return ps[i].center
+end
+
+# ---- Same-centring adjacency (line graph / dual graph) --------------
+
+"""
+    element_neighbors(lat, e::AbstractLatticeElement, i::Int)
+
+Neighbours of the `i`-th element of centring `e`, under the adjacency
+appropriate to `e`:
+
+- `VertexCenter` → `neighbors(lat, i)` (the usual graph)
+- `BondCenter` → **line graph**: other bonds sharing a vertex with bond `i`
+- `PlaquetteCenter` → **dual graph**: plaquettes sharing an edge with plaquette `i`
+- `CellCenter` → throws unless overridden
+
+Concrete lattices may override any of these for efficiency or to
+support custom adjacency rules (e.g. "only same-type bonds").
+"""
+function element_neighbors end
+
+element_neighbors(lat::AbstractLattice, ::VertexCenter, i::Int) = neighbors(lat, i)
+
+function element_neighbors(lat::AbstractLattice, ::BondCenter, i::Int)
+    bs = collect(bonds(lat))
+    b = bs[i]
+    endpoints = (b.i, b.j)
+    out = Int[]
+    for (k, other) in enumerate(bs)
+        k == i && continue
+        if other.i in endpoints || other.j in endpoints
+            push!(out, k)
+        end
+    end
+    return out
+end
+
+function element_neighbors(lat::AbstractLattice, ::PlaquetteCenter, i::Int)
+    ps = collect(plaquettes(lat))
+    p = ps[i]
+    p_edges = _boundary_edges(p)
+    out = Int[]
+    for (k, other) in enumerate(ps)
+        k == i && continue
+        any_shared = false
+        for e in p_edges
+            if e in _boundary_edges(other) || reverse(e) in _boundary_edges(other)
+                any_shared = true
+                break
+            end
+        end
+        any_shared && push!(out, k)
+    end
+    return out
+end
+
+# Boundary edges of a plaquette, as unordered `Tuple{Int,Int}` pairs
+# walked cyclically around the vertex list.
+function _boundary_edges(p::Plaquette)
+    vs = p.vertices
+    n = length(vs)
+    return [(vs[i], vs[mod1(i + 1, n)]) for i in 1:n]
+end
+
+# ---- Cross-centring incidence ---------------------------------------
+
+"""
+    incident(lat, from::AbstractLatticeElement, to::AbstractLatticeElement, i::Int)
+
+Return the integer indices of elements of centring `to` that are
+incident to the `i`-th element of centring `from`. Defaults cover:
+
+- `VertexCenter` ↔ `BondCenter`: bond-site incidence
+- `VertexCenter` ↔ `PlaquetteCenter`: site-plaquette incidence
+- `BondCenter` ↔ `PlaquetteCenter`: bond-plaquette incidence
+
+Same-centring pairs (`from == to`) fall through to
+[`element_neighbors`](@ref) so that `incident(lat, E(), E(), i)` is the
+adjacency under centring `E`.
+
+Concrete lattices may override any pair for O(1) access — the default
+implementations here are O(num_elements) materialisations meant for
+correctness, not hot-path use.
+"""
+function incident end
+
+# Same-centring → adjacency shortcut.
+function incident(
+    lat::AbstractLattice, e::AbstractLatticeElement, e2::AbstractLatticeElement, i::Int
+)
+    e === e2 || error("no default for incident($(typeof(e)) → $(typeof(e2)))")
+    return element_neighbors(lat, e, i)
+end
+
+# Vertex → Bond: bonds touching site i
+function incident(lat::AbstractLattice, ::VertexCenter, ::BondCenter, i::Int)
+    bs = collect(bonds(lat))
+    return [k for (k, b) in enumerate(bs) if b.i == i || b.j == i]
+end
+
+# Bond → Vertex: endpoints of bond i
+function incident(lat::AbstractLattice, ::BondCenter, ::VertexCenter, i::Int)
+    b = collect(bonds(lat))[i]
+    return [b.i, b.j]
+end
+
+# Vertex → Plaquette: plaquettes containing site i
+function incident(lat::AbstractLattice, ::VertexCenter, ::PlaquetteCenter, i::Int)
+    ps = collect(plaquettes(lat))
+    return [k for (k, p) in enumerate(ps) if i in p.vertices]
+end
+
+# Plaquette → Vertex: boundary vertices of plaquette i (in cyclic order)
+function incident(lat::AbstractLattice, ::PlaquetteCenter, ::VertexCenter, i::Int)
+    return collect(plaquettes(lat))[i].vertices
+end
+
+# Bond → Plaquette: plaquettes whose boundary contains bond i
+function incident(lat::AbstractLattice, ::BondCenter, ::PlaquetteCenter, i::Int)
+    bs = collect(bonds(lat))
+    b = bs[i]
+    target = (b.i, b.j)
+    ps = collect(plaquettes(lat))
+    out = Int[]
+    for (k, p) in enumerate(ps)
+        for e in _boundary_edges(p)
+            if e == target || e == reverse(target)
+                push!(out, k)
+                break
+            end
+        end
+    end
+    return out
+end
+
+# Plaquette → Bond: bonds forming the boundary of plaquette i, as
+# integer bond indices. Each boundary edge is matched against
+# `bonds(lat)` by endpoint set; unmatched edges are skipped.
+function incident(lat::AbstractLattice, ::PlaquetteCenter, ::BondCenter, i::Int)
+    p = collect(plaquettes(lat))[i]
+    bs = collect(bonds(lat))
+    out = Int[]
+    for e in _boundary_edges(p)
+        for (k, b) in enumerate(bs)
+            if (b.i, b.j) == e || (b.j, b.i) == e
+                push!(out, k)
+                break
+            end
+        end
+    end
+    return out
+end

--- a/test/core/test_plaquette.jl
+++ b/test/core/test_plaquette.jl
@@ -9,28 +9,40 @@ using Test
 struct TinySquareLattice <: AbstractLattice{2,Float64} end
 
 LatticeCore.num_sites(::TinySquareLattice) = 4
-LatticeCore.position(::TinySquareLattice, i::Int) =
-    ((i == 1) ? SVector(0.0, 0.0) :
-     (i == 2) ? SVector(1.0, 0.0) :
-     (i == 3) ? SVector(0.0, 1.0) :
-                SVector(1.0, 1.0))
-LatticeCore.neighbors(::TinySquareLattice, i::Int) =
-    i == 1 ? [2, 3] :
-    i == 2 ? [1, 4] :
-    i == 3 ? [1, 4] :
-             [2, 3]
+function LatticeCore.position(::TinySquareLattice, i::Int)
+    (
+        if (i == 1)
+            SVector(0.0, 0.0)
+        elseif (i == 2)
+            SVector(1.0, 0.0)
+        elseif (i == 3)
+            SVector(0.0, 1.0)
+        else
+            SVector(1.0, 1.0)
+        end
+    )
+end
+function LatticeCore.neighbors(::TinySquareLattice, i::Int)
+    if i == 1
+        [2, 3]
+    elseif i == 2
+        [1, 4]
+    elseif i == 3
+        [1, 4]
+    else
+        [2, 3]
+    end
+end
 LatticeCore.boundary(::TinySquareLattice) = nothing
 LatticeCore.size_trait(::TinySquareLattice) = FiniteSize((2, 2))
 
 # One square plaquette covering all four sites, cyclic order 1→2→4→3.
-LatticeCore.plaquettes(::TinySquareLattice) = (
-    Plaquette{2,Float64}([1, 2, 4, 3], SVector(0.5, 0.5), :square),
-)
+function LatticeCore.plaquettes(::TinySquareLattice)
+    (Plaquette{2,Float64}([1, 2, 4, 3], SVector(0.5, 0.5), :square),)
+end
 
 @testset "PlaquetteRule and Plaquette types" begin
-    rule = PlaquetteRule(
-        [(1, 0, 0), (1, 1, 0), (1, 1, 1), (1, 0, 1)], :square
-    )
+    rule = PlaquetteRule([(1, 0, 0), (1, 1, 0), (1, 1, 1), (1, 0, 1)], :square)
     @test rule.corners[1] == (1, 0, 0)
     @test rule.type === :square
     @test length(rule.corners) == 4

--- a/test/core/test_plaquette.jl
+++ b/test/core/test_plaquette.jl
@@ -1,0 +1,126 @@
+using LatticeCore
+using StaticArrays
+using Test
+
+# Minimal concrete lattice used to exercise the plaquette /
+# element_neighbors / incident defaults without depending on
+# downstream packages. Models a 2×2 square sample with OBC so we can
+# count everything by hand.
+struct TinySquareLattice <: AbstractLattice{2,Float64} end
+
+LatticeCore.num_sites(::TinySquareLattice) = 4
+LatticeCore.position(::TinySquareLattice, i::Int) =
+    ((i == 1) ? SVector(0.0, 0.0) :
+     (i == 2) ? SVector(1.0, 0.0) :
+     (i == 3) ? SVector(0.0, 1.0) :
+                SVector(1.0, 1.0))
+LatticeCore.neighbors(::TinySquareLattice, i::Int) =
+    i == 1 ? [2, 3] :
+    i == 2 ? [1, 4] :
+    i == 3 ? [1, 4] :
+             [2, 3]
+LatticeCore.boundary(::TinySquareLattice) = nothing
+LatticeCore.size_trait(::TinySquareLattice) = FiniteSize((2, 2))
+
+# One square plaquette covering all four sites, cyclic order 1→2→4→3.
+LatticeCore.plaquettes(::TinySquareLattice) = (
+    Plaquette{2,Float64}([1, 2, 4, 3], SVector(0.5, 0.5), :square),
+)
+
+@testset "PlaquetteRule and Plaquette types" begin
+    rule = PlaquetteRule(
+        [(1, 0, 0), (1, 1, 0), (1, 1, 1), (1, 0, 1)], :square
+    )
+    @test rule.corners[1] == (1, 0, 0)
+    @test rule.type === :square
+    @test length(rule.corners) == 4
+
+    p = Plaquette{2,Float64}([1, 2, 4, 3], SVector(0.5, 0.5), :square)
+    @test p.vertices == [1, 2, 4, 3]
+    @test plaquette_center(p) == SVector(0.5, 0.5)
+    @test p.type === :square
+end
+
+@testset "Element-center defaults for PlaquetteCenter" begin
+    lat = TinySquareLattice()
+
+    @test num_elements(lat, PlaquetteCenter()) == 1
+    @test length(collect(elements(lat, PlaquetteCenter()))) == 1
+    @test element_position(lat, PlaquetteCenter(), 1) == SVector(0.5, 0.5)
+end
+
+@testset "neighbor_plaquettes default" begin
+    lat = TinySquareLattice()
+    # Every site is on the boundary of the single square plaquette.
+    for i in 1:4
+        @test length(collect(neighbor_plaquettes(lat, i))) == 1
+    end
+end
+
+@testset "element_neighbors (line graph / dual graph)" begin
+    lat = TinySquareLattice()
+
+    @testset "VertexCenter → existing neighbors" begin
+        @test element_neighbors(lat, VertexCenter(), 1) == neighbors(lat, 1)
+    end
+
+    @testset "BondCenter → line graph: bonds sharing a vertex" begin
+        bs = collect(bonds(lat))
+        # TinySquare has 4 bonds: 1-2, 1-3, 2-4, 3-4.
+        @test length(bs) == 4
+        # Every bond shares a vertex with exactly two other bonds in
+        # this tiny square.
+        for i in 1:length(bs)
+            @test length(element_neighbors(lat, BondCenter(), i)) == 2
+        end
+    end
+
+    @testset "PlaquetteCenter → dual graph: single plaquette has no peers" begin
+        @test isempty(element_neighbors(lat, PlaquetteCenter(), 1))
+    end
+end
+
+@testset "incident: cross-centring" begin
+    lat = TinySquareLattice()
+    bs = collect(bonds(lat))
+
+    @testset "VertexCenter → BondCenter: site i is on exactly 2 bonds" begin
+        for i in 1:4
+            inc = incident(lat, VertexCenter(), BondCenter(), i)
+            @test length(inc) == 2
+            # Every returned bond index must actually touch site i.
+            @test all(b -> b.i == i || b.j == i, bs[inc])
+        end
+    end
+
+    @testset "BondCenter → VertexCenter: endpoints" begin
+        for k in 1:length(bs)
+            @test Set(incident(lat, BondCenter(), VertexCenter(), k)) ==
+                Set([bs[k].i, bs[k].j])
+        end
+    end
+
+    @testset "VertexCenter → PlaquetteCenter: every site is on the plaquette" begin
+        for i in 1:4
+            @test incident(lat, VertexCenter(), PlaquetteCenter(), i) == [1]
+        end
+    end
+
+    @testset "PlaquetteCenter → VertexCenter: boundary walk" begin
+        @test incident(lat, PlaquetteCenter(), VertexCenter(), 1) == [1, 2, 4, 3]
+    end
+
+    @testset "BondCenter → PlaquetteCenter: every bond bounds the plaquette" begin
+        for k in 1:length(bs)
+            @test incident(lat, BondCenter(), PlaquetteCenter(), k) == [1]
+        end
+    end
+
+    @testset "PlaquetteCenter → BondCenter: the 4 boundary bonds" begin
+        @test length(incident(lat, PlaquetteCenter(), BondCenter(), 1)) == 4
+    end
+
+    @testset "Same-centring pairs fall through to element_neighbors" begin
+        @test incident(lat, VertexCenter(), VertexCenter(), 1) == neighbors(lat, 1)
+    end
+end


### PR DESCRIPTION
## Summary

Iteration 3a of the LatticeCore-first push. Introduces the **plaquette abstraction** that mirrors the existing `Connection` / `Bond` pattern, plus a **uniform incidence / adjacency API** that makes site / bond / plaquette relationships first-class on `AbstractLattice`.

### New types (`src/Plaquette.jl`)

```julia
# Declarative: what every topology writes down once, then forgets about.
struct PlaquetteRule
    corners::Vector{NTuple{3,Int}}   # (sublattice_id, dx, dy), cyclic
    type::Symbol                     # :square / :up_triangle / :hexagon …
end

# Per-sample, materialised by walking cells × rules under the BC.
struct Plaquette{D, T}
    vertices::Vector{Int}            # 1-based site indices, cyclic
    center::SVector{D, T}
    type::Symbol
end
```

### Abstract functions + defaults

**Plaquette access** (concrete lattices implement `plaquettes`):

```julia
plaquettes(lat)                       # iterator of Plaquette
neighbor_plaquettes(lat, i)           # default: filter plaquettes(lat)
plaquette_center(p)                   # p.center

num_elements(lat, ::PlaquetteCenter)  # default: count(plaquettes(lat))
elements(lat, ::PlaquetteCenter)      # default: plaquettes(lat)
element_position(lat, ::PlaquetteCenter, i)  # default: via collect
```

**Same-centring adjacency** (line / dual graph):

```julia
element_neighbors(lat, ::VertexCenter, i)    # = neighbors(lat, i)
element_neighbors(lat, ::BondCenter, i)      # line graph
element_neighbors(lat, ::PlaquetteCenter, i) # dual graph
```

**Cross-centring incidence** — all 6 pairs:

```julia
incident(lat, VertexCenter(),    BondCenter(),      i)  # bonds touching site i
incident(lat, BondCenter(),      VertexCenter(),    i)  # [b.i, b.j]
incident(lat, VertexCenter(),    PlaquetteCenter(), i)  # plaquettes containing site i
incident(lat, PlaquetteCenter(), VertexCenter(),    i)  # boundary walk
incident(lat, BondCenter(),      PlaquetteCenter(), i)  # plaquettes with bond i on boundary
incident(lat, PlaquetteCenter(), BondCenter(),      i)  # boundary bonds
```

Same-centring pairs (`incident(lat, E(), E(), i)`) fall through to `element_neighbors`, so `incident` is a single unified entry point.

### Implementation notes

- Defaults are **materialisation-based** (`collect(bonds(lat))` / `collect(plaquettes(lat))` each call). They exist for **correctness**, not hot-path performance. Concrete lattices that encode the canonical `(cell, kind)` index formula used by `Connection` / `Bond` will override these for O(1) access in the follow-up (Lattice2D PR).
- The toric code motivation is why all 6 incidence pairs are in this PR: writing `H = -Σ_p B_p - Σ_v A_v` needs both `incident(lat, PlaquetteCenter(), BondCenter(), p)` and `incident(lat, VertexCenter(), BondCenter(), v)` in the same idiom.

### Test plan

Added `test/core/test_plaquette.jl` with a 4-site `TinySquareLattice` and one square plaquette, exercising every default:

- `PlaquetteRule` / `Plaquette` construction and field reads
- `num_elements(lat, PlaquetteCenter()) == 1`
- `element_position(lat, PlaquetteCenter(), 1) == center`
- `neighbor_plaquettes(lat, i)` for every site
- `element_neighbors` for Vertex (existing `neighbors`), Bond (line graph, 2 per bond on the 4-site square), Plaquette (empty — the single plaquette has no peers)
- All 6 `incident` cross-centring pairs, plus the `incident(E, E, i)` → `element_neighbors` fall-through

- [x] `Pkg.test()` — **862 / 862 pass** (was 819, +43 new assertions).

Bumps version 0.8.3 → **0.8.4**.

## Type of Change

- [x] ✨ **Feature** (`enhancement`)
- [ ] 🐛 **Bug Fix** (`bug`)
- [ ] ⚡ **Performance** (`performance`)
- [ ] 📖 **Documentation** (`documentation`)
- [ ] 🧰 **Maintenance** (`chore` or `refactor`)
- [ ] 💥 **Breaking change** (`breaking`)