### PR TITLE
perf: iterator-based element-center API (no collect)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,4 @@
 docs/build/
 docs/src/assets/favicon.ico
 docs/src/assets/logo.png
-Manifest.toml
+Manifest.tomlnotes/

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.8.4"
+version = "0.8.5"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/Bond.jl
+++ b/src/Bond.jl
@@ -93,8 +93,20 @@ elements(lat::AbstractLattice, ::BondCenter) = bonds(lat)
 
 element_position(lat::AbstractLattice, ::VertexCenter, i::Int) = position(lat, i)
 function element_position(lat::AbstractLattice, ::BondCenter, i::Int)
-    bs = collect(bonds(lat))
-    return bond_center(lat, bs[i])
+    return bond_center(lat, _nth(bonds(lat), i))
+end
+
+# Internal: fetch the i-th element of an iterator without collecting.
+# Used by generic element_position / incident defaults so we avoid
+# materialising the full bond/plaquette iterator just to index once.
+function _nth(itr, i::Int)
+    i >= 1 || throw(BoundsError(itr, i))
+    k = 0
+    for x in itr
+        k += 1
+        k == i && return x
+    end
+    throw(BoundsError(itr, i))
 end
 
 # element_positions ----------------------------------------------------

--- a/src/Plaquette.jl
+++ b/src/Plaquette.jl
@@ -101,8 +101,7 @@ elements(lat::AbstractLattice, ::PlaquetteCenter) = plaquettes(lat)
 # Default: materialise and index. O(num_plaquettes) per call; concrete
 # lattices may override for O(1).
 function element_position(lat::AbstractLattice, ::PlaquetteCenter, i::Int)
-    ps = collect(plaquettes(lat))
-    return ps[i].center
+    return _nth(plaquettes(lat), i).center
 end
 
 # ---- Same-centring adjacency (line graph / dual graph) --------------
@@ -126,11 +125,10 @@ function element_neighbors end
 element_neighbors(lat::AbstractLattice, ::VertexCenter, i::Int) = neighbors(lat, i)
 
 function element_neighbors(lat::AbstractLattice, ::BondCenter, i::Int)
-    bs = collect(bonds(lat))
-    b = bs[i]
+    b = _nth(bonds(lat), i)
     endpoints = (b.i, b.j)
     out = Int[]
-    for (k, other) in enumerate(bs)
+    for (k, other) in enumerate(bonds(lat))
         k == i && continue
         if other.i in endpoints || other.j in endpoints
             push!(out, k)
@@ -140,11 +138,10 @@ function element_neighbors(lat::AbstractLattice, ::BondCenter, i::Int)
 end
 
 function element_neighbors(lat::AbstractLattice, ::PlaquetteCenter, i::Int)
-    ps = collect(plaquettes(lat))
-    p = ps[i]
+    p = _nth(plaquettes(lat), i)
     p_edges = _boundary_edges(p)
     out = Int[]
-    for (k, other) in enumerate(ps)
+    for (k, other) in enumerate(plaquettes(lat))
         k == i && continue
         any_shared = false
         for e in p_edges
@@ -198,35 +195,34 @@ end
 
 # Vertex → Bond: bonds touching site i
 function incident(lat::AbstractLattice, ::VertexCenter, ::BondCenter, i::Int)
-    bs = collect(bonds(lat))
-    return [k for (k, b) in enumerate(bs) if b.i == i || b.j == i]
+    return [k for (k, b) in enumerate(bonds(lat)) if b.i == i || b.j == i]
 end
 
 # Bond → Vertex: endpoints of bond i
 function incident(lat::AbstractLattice, ::BondCenter, ::VertexCenter, i::Int)
-    b = collect(bonds(lat))[i]
+    b = _nth(bonds(lat), i)
     return [b.i, b.j]
 end
 
 # Vertex → Plaquette: plaquettes containing site i
 function incident(lat::AbstractLattice, ::VertexCenter, ::PlaquetteCenter, i::Int)
-    ps = collect(plaquettes(lat))
-    return [k for (k, p) in enumerate(ps) if i in p.vertices]
+    return [k for (k, p) in enumerate(plaquettes(lat)) if i in p.vertices]
 end
 
 # Plaquette → Vertex: boundary vertices of plaquette i (in cyclic order)
 function incident(lat::AbstractLattice, ::PlaquetteCenter, ::VertexCenter, i::Int)
-    return collect(plaquettes(lat))[i].vertices
+    return _nth(plaquettes(lat), i).vertices
 end
 
-# Bond → Plaquette: plaquettes whose boundary contains bond i
+# Bond → Plaquette: plaquettes whose boundary contains bond i.
+#
+# Iterator-based: walks `bonds(lat)` once to fetch the i-th bond, then
+# walks `plaquettes(lat)` once. No O(N²) materialisation.
 function incident(lat::AbstractLattice, ::BondCenter, ::PlaquetteCenter, i::Int)
-    bs = collect(bonds(lat))
-    b = bs[i]
+    b = _nth(bonds(lat), i)
     target = (b.i, b.j)
-    ps = collect(plaquettes(lat))
     out = Int[]
-    for (k, p) in enumerate(ps)
+    for (k, p) in enumerate(plaquettes(lat))
         for e in _boundary_edges(p)
             if e == target || e == reverse(target)
                 push!(out, k)
@@ -241,11 +237,10 @@ end
 # integer bond indices. Each boundary edge is matched against
 # `bonds(lat)` by endpoint set; unmatched edges are skipped.
 function incident(lat::AbstractLattice, ::PlaquetteCenter, ::BondCenter, i::Int)
-    p = collect(plaquettes(lat))[i]
-    bs = collect(bonds(lat))
+    p = _nth(plaquettes(lat), i)
     out = Int[]
     for e in _boundary_edges(p)
-        for (k, b) in enumerate(bs)
+        for (k, b) in enumerate(bonds(lat))
             if (b.i, b.j) == e || (b.j, b.i) == e
                 push!(out, k)
                 break


### PR DESCRIPTION
## Summary
- Drop `collect(bonds(lat))` / `collect(plaquettes(lat))` from generic `element_position` / `element_neighbors` / `incident` defaults; walk the iterators directly via a new internal `_nth` helper.
- `incident(lat, BondCenter(), PlaquetteCenter(), i)` and the dual-graph `element_neighbors(::PlaquetteCenter, i)` no longer pre-materialise both sides, eliminating the effectively-O(N^2) allocation pattern called out in the issue.
- Concrete-lattice override surface is unchanged; this only touches `AbstractLattice` fallbacks. No caching layer (kept for a follow-up issue per the plan). Version bump 0.8.4 to 0.8.5.

Closes #31

## Test plan
- [x] `julia --project -e 'using Pkg; Pkg.test()'` (862/862 pass)