### PR TITLE
refactor: SVector return type for incident bond->vertex

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.8.5"
+version = "0.9.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/Plaquette.jl
+++ b/src/Plaquette.jl
@@ -179,6 +179,20 @@ Same-centring pairs (`from == to`) fall through to
 [`element_neighbors`](@ref) so that `incident(lat, E(), E(), i)` is the
 adjacency under centring `E`.
 
+# Return type
+
+The result is always an `AbstractVector{Int}` (iterable, indexable,
+`length`-supporting). When the cardinality is statically known, an
+`SVector{N,Int}` is returned to avoid heap allocation:
+
+- `incident(lat, ::BondCenter, ::VertexCenter, i)` → `SVector{2,Int}`
+  (a bond always has exactly 2 endpoints).
+
+Otherwise (variable plaquette size, dynamic adjacency, etc.) a
+`Vector{Int}` is returned. Callers that previously did
+`a, b = incident(lat, BondCenter(), VertexCenter(), k)` continue to
+work because `SVector` supports tuple-style destructuring.
+
 Concrete lattices may override any pair for O(1) access — the default
 implementations here are O(num_elements) materialisations meant for
 correctness, not hot-path use.
@@ -198,10 +212,13 @@ function incident(lat::AbstractLattice, ::VertexCenter, ::BondCenter, i::Int)
     return [k for (k, b) in enumerate(bonds(lat)) if b.i == i || b.j == i]
 end
 
-# Bond → Vertex: endpoints of bond i
+# Bond → Vertex: endpoints of bond i.
+# Cardinality is statically 2, so we return an `SVector{2,Int}` to avoid
+# the heap allocation a 2-element `Vector{Int}` would incur. The result
+# is still an `AbstractVector{Int}` and supports tuple destructuring.
 function incident(lat::AbstractLattice, ::BondCenter, ::VertexCenter, i::Int)
     b = _nth(bonds(lat), i)
-    return [b.i, b.j]
+    return SVector{2,Int}(b.i, b.j)
 end
 
 # Vertex → Plaquette: plaquettes containing site i

--- a/test/core/test_plaquette.jl
+++ b/test/core/test_plaquette.jl
@@ -107,8 +107,13 @@ end
 
     @testset "BondCenter → VertexCenter: endpoints" begin
         for k in 1:length(bs)
-            @test Set(incident(lat, BondCenter(), VertexCenter(), k)) ==
-                Set([bs[k].i, bs[k].j])
+            inc = incident(lat, BondCenter(), VertexCenter(), k)
+            # Static cardinality (2) → SVector{2,Int}, no heap allocation.
+            @test inc isa SVector{2,Int}
+            @test Set(inc) == Set([bs[k].i, bs[k].j])
+            # Tuple-style destructuring must keep working.
+            a, b = inc
+            @test Set((a, b)) == Set([bs[k].i, bs[k].j])
         end
     end
 


### PR DESCRIPTION
## Summary
- `incident(lat, ::BondCenter, ::VertexCenter, i)` now returns `SVector{2,Int}` instead of a heap-allocated `Vector{Int}`. Bond endpoints are statically a pair, so the static container removes the per-call allocation while staying an `AbstractVector{Int}`.
- Other `incident` methods (variable plaquette size, vertex/bond adjacency, plaquette boundary walks) keep returning `Vector{Int}` because cardinality is dynamic.
- Documented the return-type contract on the `incident` docstring: always `AbstractVector{Int}`, with `SVector{N,Int}` when cardinality is statically known.
- Project.toml bumped 0.8.5 → 0.9.0.

Closes #33

## Test plan
- [x] `julia --project -e 'using Pkg; Pkg.test()'` — 870/870 pass locally
- [x] New test asserts `incident(lat, BondCenter(), VertexCenter(), k) isa SVector{2,Int}` and that tuple destructuring (`a, b = inc`) still works
- [ ] Downstream Lattice2D / QuasiCrystal compat bump in a follow-up PR

## Breaking changes
- Return type of `incident(lat, ::BondCenter, ::VertexCenter, i)` changes from `Vector{Int}` to `SVector{2,Int}`.
- Source-compatible for the common patterns: iteration, indexing, `length`, `Set(...)`, `collect(...)`, and tuple destructuring all keep working.
- Will break: code that dispatches on the concrete type `Vector{Int}`, mutates the result via `push!`/`pop!`/`resize!`, or relies on `=== Vector{Int}` identity. Such call sites must relax to `AbstractVector{Int}` or wrap with `collect`.
- No change to the other `incident` overloads in this PR.