### PR TITLE
batch: docs + perf cleanups (#32, #34, #35, #36)

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.9.0"
+version = "0.9.1"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/Bond.jl
+++ b/src/Bond.jl
@@ -96,8 +96,9 @@ end
 _iter_length(itr, ::Base.HasLength) = length(itr)
 _iter_length(itr, ::Base.HasShape) = length(itr)
 _iter_length(itr, ::Base.SizeUnknown) = count(_ -> true, itr)
-_iter_length(itr, ::Base.IsInfinite) =
+function _iter_length(itr, ::Base.IsInfinite)
     throw(ArgumentError("cannot take length of infinite iterator"))
+end
 
 # elements -------------------------------------------------------------
 

--- a/src/Bond.jl
+++ b/src/Bond.jl
@@ -81,8 +81,23 @@ end
 
 num_elements(lat::AbstractLattice, ::VertexCenter) = num_sites(lat)
 function num_elements(lat::AbstractLattice, ::BondCenter)
-    return count(_ -> true, bonds(lat))
+    return _iter_length(bonds(lat))
 end
+
+# Internal: O(1) length when the iterator declares one, otherwise a
+# single counting pass. This avoids `count(_ -> true, …)` walking the
+# iterator a second time when concrete lattices already know the size
+# (e.g. via a `Vector{Bond}` override of `bonds(lat)`). Concrete
+# lattices retain the option to override `num_elements(lat, …)`
+# directly with an O(1) closed-form.
+function _iter_length(itr)
+    return _iter_length(itr, Base.IteratorSize(itr))
+end
+_iter_length(itr, ::Base.HasLength) = length(itr)
+_iter_length(itr, ::Base.HasShape) = length(itr)
+_iter_length(itr, ::Base.SizeUnknown) = count(_ -> true, itr)
+_iter_length(itr, ::Base.IsInfinite) =
+    throw(ArgumentError("cannot take length of infinite iterator"))
 
 # elements -------------------------------------------------------------
 

--- a/src/BoundaryCondition.jl
+++ b/src/BoundaryCondition.jl
@@ -67,6 +67,20 @@ Abstract supertype for boundary modifiers. A modifier does not change
 which bonds exist — it only reweights existing bonds through
 [`bond_weight`](@ref). Examples: [`NoModifier`](@ref),
 [`SSD`](@ref).
+
+# Extending
+
+Downstream packages may define their own modifier types by
+subtyping `AbstractBoundaryModifier` and overloading
+
+    bond_weight(::MyModifier, lat::AbstractLattice, i::Int, j::Int)::Float64
+
+The two-argument default `bond_weight(modifier, lat)` may also be
+overloaded if a modifier wants to broadcast a single scalar over
+the whole lattice. `AbstractBoundaryModifier` and the concrete
+[`NoModifier`](@ref) / [`SSD`](@ref) types are part of the public
+exported API of `LatticeCore` precisely so downstream code can
+extend them.
 """
 abstract type AbstractBoundaryModifier end
 
@@ -80,6 +94,11 @@ Sine-square deformation modifier. `L` is the characteristic scale
 used by the envelope `sin²(π · x/L)`. The concrete weight implementation
 will land with the MC layer; for now this serves as a placeholder
 carrying the scale parameter.
+
+`SSD` is exported so downstream MC / TN packages can construct
+boundaries with SSD weighting and dispatch on the type. Custom
+deformations should subtype [`AbstractBoundaryModifier`](@ref)
+rather than re-using `SSD`.
 """
 struct SSD{T<:Real} <: AbstractBoundaryModifier
     L::T

--- a/src/MomentumLattice.jl
+++ b/src/MomentumLattice.jl
@@ -138,8 +138,27 @@ end
 """
     reciprocal_lattice(lat::AbstractLattice) → PeriodicMomentumLattice
 
-Construct the reciprocal lattice for a Bravais-like `lat`. Concrete
-lattices are expected to specialise this method; the fallback throws.
+Construct the reciprocal lattice for a Bravais-like `lat`.
+
+# Trait contract
+
+This method is a **required override** for any concrete lattice
+whose `reciprocal_support(lat)` returns [`HasReciprocal`](@ref).
+The fallback deliberately throws a `MethodError` so missing
+implementations surface immediately at the trait dispatch site
+(see [`momentum_lattice`](@ref), which routes `HasReciprocal`
+lattices through `reciprocal_lattice`).
+
+Lattices with `reciprocal_support(lat) == NoReciprocal()` MUST NOT
+override this method — they have no Bravais reciprocal structure
+and `momentum_lattice` will refuse to call them. Lattices with
+`HasFourierModule()` should implement [`fourier_module`](@ref)
+instead.
+
+The returned object is expected to satisfy the
+[`AbstractMomentumLattice`](@ref) interface (`num_k_points`,
+`k_point`, `reciprocal_basis`); the canonical concrete return type
+is [`PeriodicMomentumLattice`](@ref).
 """
 function reciprocal_lattice(lat::AbstractLattice)
     throw(MethodError(reciprocal_lattice, (lat,)))
@@ -149,8 +168,25 @@ end
     fourier_module(lat::AbstractLattice) → AbstractMomentumLattice
 
 Quasicrystal-side entry point: construct the discrete Fourier module
-(Bragg peak set) for a cut-and-project lattice. Concrete quasicrystal
-lattices implement this in their own package; the fallback throws.
+(Bragg peak set) for a cut-and-project lattice.
+
+# Trait contract
+
+This method is a **required override** for any concrete lattice
+whose `reciprocal_support(lat)` returns [`HasFourierModule`](@ref).
+Concrete quasicrystal lattices implement it in their own package
+(typically `QuasiCrystal.jl`); the fallback throws a `MethodError`
+so the trait/method mismatch is visible at the call site through
+[`momentum_lattice`](@ref).
+
+Lattices with [`HasReciprocal`](@ref) should implement
+[`reciprocal_lattice`](@ref) instead, and lattices with
+[`NoReciprocal`](@ref) should not override either.
+
+The returned object is expected to be an
+[`AbstractMomentumLattice`](@ref) — typically a
+[`BraggPeakSet`](@ref) — so observers like `structure_factor`
+treat periodic and quasiperiodic lattices uniformly.
 """
 function fourier_module(lat::AbstractLattice)
     throw(MethodError(fourier_module, (lat,)))

--- a/src/Plaquette.jl
+++ b/src/Plaquette.jl
@@ -92,7 +92,7 @@ plaquette_center(p::Plaquette) = p.center
 # Default: count via the plaquettes iterator. Concrete lattices may
 # override with an O(1) cell×kind formula.
 function num_elements(lat::AbstractLattice, ::PlaquetteCenter)
-    return count(_ -> true, plaquettes(lat))
+    return _iter_length(plaquettes(lat))
 end
 
 # Default: return the iterator as-is.

--- a/src/SiteLayout.jl
+++ b/src/SiteLayout.jl
@@ -49,6 +49,21 @@ which sublattice site `i` belongs to (1-based).
 
 This is the natural layout for mixed-spin models (e.g. Ising on the
 A sublattice, XY on B).
+
+# Ownership / mutability contract
+
+`SublatticeLayout` stores the `sublattice_of::Vector{Int}` argument
+**by reference**, not by copy. The caller MUST treat the vector as
+immutable for the lifetime of the `SublatticeLayout`: mutating it
+(`push!`, `setindex!`, `resize!`, etc.) after construction will
+silently corrupt site-type lookups, since `site_type(layout, i)`
+indexes directly into this storage.
+
+If the caller wants to keep a mutable copy of the assignment, it
+should pass `copy(sublattice_of)` to the constructor explicitly.
+A future release may switch the field to a read-only container
+(e.g. an `NTuple{M,Int}` or a wrapper); doing so would be a
+breaking change and is tracked separately.
 """
 struct SublatticeLayout{N,Tup<:NTuple{N,AbstractSiteType}} <: AbstractSiteLayout
     by_sublattice::Tup


### PR DESCRIPTION
## Summary

### #32 reciprocal_lattice / fourier_module trait contract
Expanded docstrings on `reciprocal_lattice` and `fourier_module` to
spell out the trait routing: `HasReciprocal` lattices must override
`reciprocal_lattice`, `HasFourierModule` lattices must override
`fourier_module`, and `NoReciprocal` lattices must override neither.
The `MethodError` fallback is now documented as intentional.

### #34 AbstractBoundaryModifier / SSD exports
`AbstractBoundaryModifier` and `SSD` were already in the export list;
this PR confirms that and adds an "Extending" section to the
docstrings so downstream packages know they can subtype
`AbstractBoundaryModifier` and overload `bond_weight`.

### #35 SublatticeLayout ownership / mutability contract
Documented that `SublatticeLayout` stores `sublattice_of::Vector{Int}`
**by reference**, and that the caller must not mutate it after
construction. Behaviour is unchanged; switching to a read-only
container would be breaking and is flagged as a separate issue.

### #36 num_elements double-iteration
`num_elements(lat, ::BondCenter)` and `num_elements(lat, ::PlaquetteCenter)`
no longer use `count(_ -> true, …)` unconditionally. They route
through a small `_iter_length` helper that uses `Base.IteratorSize`
to pick `length(itr)` when the iterator declares one (e.g. when a
concrete lattice overrides `bonds(lat)` to return a `Vector{Bond}`)
and falls back to `count` only for `SizeUnknown` iterators.
Concrete lattices may still override `num_elements` directly with
an O(1) closed-form.

Closes #32. Closes #34. Closes #35. Closes #36.

## Test plan

- [x] `julia --project -e 'using Pkg; Pkg.test()'` — 870 / 870 pass
- [x] No public-API breakage (no signature changes; only docs +
      internal helper + version bump 0.9.0 -> 0.9.1)