### PR TITLE
perf+docs: @inbounds Indexing arithmetic; clarify element index ordering

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.9.1"
+version = "0.9.2"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/Indexing.jl
+++ b/src/Indexing.jl
@@ -147,9 +147,7 @@ end
 # Row-major layout, but within each row the x-direction alternates:
 # odd rows walk x = 1..Lx, even rows walk x = Lx..1.
 
-@inline function site_index(
-    ::Snake, dims::NTuple{2,Int}, nsub::Int, coord::LatticeCoord{2}
-)
+@inline function site_index(::Snake, dims::NTuple{2,Int}, nsub::Int, coord::LatticeCoord{2})
     @inbounds begin
         cx, cy = coord.cell
         s = coord.sublattice

--- a/src/Indexing.jl
+++ b/src/Indexing.jl
@@ -67,56 +67,79 @@ function lattice_coord end
 # only RowMajor for 1D and let the others fall through (they would
 # simply error out; 1D Snake is actively meaningless).
 
-function site_index(::RowMajor, dims::NTuple{1,Int}, nsub::Int, coord::LatticeCoord{1})
-    cx = coord.cell[1]
+# Performance note: the round-trip arithmetic below is purely bounded
+# integer ops (`÷`, `%`, `+`, `*`) on values that the caller is expected
+# to keep within `1:prod(dims) * nsub`. We use `@inbounds` to elide
+# tuple bounds checks on `dims[..]` / `coord.cell[..]`; the math itself
+# already cannot fault. Out-of-range `i` or `coord` is the caller's
+# contract to avoid (consistent with `getindex` on a `Vector`).
+
+@inline function site_index(
+    ::RowMajor, dims::NTuple{1,Int}, nsub::Int, coord::LatticeCoord{1}
+)
+    @inbounds cx = coord.cell[1]
     s = coord.sublattice
     return (cx - 1) * nsub + s
 end
 
-function lattice_coord(::RowMajor, ::NTuple{1,Int}, nsub::Int, i::Int)
-    c = (i - 1) ÷ nsub
-    s = (i - 1) % nsub + 1
-    return LatticeCoord((c + 1,), s)
+@inline function lattice_coord(::RowMajor, ::NTuple{1,Int}, nsub::Int, i::Int)
+    @inbounds begin
+        c = (i - 1) ÷ nsub
+        s = (i - 1) % nsub + 1
+        return LatticeCoord((c + 1,), s)
+    end
 end
 
 # ---- 2D RowMajor ------------------------------------------------------
 #
 # site_index(cx, cy, s) = ((cy - 1) * Lx + (cx - 1)) * nsub + s
 
-function site_index(::RowMajor, dims::NTuple{2,Int}, nsub::Int, coord::LatticeCoord{2})
-    cx, cy = coord.cell
-    s = coord.sublattice
-    Lx = dims[1]
-    return ((cy - 1) * Lx + (cx - 1)) * nsub + s
+@inline function site_index(
+    ::RowMajor, dims::NTuple{2,Int}, nsub::Int, coord::LatticeCoord{2}
+)
+    @inbounds begin
+        cx, cy = coord.cell
+        s = coord.sublattice
+        Lx = dims[1]
+        return ((cy - 1) * Lx + (cx - 1)) * nsub + s
+    end
 end
 
-function lattice_coord(::RowMajor, dims::NTuple{2,Int}, nsub::Int, i::Int)
-    c = (i - 1) ÷ nsub
-    s = (i - 1) % nsub + 1
-    Lx = dims[1]
-    cx = c % Lx + 1
-    cy = c ÷ Lx + 1
-    return LatticeCoord((cx, cy), s)
+@inline function lattice_coord(::RowMajor, dims::NTuple{2,Int}, nsub::Int, i::Int)
+    @inbounds begin
+        c = (i - 1) ÷ nsub
+        s = (i - 1) % nsub + 1
+        Lx = dims[1]
+        cx = c % Lx + 1
+        cy = c ÷ Lx + 1
+        return LatticeCoord((cx, cy), s)
+    end
 end
 
 # ---- 2D ColMajor ------------------------------------------------------
 #
 # site_index(cx, cy, s) = ((cx - 1) * Ly + (cy - 1)) * nsub + s
 
-function site_index(::ColMajor, dims::NTuple{2,Int}, nsub::Int, coord::LatticeCoord{2})
-    cx, cy = coord.cell
-    s = coord.sublattice
-    Ly = dims[2]
-    return ((cx - 1) * Ly + (cy - 1)) * nsub + s
+@inline function site_index(
+    ::ColMajor, dims::NTuple{2,Int}, nsub::Int, coord::LatticeCoord{2}
+)
+    @inbounds begin
+        cx, cy = coord.cell
+        s = coord.sublattice
+        Ly = dims[2]
+        return ((cx - 1) * Ly + (cy - 1)) * nsub + s
+    end
 end
 
-function lattice_coord(::ColMajor, dims::NTuple{2,Int}, nsub::Int, i::Int)
-    c = (i - 1) ÷ nsub
-    s = (i - 1) % nsub + 1
-    Ly = dims[2]
-    cy = c % Ly + 1
-    cx = c ÷ Ly + 1
-    return LatticeCoord((cx, cy), s)
+@inline function lattice_coord(::ColMajor, dims::NTuple{2,Int}, nsub::Int, i::Int)
+    @inbounds begin
+        c = (i - 1) ÷ nsub
+        s = (i - 1) % nsub + 1
+        Ly = dims[2]
+        cy = c % Ly + 1
+        cx = c ÷ Ly + 1
+        return LatticeCoord((cx, cy), s)
+    end
 end
 
 # ---- 2D Snake ---------------------------------------------------------
@@ -124,22 +147,28 @@ end
 # Row-major layout, but within each row the x-direction alternates:
 # odd rows walk x = 1..Lx, even rows walk x = Lx..1.
 
-function site_index(::Snake, dims::NTuple{2,Int}, nsub::Int, coord::LatticeCoord{2})
-    cx, cy = coord.cell
-    s = coord.sublattice
-    Lx = dims[1]
-    effective_x = isodd(cy) ? cx : (Lx + 1 - cx)
-    cell_index = (cy - 1) * Lx + effective_x
-    return (cell_index - 1) * nsub + s
+@inline function site_index(
+    ::Snake, dims::NTuple{2,Int}, nsub::Int, coord::LatticeCoord{2}
+)
+    @inbounds begin
+        cx, cy = coord.cell
+        s = coord.sublattice
+        Lx = dims[1]
+        effective_x = isodd(cy) ? cx : (Lx + 1 - cx)
+        cell_index = (cy - 1) * Lx + effective_x
+        return (cell_index - 1) * nsub + s
+    end
 end
 
-function lattice_coord(::Snake, dims::NTuple{2,Int}, nsub::Int, i::Int)
-    c = (i - 1) ÷ nsub
-    s = (i - 1) % nsub + 1
-    Lx = dims[1]
-    cell_index = c + 1
-    cy = (cell_index - 1) ÷ Lx + 1
-    effective_x = (cell_index - 1) % Lx + 1
-    cx = isodd(cy) ? effective_x : (Lx + 1 - effective_x)
-    return LatticeCoord((cx, cy), s)
+@inline function lattice_coord(::Snake, dims::NTuple{2,Int}, nsub::Int, i::Int)
+    @inbounds begin
+        c = (i - 1) ÷ nsub
+        s = (i - 1) % nsub + 1
+        Lx = dims[1]
+        cell_index = c + 1
+        cy = (cell_index - 1) ÷ Lx + 1
+        effective_x = (cell_index - 1) % Lx + 1
+        cx = isodd(cy) ? effective_x : (Lx + 1 - effective_x)
+        return LatticeCoord((cx, cy), s)
+    end
 end

--- a/src/LatticeElement.jl
+++ b/src/LatticeElement.jl
@@ -51,6 +51,23 @@ function elements end
 
 Real-space position of the `i`-th element of centring `e` on `lat`.
 See `Bond.jl` for the default `VertexCenter` / `BondCenter` methods.
+
+# Indexing convention
+
+The integer `i` follows the enumeration order of:
+
+- `1:num_sites(lat)` for `VertexCenter`,
+- `enumerate(bonds(lat))` for `BondCenter`,
+- `enumerate(plaquettes(lat))` for `PlaquetteCenter`.
+
+This means `i` is **lattice-specific**: a concrete lattice that
+overrides `bonds(lat)` / `plaquettes(lat)` (or returns them in a
+different order from another lattice type) implicitly redefines what
+`i` means here. Generic code that round-trips via integer indices is
+safe only within a single lattice instance; for cross-lattice
+identification of an element, materialise it through `elements(lat, e)`
+instead. A typed `BondIndex` / `PlaquetteIndex` wrapper that makes
+this contract type-level is tracked as a follow-up.
 """
 function element_position end
 

--- a/src/Plaquette.jl
+++ b/src/Plaquette.jl
@@ -196,6 +196,15 @@ work because `SVector` supports tuple-style destructuring.
 Concrete lattices may override any pair for O(1) access — the default
 implementations here are O(num_elements) materialisations meant for
 correctness, not hot-path use.
+
+# Indexing convention
+
+Both the input index `i` (for centring `from`) and the integer indices
+in the returned vector (for centring `to`) follow the enumeration
+order of `1:num_sites(lat)` / `enumerate(bonds(lat))` /
+`enumerate(plaquettes(lat))` — same convention as
+[`element_position`](@ref). Indices are lattice-specific and not
+portable across lattice instances.
 """
 function incident end
 


### PR DESCRIPTION
## Summary

- Indexing.jl: add `@inbounds` (and `@inline`) to all dimension-specific `site_index` / `lattice_coord` methods. Round-trip arithmetic is pure modulo / div / add on values the caller is contracted to keep in range, so bounds-checks on `dims[..]` / `coord.cell[..]` are pure overhead.
- Document index ordering on `element_position` and `incident`: integer `i` follows `1:num_sites(lat)` / `enumerate(bonds(lat))` / `enumerate(plaquettes(lat))`, and is lattice-specific. A typed `BondIndex` / `PlaquetteIndex` wrapper is deferred (kept out of scope here to avoid an API break).
- Patch bump 0.9.1 → 0.9.2.

### Micro-benchmark (2D, dims=(64,64), nsub=2, 200 sweeps over all sites)

| method | before | after |
|---|---|---|
| `lattice_coord` RowMajor | 15.6 ms | 6.2 ms |
| `lattice_coord` ColMajor | 15.7 ms | 6.3 ms |
| `lattice_coord` Snake    | 13.5 ms | 7.2 ms |

`site_index` is below the timer floor (~8 µs) in both versions but also benefits.

Closes #37
Closes #38

## Test plan

- [x] `julia --project -e 'using Pkg; Pkg.test()'` — 870/870 pass locally
- [ ] CI green on PR