### PR TITLE
test+docs: integrate Aqua.jl QA

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.9.2"
+version = "0.9.3"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]
@@ -14,14 +14,19 @@ Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 LatticeCorePlotsExt = "Plots"
 
 [compat]
+Aqua = "0.8"
+LinearAlgebra = "1"
 Plots = "1"
+Random = "1"
 StaticArrays = "1"
+Test = "1"
 julia = "1.10"
 
 [extras]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Plots", "Random", "Test"]
+test = ["Aqua", "Plots", "Random", "Test"]

--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@
 
 [![codecov](https://codecov.io/gh/sotashimozono/LatticeCore.jl/graph/badge.svg?token=oSYKPUteiH)](https://codecov.io/gh/sotashimozono/LatticeCore.jl)
 [![Build Status](https://github.com/sotashimozono/LatticeCore.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/sotashimozono/LatticeCore.jl/actions/workflows/CI.yml?query=branch%3Amain)
+[![Aqua QA](https://raw.githubusercontent.com/JuliaTesting/Aqua.jl/master/badge.svg)](https://github.com/JuliaTesting/Aqua.jl)
 [![License](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
 
 **LatticeCore** is the abstract interface layer for a family of
@@ -118,6 +119,13 @@ LatticeCore.jl            (this package, abstract interface)
 LatticeCore itself is deliberately small. It is the contract every
 downstream package agrees on; it does not ship a production lattice
 catalogue, a quasicrystal generator, or a Monte Carlo runtime.
+
+## Quality assurance
+
+The test suite runs [Aqua.jl](https://github.com/JuliaTesting/Aqua.jl)
+on every CI build (ambiguities, unbound type parameters, undefined
+exports, stale deps, compat bounds, piracy). All checks pass on
+`main`.
 
 ## License
 

--- a/src/Coordinate.jl
+++ b/src/Coordinate.jl
@@ -36,7 +36,10 @@ end
 
 # The `RealSpace(x::SVector{D, T})` outer constructor is auto-generated
 # by Julia from the inner; we only need an extra tuple-based overload.
-RealSpace(xs::NTuple{D,T}) where {D,T<:Real} = RealSpace(SVector(xs))
+# We spell the tuple as `Tuple{T, Vararg{T}}` rather than `NTuple{D, T}`
+# so that `T` stays bound (an empty tuple `NTuple{0, T}` cannot pin `T`,
+# which Aqua.test_unbound_args correctly flags).
+RealSpace(xs::Tuple{T,Vararg{T}}) where {T<:Real} = RealSpace(SVector(xs))
 
 # ---- LatticeCoord ----------------------------------------------------
 

--- a/test/core/test_aqua.jl
+++ b/test/core/test_aqua.jl
@@ -1,0 +1,15 @@
+using LatticeCore
+using Test
+using Aqua
+
+@testset "Aqua" begin
+    # Run all Aqua checks. We start with `test_all` and only carve out
+    # checks individually if a false positive shows up.
+    Aqua.test_all(LatticeCore; ambiguities = false, persistent_tasks = false)
+
+    # `test_all` skips ambiguity checks above because Base/stdlib can
+    # introduce method ambiguities outside our control. Restrict the
+    # ambiguity check to our own package so regressions inside
+    # LatticeCore are still caught.
+    Aqua.test_ambiguities(LatticeCore)
+end


### PR DESCRIPTION
## Summary
- Add Aqua.jl 0.8 to `[extras]`/`[targets]` and run `Aqua.test_all` + `Aqua.test_ambiguities(LatticeCore)` from `test/core/test_aqua.jl`.
- Fix the issues Aqua surfaced: declare stdlib compat (`LinearAlgebra`/`Random`/`Test = "1"`) and fix an unbound type parameter in the `RealSpace(::NTuple{D,T})` outer constructor (replaced with `Tuple{T,Vararg{T}}`).
- README: add an Aqua QA badge and a short quality-assurance section.
- Patch bump `0.9.2 -> 0.9.3`.

Aqua checks enabled: `ambiguities` (scoped to `LatticeCore`), `unbound_args`, `undefined_exports`, `project_extras`, `stale_deps`, `deps_compat`, `piracy`, `project_toml_formatting`. Disabled: `persistent_tasks` (test_all default for libraries with no async behaviour) and the global `ambiguities` of `test_all` (replaced by the package-scoped form so Base/stdlib ambiguities outside our control don't cause CI flakes).

Closes #30

## Test plan
- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes locally (880/880).
- [ ] CI green on `feat/aqua-integration`.