### PR TITLE
feat: graph operations API + 3D RowMajor indexing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,10 +1,11 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.9.3"
+version = "0.10.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [weakdeps]
@@ -18,6 +19,7 @@ Aqua = "0.8"
 LinearAlgebra = "1"
 Plots = "1"
 Random = "1"
+SparseArrays = "1"
 StaticArrays = "1"
 Test = "1"
 julia = "1.10"

--- a/src/Graph.jl
+++ b/src/Graph.jl
@@ -1,0 +1,217 @@
+"""
+    Graph operations for `AbstractLattice`.
+
+This file provides a small, dependency-light graph layer on top of the
+`AbstractLattice` interface:
+
+- [`adjacency_matrix`](@ref) — N × N adjacency as a `SparseMatrixCSC{Bool, Int}`
+  (or a dense `Matrix{Bool}` when `sparse=false`),
+- [`shortest_path`](@ref) — unweighted hop-count shortest path via BFS,
+  returning both the distance and a reconstructed path,
+- [`connected_components`](@ref) — connected components of the lattice
+  graph as a `Vector{Vector{Int}}`.
+
+Adjacency is built from the canonical `BondCenter` element iterator
+(`elements(lat, BondCenter())`) so that whatever bonds a lattice
+publishes are exactly what these graph operations see. This keeps the
+API generic over any concrete `AbstractLattice` and consistent with
+the rest of the element-centric interface.
+
+Only `SparseArrays` (stdlib) is used; `Graphs.jl` is intentionally not
+a dependency.
+"""
+
+using SparseArrays
+
+"""
+    adjacency_matrix(lat::AbstractLattice; sparse::Bool=true)
+
+Return the N × N undirected adjacency matrix of the lattice graph,
+where `N = num_sites(lat)`. The matrix is symmetric; `A[i, j] == true`
+iff there is a bond between sites `i` and `j`.
+
+Bonds are taken from `elements(lat, BondCenter())`, so concrete lattices
+that override `bonds(lat)` automatically get a consistent adjacency
+matrix without further work.
+
+# Keyword arguments
+- `sparse=true` (default): return a `SparseMatrixCSC{Bool, Int}`. This
+  is the recommended form for large lattices.
+- `sparse=false`: return a dense `Matrix{Bool}` of the same content.
+  Useful for tiny test lattices and notebooks.
+
+Self-loops (a bond with `i == j`) are skipped. Duplicate bonds in the
+input are folded into a single entry.
+
+# Example
+```julia
+lat = SimpleSquareLattice(3, 3, OpenAxis())
+A = adjacency_matrix(lat)        # 9×9 SparseMatrixCSC{Bool, Int}
+A == transpose(A)                # true
+```
+"""
+function adjacency_matrix(lat::AbstractLattice; sparse::Bool=true)
+    is_finite(lat) ||
+        throw(ArgumentError("adjacency_matrix requires a finite lattice"))
+    N = num_sites(lat)
+    Is = Int[]
+    Js = Int[]
+    seen = Set{Tuple{Int,Int}}()
+    for b in elements(lat, BondCenter())
+        i, j = b.i, b.j
+        i == j && continue
+        key = i < j ? (i, j) : (j, i)
+        key in seen && continue
+        push!(seen, key)
+        push!(Is, i)
+        push!(Js, j)
+        push!(Is, j)
+        push!(Js, i)
+    end
+    Vs = trues(length(Is))
+    return _adjacency_matrix_assemble(Is, Js, Vs, N, sparse)
+end
+
+# Internal: pick sparse vs dense storage. `combine = |` folds any
+# duplicated coordinate (shouldn't happen because of the `seen` guard,
+# but cheap insurance) into a single `true`. The keyword argument
+# shadowing happens because `adjacency_matrix(...; sparse=true)`
+# binds `sparse` locally to a `Bool`, which would otherwise prevent
+# us from calling `SparseArrays.sparse(...)`. We pass the flag in
+# under a non-colliding name and qualify the constructor explicitly.
+function _adjacency_matrix_assemble(
+    Is::Vector{Int}, Js::Vector{Int}, Vs::AbstractVector{Bool}, N::Int, use_sparse::Bool
+)
+    if use_sparse
+        return SparseArrays.sparse(Is, Js, Vs, N, N, |)
+    else
+        # Return a true `Matrix{Bool}` (not a `BitMatrix`) so callers
+        # that dispatch on dense representations get the expected
+        # element-type-preserving array.
+        M = zeros(Bool, N, N)
+        @inbounds for k in eachindex(Is)
+            M[Is[k], Js[k]] = true
+        end
+        return M
+    end
+end
+
+"""
+    shortest_path(lat::AbstractLattice, src::Int, dst::Int)
+        -> (dist::Int, path::Vector{Int})
+
+Unweighted shortest path on the lattice graph from `src` to `dst`,
+computed via breadth-first search using `neighbors(lat, ·)`.
+
+Returns a tuple `(dist, path)` where:
+- `dist` is the hop count (number of bonds) between `src` and `dst`.
+  `0` if `src == dst`.
+- `path` is the reconstructed sequence of site indices, starting at
+  `src` and ending at `dst`. `[src]` if `src == dst`.
+
+If `src` and `dst` are in different connected components,
+`(typemax(Int), Int[])` is returned. Edges are treated as having unit
+weight; for weighted shortest paths, downstream packages may add a
+Dijkstra/A* layer on top.
+
+# Example
+```julia
+lat = SimpleSquareLattice(3, 3, OpenAxis())
+d, p = shortest_path(lat, 1, 9)
+# d == 4, p == [1, 2, 3, 6, 9]   (one of several minimum paths)
+```
+"""
+function shortest_path(lat::AbstractLattice, src::Int, dst::Int)
+    is_finite(lat) ||
+        throw(ArgumentError("shortest_path requires a finite lattice"))
+    N = num_sites(lat)
+    (1 <= src <= N) || throw(BoundsError(lat, src))
+    (1 <= dst <= N) || throw(BoundsError(lat, dst))
+
+    if src == dst
+        return (0, [src])
+    end
+
+    parent = fill(0, N)
+    visited = falses(N)
+    visited[src] = true
+    queue = Int[src]
+    head = 1
+    found = false
+    while head <= length(queue)
+        u = queue[head]
+        head += 1
+        for v in neighbors(lat, u)
+            if !visited[v]
+                visited[v] = true
+                parent[v] = u
+                if v == dst
+                    found = true
+                    break
+                end
+                push!(queue, v)
+            end
+        end
+        found && break
+    end
+
+    if !found
+        return (typemax(Int), Int[])
+    end
+
+    # Reconstruct path src -> ... -> dst by walking parents backwards.
+    path = Int[dst]
+    cur = dst
+    while cur != src
+        cur = parent[cur]
+        push!(path, cur)
+    end
+    reverse!(path)
+    return (length(path) - 1, path)
+end
+
+"""
+    connected_components(lat::AbstractLattice) -> Vector{Vector{Int}}
+
+Return the connected components of the lattice graph, computed by BFS
+over `neighbors(lat, ·)`. Each inner vector is sorted in ascending
+order of site index, and components are returned in order of their
+smallest member.
+
+Useful for analysing diluted / defective lattices and for sanity
+checks on user-defined `AbstractLattice` subtypes.
+
+# Example
+```julia
+# A 3x3 open square stripped of one site is still connected:
+length(connected_components(lat)) == 1
+```
+"""
+function connected_components(lat::AbstractLattice)
+    is_finite(lat) ||
+        throw(ArgumentError("connected_components requires a finite lattice"))
+    N = num_sites(lat)
+    visited = falses(N)
+    comps = Vector{Vector{Int}}()
+    for s in 1:N
+        visited[s] && continue
+        comp = Int[]
+        queue = Int[s]
+        visited[s] = true
+        head = 1
+        while head <= length(queue)
+            u = queue[head]
+            head += 1
+            push!(comp, u)
+            for v in neighbors(lat, u)
+                if !visited[v]
+                    visited[v] = true
+                    push!(queue, v)
+                end
+            end
+        end
+        sort!(comp)
+        push!(comps, comp)
+    end
+    return comps
+end

--- a/src/Graph.jl
+++ b/src/Graph.jl
@@ -51,8 +51,7 @@ A == transpose(A)                # true
 ```
 """
 function adjacency_matrix(lat::AbstractLattice; sparse::Bool=true)
-    is_finite(lat) ||
-        throw(ArgumentError("adjacency_matrix requires a finite lattice"))
+    is_finite(lat) || throw(ArgumentError("adjacency_matrix requires a finite lattice"))
     N = num_sites(lat)
     Is = Int[]
     Js = Int[]
@@ -122,8 +121,7 @@ d, p = shortest_path(lat, 1, 9)
 ```
 """
 function shortest_path(lat::AbstractLattice, src::Int, dst::Int)
-    is_finite(lat) ||
-        throw(ArgumentError("shortest_path requires a finite lattice"))
+    is_finite(lat) || throw(ArgumentError("shortest_path requires a finite lattice"))
     N = num_sites(lat)
     (1 <= src <= N) || throw(BoundsError(lat, src))
     (1 <= dst <= N) || throw(BoundsError(lat, dst))
@@ -188,8 +186,7 @@ length(connected_components(lat)) == 1
 ```
 """
 function connected_components(lat::AbstractLattice)
-    is_finite(lat) ||
-        throw(ArgumentError("connected_components requires a finite lattice"))
+    is_finite(lat) || throw(ArgumentError("connected_components requires a finite lattice"))
     N = num_sites(lat)
     visited = falses(N)
     comps = Vector{Vector{Int}}()

--- a/src/Indexing.jl
+++ b/src/Indexing.jl
@@ -142,6 +142,42 @@ end
     end
 end
 
+# ---- 3D RowMajor ------------------------------------------------------
+#
+# site_index(cx, cy, cz, s) =
+#     (((cz - 1) * Ly + (cy - 1)) * Lx + (cx - 1)) * nsub + s
+#
+# Convention: x is the fastest axis, then y, then z (slowest). This
+# matches the 2D RowMajor extension and is the natural ordering for
+# downstream consumers that treat a 3D lattice as a stack of
+# row-major 2D slices.
+
+@inline function site_index(
+    ::RowMajor, dims::NTuple{3,Int}, nsub::Int, coord::LatticeCoord{3}
+)
+    @inbounds begin
+        cx, cy, cz = coord.cell
+        s = coord.sublattice
+        Lx = dims[1]
+        Ly = dims[2]
+        return (((cz - 1) * Ly + (cy - 1)) * Lx + (cx - 1)) * nsub + s
+    end
+end
+
+@inline function lattice_coord(::RowMajor, dims::NTuple{3,Int}, nsub::Int, i::Int)
+    @inbounds begin
+        c = (i - 1) ÷ nsub
+        s = (i - 1) % nsub + 1
+        Lx = dims[1]
+        Ly = dims[2]
+        cx = c % Lx + 1
+        cyz = c ÷ Lx
+        cy = cyz % Ly + 1
+        cz = cyz ÷ Ly + 1
+        return LatticeCoord((cx, cy, cz), s)
+    end
+end
+
 # ---- 2D Snake ---------------------------------------------------------
 #
 # Row-major layout, but within each row the x-direction alternates:

--- a/src/LatticeCore.jl
+++ b/src/LatticeCore.jl
@@ -21,6 +21,7 @@ include("Indexing.jl")
 include("MomentumLattice.jl")
 include("StructureFactor.jl")
 include("LazyInfinite.jl")
+include("Graph.jl")
 include("Plot.jl")
 include("reference/LineLattice.jl")
 include("reference/SimpleSquareLattice.jl")
@@ -84,6 +85,9 @@ export AcceptanceWindow, HyperReciprocalLattice, BraggPeakSet
 
 # ---- Lazy / infinite ----
 export materialize, require_finite
+
+# ---- Graph operations ----
+export adjacency_matrix, shortest_path, connected_components
 
 # ---- Plotting (methods live in LatticeCorePlotsExt) ----
 export plot_lattice, plot_bonds!, plot_sites!

--- a/test/core/test_3d_lattice.jl
+++ b/test/core/test_3d_lattice.jl
@@ -1,0 +1,156 @@
+using LatticeCore
+using StaticArrays
+using SparseArrays
+using Test
+
+# Minimal 3D dummy lattice: 2 x 2 x 2 grid (8 sites) with OBC-style
+# nearest-neighbour links. The intent is to exercise the
+# `AbstractLattice{3, T}` interface + the new 3D RowMajor indexing,
+# not to provide a production cubic lattice. Real concrete cubics
+# (Simple Cubic / FCC / BCC) live in a future Lattice3D.jl.
+
+struct ToyCubicLattice <: AbstractLattice{3,Float64}
+    Lx::Int
+    Ly::Int
+    Lz::Int
+end
+
+ToyCubicLattice() = ToyCubicLattice(2, 2, 2)
+
+LatticeCore.num_sites(l::ToyCubicLattice) = l.Lx * l.Ly * l.Lz
+
+@inline function _to_xyz(l::ToyCubicLattice, i::Int)
+    Lx = l.Lx
+    Ly = l.Ly
+    c = i - 1
+    cx = c % Lx + 1
+    cyz = c ÷ Lx
+    cy = cyz % Ly + 1
+    cz = cyz ÷ Ly + 1
+    return (cx, cy, cz)
+end
+
+@inline function _from_xyz(l::ToyCubicLattice, x::Int, y::Int, z::Int)
+    return ((z - 1) * l.Ly + (y - 1)) * l.Lx + (x - 1) + 1
+end
+
+function LatticeCore.position(l::ToyCubicLattice, i::Int)
+    x, y, z = _to_xyz(l, i)
+    return SVector{3,Float64}(Float64(x), Float64(y), Float64(z))
+end
+
+function LatticeCore.neighbors(l::ToyCubicLattice, i::Int)
+    x, y, z = _to_xyz(l, i)
+    out = Int[]
+    for (dx, dy, dz) in
+        ((1, 0, 0), (-1, 0, 0), (0, 1, 0), (0, -1, 0), (0, 0, 1), (0, 0, -1))
+        nx, ny, nz = x + dx, y + dy, z + dz
+        (1 <= nx <= l.Lx && 1 <= ny <= l.Ly && 1 <= nz <= l.Lz) || continue
+        push!(out, _from_xyz(l, nx, ny, nz))
+    end
+    return out
+end
+
+LatticeCore.boundary(::ToyCubicLattice) = nothing
+LatticeCore.size_trait(l::ToyCubicLattice) = FiniteSize((l.Lx, l.Ly, l.Lz))
+
+@testset "AbstractLattice{3} interface (ToyCubicLattice)" begin
+    lat = ToyCubicLattice(2, 2, 2)
+
+    @testset "type parameters and basics" begin
+        @test lat isa AbstractLattice{3,Float64}
+        @test dimension(lat) == 3
+        @test eltype(lat) === Float64
+        @test num_sites(lat) == 8
+    end
+
+    @testset "positions are SVector{3, Float64}" begin
+        @test position(lat, 1) isa SVector{3,Float64}
+        @test position(lat, 1) == SVector{3,Float64}(1.0, 1.0, 1.0)
+        @test position(lat, 8) == SVector{3,Float64}(2.0, 2.0, 2.0)
+        ps = collect(positions(lat))
+        @test length(ps) == 8
+        @test all(p isa SVector{3,Float64} for p in ps)
+    end
+
+    @testset "neighbors and connectivity" begin
+        # Site (1,1,1) has 3 neighbours in a 2x2x2 OBC cube.
+        @test length(neighbors(lat, 1)) == 3
+        # Total edges in a 2x2x2 OBC cube: 12. Sum of degrees == 24.
+        total_deg = sum(length(neighbors(lat, i)) for i in 1:num_sites(lat))
+        @test total_deg == 24
+    end
+
+    @testset "default bond iterator produces SVector{3} displacements" begin
+        bs = collect(bonds(lat))
+        @test length(bs) == 12
+        @test all(b isa Bond{3,Float64} for b in bs)
+        @test all(b.vector isa SVector{3,Float64} for b in bs)
+    end
+
+    @testset "size_trait reports 3D dims" begin
+        st = size_trait(lat)
+        @test st isa FiniteSize{3}
+        @test st.dims == (2, 2, 2)
+    end
+
+    @testset "graph API works in 3D" begin
+        A = adjacency_matrix(lat)
+        @test A isa SparseMatrixCSC{Bool,Int}
+        @test size(A) == (8, 8)
+        @test A == transpose(A)
+        @test count(A) == 24
+
+        d, p = shortest_path(lat, 1, 8)
+        # Diagonal of the 2x2x2 cube: distance is 3.
+        @test d == 3
+        @test first(p) == 1 && last(p) == 8
+
+        comps = connected_components(lat)
+        @test length(comps) == 1
+        @test comps[1] == collect(1:8)
+    end
+end
+
+@testset "3D RowMajor indexing" begin
+    function _assert_roundtrip_3d(dims, nsub)
+        total = prod(dims) * nsub
+        for i in 1:total
+            lc = lattice_coord(RowMajor(), dims, nsub, i)
+            @test site_index(RowMajor(), dims, nsub, lc) == i
+        end
+    end
+
+    @testset "site_index 2x2x2" begin
+        # x is fastest, z is slowest:
+        #   (1,1,1)->1, (2,1,1)->2, (1,2,1)->3, (2,2,1)->4,
+        #   (1,1,2)->5, (2,1,2)->6, (1,2,2)->7, (2,2,2)->8.
+        @test site_index(RowMajor(), (2, 2, 2), 1, LatticeCoord((1, 1, 1))) == 1
+        @test site_index(RowMajor(), (2, 2, 2), 1, LatticeCoord((2, 1, 1))) == 2
+        @test site_index(RowMajor(), (2, 2, 2), 1, LatticeCoord((1, 2, 1))) == 3
+        @test site_index(RowMajor(), (2, 2, 2), 1, LatticeCoord((2, 2, 2))) == 8
+    end
+
+    @testset "lattice_coord 2x2x2" begin
+        @test lattice_coord(RowMajor(), (2, 2, 2), 1, 1).cell == (1, 1, 1)
+        @test lattice_coord(RowMajor(), (2, 2, 2), 1, 5).cell == (1, 1, 2)
+        @test lattice_coord(RowMajor(), (2, 2, 2), 1, 8).cell == (2, 2, 2)
+    end
+
+    @testset "round-trip 3D" begin
+        _assert_roundtrip_3d((2, 2, 2), 1)
+        _assert_roundtrip_3d((3, 2, 4), 1)
+        _assert_roundtrip_3d((2, 3, 2), 2)
+    end
+
+    @testset "every site index is hit exactly once (3D)" begin
+        for dims in ((2, 2, 2), (3, 2, 4)), nsub in (1, 2)
+            seen = Set{Int}()
+            for cx in 1:dims[1], cy in 1:dims[2], cz in 1:dims[3], s in 1:nsub
+                push!(seen, site_index(RowMajor(), dims, nsub, LatticeCoord((cx, cy, cz), s)))
+            end
+            @test length(seen) == prod(dims) * nsub
+            @test extrema(seen) == (1, prod(dims) * nsub)
+        end
+    end
+end

--- a/test/core/test_3d_lattice.jl
+++ b/test/core/test_3d_lattice.jl
@@ -147,7 +147,9 @@ end
         for dims in ((2, 2, 2), (3, 2, 4)), nsub in (1, 2)
             seen = Set{Int}()
             for cx in 1:dims[1], cy in 1:dims[2], cz in 1:dims[3], s in 1:nsub
-                push!(seen, site_index(RowMajor(), dims, nsub, LatticeCoord((cx, cy, cz), s)))
+                push!(
+                    seen, site_index(RowMajor(), dims, nsub, LatticeCoord((cx, cy, cz), s))
+                )
             end
             @test length(seen) == prod(dims) * nsub
             @test extrema(seen) == (1, prod(dims) * nsub)

--- a/test/core/test_aqua.jl
+++ b/test/core/test_aqua.jl
@@ -5,7 +5,7 @@ using Aqua
 @testset "Aqua" begin
     # Run all Aqua checks. We start with `test_all` and only carve out
     # checks individually if a false positive shows up.
-    Aqua.test_all(LatticeCore; ambiguities = false, persistent_tasks = false)
+    Aqua.test_all(LatticeCore; ambiguities=false, persistent_tasks=false)
 
     # `test_all` skips ambiguity checks above because Base/stdlib can
     # introduce method ambiguities outside our control. Restrict the

--- a/test/core/test_graph.jl
+++ b/test/core/test_graph.jl
@@ -1,0 +1,130 @@
+using LatticeCore
+using SparseArrays
+using StaticArrays
+using Test
+
+# Minimal local lattice with custom topology for testing graph ops
+# without depending on the reference lattices' particular bond order.
+
+# A path graph 1-2-3-4-5 (1D chain, OBC-like).
+struct GraphPath <: AbstractLattice{1,Float64}
+    N::Int
+end
+LatticeCore.num_sites(l::GraphPath) = l.N
+LatticeCore.position(l::GraphPath, i::Int) = SVector{1,Float64}(Float64(i))
+function LatticeCore.neighbors(l::GraphPath, i::Int)
+    return filter(j -> 1 <= j <= l.N, [i - 1, i + 1])
+end
+LatticeCore.boundary(::GraphPath) = nothing
+LatticeCore.size_trait(l::GraphPath) = FiniteSize((l.N,))
+
+# Two disjoint triangles: {1,2,3} and {4,5,6}.
+struct TwoTriangles <: AbstractLattice{1,Float64} end
+LatticeCore.num_sites(::TwoTriangles) = 6
+LatticeCore.position(::TwoTriangles, i::Int) = SVector{1,Float64}(Float64(i))
+function LatticeCore.neighbors(::TwoTriangles, i::Int)
+    return if i == 1
+        [2, 3]
+    elseif i == 2
+        [1, 3]
+    elseif i == 3
+        [1, 2]
+    elseif i == 4
+        [5, 6]
+    elseif i == 5
+        [4, 6]
+    elseif i == 6
+        [4, 5]
+    else
+        Int[]
+    end
+end
+LatticeCore.boundary(::TwoTriangles) = nothing
+LatticeCore.size_trait(::TwoTriangles) = FiniteSize((6,))
+
+@testset "Graph operations" begin
+    @testset "adjacency_matrix on path graph" begin
+        lat = GraphPath(5)
+        A = adjacency_matrix(lat)
+        @test A isa SparseMatrixCSC{Bool,Int}
+        @test size(A) == (5, 5)
+        @test A == transpose(A)
+        # 4 undirected edges, 8 stored true entries
+        @test count(A) == 8
+        @test A[1, 2] && A[2, 1]
+        @test A[2, 3] && A[3, 4] && A[4, 5]
+        @test !A[1, 3]
+        @test !A[1, 1]   # no self-loops
+
+        Ad = adjacency_matrix(lat; sparse=false)
+        @test Ad isa Matrix{Bool}
+        @test Ad == Matrix(A)
+    end
+
+    @testset "adjacency_matrix on SimpleSquareLattice" begin
+        sq = SimpleSquareLattice(3, 3, OpenAxis())
+        A = adjacency_matrix(sq)
+        @test size(A) == (9, 9)
+        @test A == transpose(A)
+        # 3x3 OBC square has 12 edges -> 24 stored true entries.
+        @test count(A) == 24
+    end
+
+    @testset "shortest_path on path graph" begin
+        lat = GraphPath(5)
+        d, p = shortest_path(lat, 1, 5)
+        @test d == 4
+        @test p == [1, 2, 3, 4, 5]
+
+        d2, p2 = shortest_path(lat, 3, 3)
+        @test d2 == 0
+        @test p2 == [3]
+
+        d3, p3 = shortest_path(lat, 4, 2)
+        @test d3 == 2
+        @test p3 == [4, 3, 2]
+    end
+
+    @testset "shortest_path on disconnected graph" begin
+        lat = TwoTriangles()
+        d, p = shortest_path(lat, 1, 4)
+        @test d == typemax(Int)
+        @test isempty(p)
+
+        # Within one component
+        d2, p2 = shortest_path(lat, 4, 6)
+        @test d2 == 1
+        @test p2 == [4, 6]
+    end
+
+    @testset "shortest_path bounds checking" begin
+        lat = GraphPath(3)
+        @test_throws BoundsError shortest_path(lat, 0, 2)
+        @test_throws BoundsError shortest_path(lat, 1, 4)
+    end
+
+    @testset "shortest_path on SimpleSquareLattice OBC" begin
+        sq = SimpleSquareLattice(3, 3, OpenAxis())
+        d, p = shortest_path(sq, 1, 9)
+        @test d == 4
+        @test first(p) == 1 && last(p) == 9
+        @test length(p) == 5
+        # All consecutive pairs in the path must be neighbours.
+        for k in 1:(length(p) - 1)
+            @test p[k + 1] in neighbors(sq, p[k])
+        end
+    end
+
+    @testset "connected_components" begin
+        lat1 = GraphPath(5)
+        comps1 = connected_components(lat1)
+        @test length(comps1) == 1
+        @test comps1[1] == [1, 2, 3, 4, 5]
+
+        lat2 = TwoTriangles()
+        comps2 = connected_components(lat2)
+        @test length(comps2) == 2
+        @test comps2[1] == [1, 2, 3]
+        @test comps2[2] == [4, 5, 6]
+    end
+end


### PR DESCRIPTION
## Summary

- Add a dependency-light graph layer over `AbstractLattice`:
  - `adjacency_matrix(lat; sparse=true)` returns an N×N
    `SparseMatrixCSC{Bool, Int}` (or a `Matrix{Bool}` when
    `sparse=false`), built from `elements(lat, BondCenter())` so it
    follows whatever bond order the lattice publishes.
  - `shortest_path(lat, src, dst)` returns `(hop_count, path)` via BFS
    over `neighbors(lat, ·)`; disconnected pairs return
    `(typemax(Int), Int[])`.
  - `connected_components(lat)` returns `Vector{Vector{Int}}` (each
    sorted, components in order of smallest member).
  - `SparseArrays` (stdlib) is added as a direct dep; `Graphs.jl` is
    intentionally not pulled in.
- Make `AbstractLattice{3}` first-class on the indexing layer:
  - Added `RowMajor` 3D `site_index` / `lattice_coord` (round-trip
    proven on multiple `(dims, nsub)` combos).
  - Existing interface functions (`positions`, `neighbors`,
    `bonds`, `bond_center`, `size_trait`, …) were already
    `D`-generic; verified end-to-end via a 2×2×2 `ToyCubicLattice`
    test fixture.
- No concrete 3D lattice (Cubic / FCC / Pyrochlore) is added here;
  those land in a future `Lattice3D.jl`.
- `Project.toml`: minor bump 0.9.3 → 0.10.0.

Closes #23
Closes #25

## Test plan

- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes (1012 / 1012)
- [x] Aqua suite still passes (`test_all` + `test_ambiguities`)
- [x] New `test/core/test_graph.jl` exercises the graph API on a
      hand-rolled `GraphPath`, on `TwoTriangles` (disconnected), and
      on `SimpleSquareLattice` (existing reference lattice)
- [x] New `test/core/test_3d_lattice.jl` exercises the 3D interface
      via a `ToyCubicLattice{3, Float64}` and 3D `RowMajor`
      indexing round-trips

## Breaking

None. This is a minor bump because the public API gains substantive
new exports (`adjacency_matrix`, `shortest_path`, `connected_components`)
and the indexing layer now dispatches an additional 3D method, but
no existing signature changes.