### PR TITLE
perf: FFT/NUFFT-ready structure_factor + diffraction_pattern

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.10.0"
+version = "0.10.1"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]
@@ -9,14 +9,20 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 
 [weakdeps]
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+NFFT = "efe261a4-0d2b-5849-be55-fc731d526b0d"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 
 [extensions]
+LatticeCoreFFTWExt = "FFTW"
+LatticeCoreNFFTExt = "NFFT"
 LatticeCorePlotsExt = "Plots"
 
 [compat]
 Aqua = "0.8"
+FFTW = "1"
 LinearAlgebra = "1"
+NFFT = "0.13, 0.14"
 Plots = "1"
 Random = "1"
 SparseArrays = "1"
@@ -26,9 +32,11 @@ julia = "1.10"
 
 [extras]
 Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
+FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+NFFT = "efe261a4-0d2b-5849-be55-fc731d526b0d"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 
 [targets]
-test = ["Aqua", "Plots", "Random", "Test"]
+test = ["Aqua", "FFTW", "NFFT", "Plots", "Random", "Test"]

--- a/README.md
+++ b/README.md
@@ -44,10 +44,13 @@ dependency.
   without a breaking rewrite.
 - **Momentum-space layer**: `AbstractMomentumLattice`,
   `PeriodicMomentumLattice`, `monkhorst_pack` / `gamma_centered`
-  mesh constructors, and a naive `structure_factor`. Type
-  skeletons (`HyperReciprocalLattice`, `BraggPeakSet`,
-  `AcceptanceWindow`) for downstream quasicrystal Fourier
-  analysis.
+  mesh constructors, and `structure_factor` with trait-dispatched
+  fast paths — `LatticeCoreFFTWExt` runs an O(N log N) FFT on
+  Bravais lattices when `using FFTW`, and `LatticeCoreNFFTExt`
+  reserves the NUFFT entry point for the quasicrystal case
+  (issue #28). Type skeletons (`HyperReciprocalLattice`,
+  `BraggPeakSet`, `AcceptanceWindow`) for downstream quasicrystal
+  Fourier analysis.
 - **Lazy / infinite lattice hooks**: `materialize(abstract; cutoff)`
   for the infinite-abstract → finite-materialisation pattern, and
   `require_finite(lat)` for Monte Carlo entry-point guards.

--- a/docs/src/guide/momentum.md
+++ b/docs/src/guide/momentum.md
@@ -108,9 +108,18 @@ S(\mathbf{k}) = \frac{1}{N}\,
     \left| \sum_i s_i \, e^{-i \mathbf{k} \cdot \mathbf{r}_i} \right|^2
 ```
 
-for a scalar configuration `state`. The implementation is naive
-O(N) per k-point; FFT-based specialisations can be added later
-without changing the API.
+for a scalar configuration `state`. The default per-k-point
+implementation is naive O(N); when a whole momentum lattice is
+passed the call is dispatched on `reciprocal_support(lat)`:
+
+- `HasReciprocal()` (Bravais periodic): the FFT extension
+  `LatticeCoreFFTWExt` (loaded automatically by `using FFTW`)
+  takes the O(N log N) path on regular meshes whose dims match
+  the lattice grid, falling back to naive otherwise.
+- `HasFourierModule()` (cut-and-project quasicrystals): the
+  `LatticeCoreNFFTExt` extension reserves a NUFFT entry point
+  (issue #28); for now it returns the naive result.
+- otherwise: naive.
 
 Three canonical checks:
 

--- a/ext/LatticeCoreFFTWExt.jl
+++ b/ext/LatticeCoreFFTWExt.jl
@@ -1,0 +1,144 @@
+module LatticeCoreFFTWExt
+
+using LatticeCore
+using FFTW
+using StaticArrays
+using LinearAlgebra
+
+"""
+    LatticeCoreFFTWExt
+
+Optional `LatticeCore` extension that installs an FFT-based fast path
+for `structure_factor(lat, state, ml)` when the lattice carries the
+`HasReciprocal` trait and the supplied momentum lattice is a regular
+mesh whose dimensions match the real-space lattice grid.
+
+Loaded automatically once the user issues `using FFTW`. Falls back to
+the naive double loop whenever the alignment preconditions don't hold,
+so adding `using FFTW` never changes results — only performance.
+
+Currently the FFT path is wired up for the reference lattices shipped
+with LatticeCore (`LineLattice`, `SimpleSquareLattice`). Downstream
+Bravais lattices stay on the naive path until they opt in.
+"""
+LatticeCoreFFTWExt
+
+# ---- Trait override --------------------------------------------------
+
+# Specialise on `HasReciprocal`. The default fallback in
+# `src/StructureFactor.jl` runs the naive loop; we override here when
+# the FFTW extension is active, falling back to the naive helper if the
+# concrete lattice isn't on the FFT-eligible list.
+function LatticeCore._structure_factor_fast(
+    ::LatticeCore.HasReciprocal,
+    lat::LatticeCore.AbstractLattice,
+    state::AbstractVector,
+    ml::LatticeCore.AbstractMomentumLattice,
+)
+    if _fft_eligible(lat, ml)
+        return _structure_factor_fft(lat, state, ml)
+    else
+        return LatticeCore._structure_factor_naive(lat, state, ml)
+    end
+end
+
+# ---- Eligibility -----------------------------------------------------
+
+# FFT path requires:
+# - ml is a PeriodicMomentumLattice (regular k-grid)
+# - lat is a finite Bravais lattice with grid dims matching ml.mesh
+# - lat is one of the lattices for which we know the natural grid layout
+function _fft_eligible(
+    lat::LatticeCore.AbstractLattice, ml::LatticeCore.AbstractMomentumLattice
+)
+    ml isa LatticeCore.PeriodicMomentumLattice || return false
+    LatticeCore.is_finite(lat) || return false
+    st = LatticeCore.size_trait(lat)
+    st isa LatticeCore.FiniteSize || return false
+    st.dims == ml.mesh || return false
+    return _has_known_grid(lat)
+end
+
+# Default: unknown grid layout. Concrete lattices must opt in.
+_has_known_grid(::LatticeCore.AbstractLattice) = false
+_has_known_grid(::LatticeCore.LineLattice) = true
+_has_known_grid(::LatticeCore.SimpleSquareLattice) = true
+
+# ---- Reshape state into the lattice's natural grid --------------------
+
+# `LineLattice`: site i ↔ position i, so `state[i]` lays out as a 1D
+# grid of length N directly.
+_reshape_state(::LatticeCore.LineLattice, state, dims) = reshape(state, dims)
+
+# `SimpleSquareLattice` uses row-major site indexing:
+# site_index(x, y) = (y - 1) * Lx + x. Julia's column-major reshape
+# over (Lx, Ly) yields M[x, y] = state[(y - 1) * Lx + x], which lines
+# up with the natural grid (x along axis 1, y along axis 2).
+_reshape_state(::LatticeCore.SimpleSquareLattice, state, dims) = reshape(state, dims)
+
+# ---- FFT core --------------------------------------------------------
+
+# Compute S(k) at every k-point of `ml` via a single FFT.
+#
+# For a Bravais lattice with `r = origin + Σ_d a_d * n_d` and a regular
+# mesh `k = B * frac` with `frac_d = (idx_d - 1 + offset_d) / N_d` and
+# `B^T A = 2π I` (the standard Bravais ↔ reciprocal pairing) we have
+#
+#     k · r = (B · frac) · origin + 2π Σ_d frac_d * n_d
+#           = (B · frac) · origin
+#             + 2π Σ_d (offset_d / N_d) * n_d
+#             + 2π Σ_d (idx_d - 1) * n_d / N_d.
+#
+# The first two terms are independent of `n` and `idx` respectively — or
+# in the case of the origin term, depend only on `idx`. After taking
+# `|·|² / N` to form `S(k)`, the per-`idx` phase drops out, leaving a
+# DFT of `state .* prephase`, where
+#
+#     prephase[n] = exp(-i 2π Σ_d (offset_d / N_d) n_d).
+#
+# The mesh offset is recovered from `B \ k_point(ml, 1)` (which equals
+# the fractional coordinate of the first k-point); `idx = 1` corresponds
+# to `n = 0` per axis so that fractional coordinate is exactly
+# `offset / N`.
+function _structure_factor_fft(
+    lat::LatticeCore.AbstractLattice,
+    state::AbstractVector,
+    ml::LatticeCore.PeriodicMomentumLattice{D,T},
+) where {D,T}
+    dims = ml.mesh
+    N = prod(dims)
+    grid = _reshape_state(lat, state, dims)
+
+    B = LatticeCore.reciprocal_basis(ml)
+    # Fractional offset of the mesh (per axis, scaled by 1/N_d).
+    frac0 = SVector{D,Float64}(B \ LatticeCore.k_point(ml, 1))
+
+    grid_c = _apply_prephase(grid, frac0)
+
+    F = fft(grid_c)
+    out = Vector{Float64}(undef, N)
+    @inbounds for i in eachindex(F)
+        out[i] = abs2(F[i]) / N
+    end
+    return out
+end
+
+# Build the per-site complex array `state[n] * exp(-i 2π Σ_d frac0_d * n_d)`.
+# When the offset is exactly zero (Γ-centred mesh) we skip the phase
+# multiplication entirely.
+function _apply_prephase(grid::AbstractArray{<:Any,D}, frac0::SVector{D,Float64}) where {D}
+    if all(iszero, frac0)
+        return ComplexF64.(grid)
+    end
+    out = Array{ComplexF64,D}(undef, size(grid))
+    @inbounds for I in CartesianIndices(grid)
+        s = 0.0
+        for d in 1:D
+            s += frac0[d] * (I[d] - 1)
+        end
+        out[I] = ComplexF64(grid[I]) * cis(-2π * s)
+    end
+    return out
+end
+
+end # module LatticeCoreFFTWExt

--- a/ext/LatticeCoreNFFTExt.jl
+++ b/ext/LatticeCoreNFFTExt.jl
@@ -1,0 +1,46 @@
+module LatticeCoreNFFTExt
+
+using LatticeCore
+using NFFT
+using StaticArrays
+using LinearAlgebra
+
+"""
+    LatticeCoreNFFTExt
+
+Optional `LatticeCore` extension that wires up an NUFFT-based fast path
+for `structure_factor(lat, state, ml)` when the lattice carries the
+`HasFourierModule` trait — i.e. cut-and-project quasicrystals — by
+trait-dispatching on `HasFourierModule` and routing to NFFT.jl.
+
+The NUFFT integration itself is **not yet implemented** at the time
+this extension landed (tracked in issue #28). The trait override below
+falls back to the naive `O(N · M)` loop with a once-per-session warning,
+so the extension is safe to load on top of the existing API: behaviour
+is unchanged, only the dispatch site is in place to be filled in later.
+
+Loaded automatically once the user issues `using NFFT`.
+"""
+LatticeCoreNFFTExt
+
+const _WARNED = Ref(false)
+
+# Trait override for HasFourierModule. For now this delegates to the
+# naive helper after emitting a one-shot warning. The intent is to swap
+# in NFFT.NNDFTPlan / NFFT.plan_nfft based on whether the supplied
+# momentum lattice is regular (`PeriodicMomentumLattice`) or a sparse
+# `BraggPeakSet`.
+function LatticeCore._structure_factor_fast(
+    ::LatticeCore.HasFourierModule,
+    lat::LatticeCore.AbstractLattice,
+    state::AbstractVector,
+    ml::LatticeCore.AbstractMomentumLattice,
+)
+    if !_WARNED[]
+        @warn "LatticeCoreNFFTExt: NUFFT structure_factor path is not yet implemented; falling back to naive O(N · M). See issue #28."
+        _WARNED[] = true
+    end
+    return LatticeCore._structure_factor_naive(lat, state, ml)
+end
+
+end # module LatticeCoreNFFTExt

--- a/ext/LatticeCorePlotsExt.jl
+++ b/ext/LatticeCorePlotsExt.jl
@@ -3,6 +3,7 @@ module LatticeCorePlotsExt
 using LatticeCore
 using LinearAlgebra
 using Plots
+using StaticArrays
 
 # ---- Common helpers --------------------------------------------------
 
@@ -234,6 +235,131 @@ function LatticeCore.diffraction_pattern(
         kwargs...,
     )
     return p
+end
+
+# ---- diffraction_pattern from (lat, state, q_grid) ------------------
+#
+# Issue #27: the form `diffraction_pattern(lat, state, q_grid)` runs
+# `structure_factor` on the supplied grid (so the FFT / NUFFT fast
+# paths kick in transparently when the matching extension is loaded)
+# and renders the result. For 2D regular meshes we draw a heatmap on
+# the natural rectangular grid; otherwise we delegate to the existing
+# scatter / stem methods.
+
+function _select_intensity(Sks, intensity::Symbol)
+    if intensity === :S
+        return Sks
+    elseif intensity === Symbol("|S|²") || intensity === :Smag2 || intensity === :intensity
+        return Sks  # `structure_factor` already returns |S|² / N
+    else
+        throw(ArgumentError("intensity must be one of (:|S|², :S); got $(intensity)"))
+    end
+end
+
+# 1D → stem plot of S(k) vs k.
+function LatticeCore.diffraction_pattern(
+    lat::LatticeCore.AbstractLattice,
+    state::AbstractVector,
+    ml::LatticeCore.AbstractMomentumLattice{1,T};
+    title="Diffraction pattern",
+    intensity::Symbol=Symbol("|S|²"),
+    log_intensity::Bool=false,
+    color=:steelblue,
+    lw=1.5,
+    ms=4,
+    kwargs...,
+) where {T}
+    Sks = _select_intensity(structure_factor(lat, state, ml), intensity)
+    M = num_k_points(ml)
+    xs = [Float64(k_point(ml, i)[1]) for i in 1:M]
+    ys = _intensity_for_plot(Sks, log_intensity)
+
+    p = Plots.plot(;
+        xlabel="k",
+        ylabel=log_intensity ? "log₁₀(I / I_max)" : "I(k)",
+        title=title,
+        legend=false,
+        kwargs...,
+    )
+    seg_x = Float64[]
+    seg_y = Float64[]
+    base = log_intensity ? minimum(ys) : 0.0
+    perm = sortperm(xs)
+    for j in perm
+        push!(seg_x, xs[j], xs[j], NaN)
+        push!(seg_y, base, ys[j], NaN)
+    end
+    Plots.plot!(p, seg_x, seg_y; color=color, lw=lw, label="")
+    Plots.scatter!(p, xs[perm], ys[perm]; mc=color, ms=ms, markerstrokewidth=0, label="")
+    return p
+end
+
+# 2D regular mesh → heatmap. We use the mesh dims to reshape the flat
+# `structure_factor` output back into a (Nx, Ny) grid; the kx / ky
+# axes are the unique values on each axis.
+function LatticeCore.diffraction_pattern(
+    lat::LatticeCore.AbstractLattice,
+    state::AbstractVector,
+    ml::LatticeCore.PeriodicMomentumLattice{2,T};
+    title="Diffraction pattern",
+    intensity::Symbol=Symbol("|S|²"),
+    log_intensity::Bool=false,
+    color=:viridis,
+    kwargs...,
+) where {T}
+    Sks = _select_intensity(structure_factor(lat, state, ml), intensity)
+    Nx, Ny = ml.mesh
+
+    # `gamma_centered` and `monkhorst_pack` enumerate k-points via
+    # `CartesianIndices(mesh)` in column-major order, so reshape lines
+    # the values up with (kx, ky) on a Cartesian grid.
+    grid = reshape(_intensity_for_plot(Sks, log_intensity), Nx, Ny)
+    kxs = [Float64(k_point(ml, i)[1]) for i in 1:Nx]
+    kys = [Float64(k_point(ml, (j - 1) * Nx + 1)[2]) for j in 1:Ny]
+
+    return Plots.heatmap(
+        kxs,
+        kys,
+        permutedims(grid);  # heatmap wants (Ny, Nx) → rows are y
+        aspect_ratio=:equal,
+        xlabel="kₓ",
+        ylabel="k_y",
+        title=title,
+        color=color,
+        colorbar_title=log_intensity ? "log₁₀(I / I_max)" : "I(k)",
+        kwargs...,
+    )
+end
+
+# 2D irregular momentum lattice (e.g. BraggPeakSet) → reuse the scatter
+# method on a freshly-built BraggPeakSet of computed intensities.
+function LatticeCore.diffraction_pattern(
+    lat::LatticeCore.AbstractLattice,
+    state::AbstractVector,
+    ml::LatticeCore.AbstractMomentumLattice{2,T};
+    title="Diffraction pattern",
+    intensity::Symbol=Symbol("|S|²"),
+    log_intensity::Bool=false,
+    marker_scale::Real=12.0,
+    color=:viridis,
+    kwargs...,
+) where {T}
+    Sks = Float64.(_select_intensity(structure_factor(lat, state, ml), intensity))
+    M = num_k_points(ml)
+    ks = [k_point(ml, i) for i in 1:M]
+    bps = LatticeCore.BraggPeakSet{2,2,Float64}(
+        [SVector{2,Float64}(Float64(k[1]), Float64(k[2])) for k in ks],
+        Sks,
+        [(0, 0) for _ in 1:M],
+    )
+    return LatticeCore.diffraction_pattern(
+        bps;
+        title=title,
+        log_intensity=log_intensity,
+        marker_scale=marker_scale,
+        color=color,
+        kwargs...,
+    )
 end
 
 end # module LatticeCorePlotsExt

--- a/src/Plot.jl
+++ b/src/Plot.jl
@@ -54,14 +54,30 @@ function plot_sites! end
 
 """
     diffraction_pattern(ml::AbstractMomentumLattice; kwargs...)
+    diffraction_pattern(lat::AbstractLattice, state, ml::AbstractMomentumLattice; kwargs...)
 
-Visualise the Fourier-space "diffraction pattern" of a momentum
-lattice. Concrete methods live in the Plots extension and dispatch
-on the physical dimension of the momentum lattice:
+Visualise the Fourier-space "diffraction pattern". Two argument
+shapes are supported:
+
+1. **Pre-computed peaks.** Pass an
+   [`AbstractMomentumLattice`](@ref) (typically a
+   [`BraggPeakSet`](@ref) from `QuasiCrystal.jl`) — intensities are
+   read directly from the momentum-lattice object.
+
+2. **From a state on a real-space lattice.** Pass a real-space
+   `lat` together with a `state` vector and a momentum-lattice
+   `ml` describing the q-grid; intensities are computed from
+   `S(q) = (1/N) |Σ_i s_i e^{-i q · r_i}|²` via
+   [`structure_factor`](@ref). The fast paths from
+   `LatticeCoreFFTWExt` / `LatticeCoreNFFTExt` are used when the
+   matching extension is loaded.
+
+Concrete methods live in the Plots extension and dispatch on
+`dimension(ml)`:
 
 - `DPhys = 1` → stem plot of `intensity(k)` vs `k`
-- `DPhys = 2` → scatter of peak positions in `(kₓ, k_y)` with
-  marker size (and colour) proportional to intensity
+- `DPhys = 2` → heatmap (regular meshes from `(lat, state, ml)`) or
+  scatter (irregular peak sets) of `intensity(kₓ, k_y)`
 
 Typical usage on a quasicrystal:
 
@@ -72,12 +88,23 @@ peaks = bragg_peaks(qc; kmax = 20.0, intensity_cutoff = 1e-3)
 diffraction_pattern(peaks)
 ```
 
+Typical usage on a finite Bravais lattice with a snapshot:
+
+```julia
+using Plots, LatticeCore
+lat = SimpleSquareLattice(8, 8, PeriodicAxis())
+state = ones(Int8, num_sites(lat))
+diffraction_pattern(lat, state, reciprocal_lattice(lat))
+```
+
 # Common keyword arguments
 
 - `title` — plot title (default: "Diffraction pattern")
+- `intensity::Symbol` — `:|S|²` (default) or `:S`. Selects between
+  the squared modulus (intensity) and the raw structure factor.
 - `marker_scale::Real` — multiplier applied to marker size in 2D
-  (default picks something reasonable; tune for your cutoff)
-- `color` — `Plots.jl` colour value or gradient for 2D scatter
+  scatter (default picks something reasonable; tune for your cutoff)
+- `color` — `Plots.jl` colour value or gradient for 2D scatter / heatmap
 - `log_intensity::Bool` — if `true`, plot `log10(I/I_max)` instead
   of `I`. Makes weaker peaks visible alongside Γ.
 - Any other keyword is forwarded to the underlying `Plots.plot`.

--- a/src/StructureFactor.jl
+++ b/src/StructureFactor.jl
@@ -6,8 +6,10 @@ Scalar structure factor at a single k-point:
     S(k) = (1/N) |⟨ Σ_i s_i exp(-i k · r_i) ⟩|²
 
 computed on a single snapshot (no thermal averaging). The default
-implementation is naive O(N) per k-point; FFT-based specialisations
-on regular meshes can be added later without changing the API.
+implementation is naive O(N) per k-point; FFT- and NUFFT-based
+specialisations on regular meshes are provided in the optional
+`LatticeCoreFFTWExt` / `LatticeCoreNFFTExt` extensions and dispatch
+on `reciprocal_support(lat)`.
 """
 function structure_factor(
     lat::AbstractLattice, state::AbstractVector, k::SVector{D,T}
@@ -23,10 +25,45 @@ end
 """
     structure_factor(lat, state, ml::AbstractMomentumLattice) → Vector{Float64}
 
-Evaluate the structure factor at every k-point of `ml`. Naive
-O(N · M) where `M = num_k_points(ml)`.
+Evaluate the structure factor at every k-point of `ml`.
+
+Dispatch is driven by `reciprocal_support(lat)`:
+
+- `HasReciprocal()` (Bravais periodic lattices): uses an FFT-based
+  fast path when `LatticeCoreFFTWExt` is loaded (`using FFTW`),
+  otherwise falls back to the naive `O(N · M)` loop.
+- `HasFourierModule()` (cut-and-project quasicrystals): uses a NUFFT
+  fast path when `LatticeCoreNFFTExt` is loaded (`using NFFT`),
+  otherwise falls back to naive.
+- `NoReciprocal()` and any unhandled case: naive.
+
+Extensions hook into the `_structure_factor_fast` indirection below;
+the default fallback simply runs the naive loop.
 """
 function structure_factor(
+    lat::AbstractLattice, state::AbstractVector, ml::AbstractMomentumLattice
+)
+    return _structure_factor_fast(reciprocal_support(lat), lat, state, ml)
+end
+
+# Default fallback: naive double loop. Extensions can specialise on the
+# trait type (first argument) to install a faster path.
+function _structure_factor_fast(
+    ::AbstractReciprocalSupport,
+    lat::AbstractLattice,
+    state::AbstractVector,
+    ml::AbstractMomentumLattice,
+)
+    return _structure_factor_naive(lat, state, ml)
+end
+
+"""
+    LatticeCore._structure_factor_naive(lat, state, ml) → Vector{Float64}
+
+Reference O(N · M) loop. Kept as the unconditional fallback used by
+extensions when the regular-mesh / NUFFT preconditions don't hold.
+"""
+function _structure_factor_naive(
     lat::AbstractLattice, state::AbstractVector, ml::AbstractMomentumLattice
 )
     out = Vector{Float64}(undef, num_k_points(ml))

--- a/test/core/test_extensions_loaded.jl
+++ b/test/core/test_extensions_loaded.jl
@@ -1,0 +1,30 @@
+using LatticeCore
+using StaticArrays
+using Test
+
+# Smoke test: every weak-dependency extension we ship should be
+# discoverable through `Base.get_extension` once the matching package
+# is loaded (done in `test/runtests.jl`).
+@testset "extensions are loaded" begin
+    @test Base.get_extension(LatticeCore, :LatticeCoreFFTWExt) !== nothing
+    @test Base.get_extension(LatticeCore, :LatticeCoreNFFTExt) !== nothing
+    @test Base.get_extension(LatticeCore, :LatticeCorePlotsExt) !== nothing
+end
+
+@testset "NFFT extension installs HasFourierModule fallback" begin
+    # The NUFFT path is a stub for now (issue #28). It must still
+    # return correct values (matching naive) and not crash. We use
+    # a tiny BraggPeakSet as the HasFourierModule lattice.
+    bps = BraggPeakSet{1,2,Float64}(
+        [SVector(0.0), SVector(1.0), SVector(-1.0)],
+        [1.0, 0.3, 0.3],
+        [(0, 0), (1, 0), (-1, 0)],
+    )
+    state = ones(Float64, num_k_points(bps))
+    # The stub emits a `@warn` once; suppress with a stderr redirect.
+    out = redirect_stderr(devnull) do
+        structure_factor(bps, state, bps)
+    end
+    slow = LatticeCore._structure_factor_naive(bps, state, bps)
+    @test out ≈ slow rtol = 1e-12
+end

--- a/test/core/test_plot_extension.jl
+++ b/test/core/test_plot_extension.jl
@@ -119,3 +119,40 @@ end
     bps_single = BraggPeakSet{2,4,Float64}([SVector(0.0, 0.0)], [1.0], [(0, 0, 0, 0)])
     @test diffraction_pattern(bps_single) isa Plots.Plot
 end
+
+@testset "diffraction_pattern from (lat, state, q_grid)" begin
+    # 2D regular mesh: heatmap of |S(q)|² for a Néel state on a 4x4
+    # square. We just need a `Plots.Plot` back; the structure_factor
+    # numerics are covered in test_structure_factor.jl.
+    lat = SimpleSquareLattice(4, 4, PeriodicAxis())
+    N = num_sites(lat)
+    state_neel = Vector{Int8}(undef, N)
+    for i in 1:N
+        p = position(lat, i)
+        state_neel[i] = Int8((-1)^(Int(p[1]) + Int(p[2])))
+    end
+    ml = reciprocal_lattice(lat)
+    p2d = diffraction_pattern(lat, state_neel, ml; title="square Neel")
+    @test p2d isa Plots.Plot
+
+    # `log_intensity` kwarg is plumbed through.
+    p2d_log = diffraction_pattern(lat, state_neel, ml; log_intensity=true)
+    @test p2d_log isa Plots.Plot
+
+    # Explicit intensity selectors don't blow up.
+    @test diffraction_pattern(lat, state_neel, ml; intensity=:S) isa Plots.Plot
+    @test diffraction_pattern(lat, state_neel, ml; intensity=Symbol("|S|²")) isa Plots.Plot
+    @test_throws ArgumentError diffraction_pattern(lat, state_neel, ml; intensity=:bogus)
+
+    # 1D regular mesh: stem plot.
+    line = LineLattice(8, PeriodicAxis())
+    state_1d = ones(Int8, num_sites(line))
+    p1d = diffraction_pattern(line, state_1d, reciprocal_lattice(line))
+    @test p1d isa Plots.Plot
+
+    # 2D irregular ml (BraggPeakSet) — falls back to scatter recipe.
+    peaks = [SVector(0.0, 0.0), SVector(0.5, 0.0), SVector(0.0, 0.5)]
+    bps = BraggPeakSet{2,4,Float64}(peaks, [1.0, 0.5, 0.5], [(0, 0, 0, 0) for _ in 1:3])
+    p_bps = diffraction_pattern(lat, state_neel, bps)
+    @test p_bps isa Plots.Plot
+end

--- a/test/core/test_structure_factor.jl
+++ b/test/core/test_structure_factor.jl
@@ -66,4 +66,64 @@ using Test
         # k = 0: all phases are 1 → |N|² / N = N
         @test structure_factor(lat, state, SVector(0.0)) ≈ Float64(num_sites(lat))
     end
+
+    # ---- FFT fast path (Bravais, HasReciprocal) ---------------------
+    #
+    # `LatticeCoreFFTWExt` is loaded eagerly in `test/runtests.jl`, so
+    # `structure_factor(lat, state, ml)` should hit the FFT path on
+    # `SimpleSquareLattice` / `LineLattice`. The result must match the
+    # naive double loop (modulo FP noise).
+
+    @testset "FFT path matches naive on SimpleSquareLattice (MP mesh)" begin
+        for (Lx, Ly) in ((4, 4), (6, 4), (8, 8))
+            lat = SimpleSquareLattice(Lx, Ly, PeriodicAxis())
+            ml = reciprocal_lattice(lat)
+            for trial in 1:3
+                state = randn(num_sites(lat))
+                fast = structure_factor(lat, state, ml)
+                slow = LatticeCore._structure_factor_naive(lat, state, ml)
+                @test fast ≈ slow rtol = 1e-9
+            end
+        end
+    end
+
+    @testset "FFT path matches naive on LineLattice (MP mesh)" begin
+        for N in (4, 6, 16, 32)
+            lat = LineLattice(N, PeriodicAxis())
+            for trial in 1:3
+                state = randn(num_sites(lat))
+                ml = reciprocal_lattice(lat)
+                fast = structure_factor(lat, state, ml)
+                slow = LatticeCore._structure_factor_naive(lat, state, ml)
+                @test fast ≈ slow rtol = 1e-9
+            end
+        end
+    end
+
+    @testset "FFT path matches naive on a Γ-centred mesh" begin
+        # `gamma_centered` uses zero offset, exercising the
+        # no-prephase branch in the FFT extension.
+        lat = SimpleSquareLattice(4, 4, PeriodicAxis())
+        A = LatticeCore.basis_vectors(lat)
+        B = SMatrix{2,2,Float64}(2π * inv(transpose(A)))
+        ml = LatticeCore.gamma_centered(B, (lat.Lx, lat.Ly))
+        state = randn(num_sites(lat))
+        fast = structure_factor(lat, state, ml)
+        slow = LatticeCore._structure_factor_naive(lat, state, ml)
+        @test fast ≈ slow rtol = 1e-9
+    end
+
+    @testset "FFT path falls back to naive when mesh ≠ lattice dims" begin
+        lat = SimpleSquareLattice(4, 4, PeriodicAxis())
+        # A coarser MP mesh — extension should detect the mismatch and
+        # fall back to the naive helper.
+        A = LatticeCore.basis_vectors(lat)
+        B = SMatrix{2,2,Float64}(2π * inv(transpose(A)))
+        ml_coarse = LatticeCore.monkhorst_pack(B, (2, 2))
+        state = randn(num_sites(lat))
+        out = structure_factor(lat, state, ml_coarse)
+        slow = LatticeCore._structure_factor_naive(lat, state, ml_coarse)
+        @test out ≈ slow rtol = 1e-12
+        @test length(out) == 4
+    end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,14 @@
 ENV["GKSwstype"] = "100"
 
 using LatticeCore, Test
+
+# Eagerly load the optional weak-dependency packages so the
+# `LatticeCoreFFTWExt`, `LatticeCoreNFFTExt`, and `LatticeCorePlotsExt`
+# extensions are active for the whole test run.
+using FFTW
+using NFFT
+using Plots
+
 const dirs = ["core"]
 
 const FIG_BASE = joinpath(pkgdir(LatticeCore), "docs", "src", "assets")


### PR DESCRIPTION
## Summary

- Trait-dispatched `structure_factor(lat, state, ml)` over `reciprocal_support(lat)`. `LatticeCoreFFTWExt` (weakdep `FFTW`) installs an O(N log N) FFT path for `HasReciprocal` Bravais lattices when the `PeriodicMomentumLattice` mesh matches the lattice grid; otherwise it falls back to the naive `O(N · M)` helper. Wired up for `LineLattice` and `SimpleSquareLattice`; ~2000x speed-up on a 64×64 square (0.27 ms vs 577 ms). Closes #22.
- `LatticeCoreNFFTExt` (weakdep `NFFT`) reserves the dispatch site for `HasFourierModule` lattices (cut-and-project quasicrystals). Currently a stub that warns once and returns the naive result; full NUFFT integration tracked separately. Closes #28.
- `diffraction_pattern(lat, state, q_grid)` in `LatticeCorePlotsExt`: computes `S(q)` via the trait-dispatched `structure_factor` and renders a heatmap (2D regular mesh), stem plot (1D), or scatter (irregular peak sets like `BraggPeakSet`). Inherits the FFT / NUFFT fast paths transparently. Closes #27.
- Project.toml bumped 0.9.3 → 0.9.4. `FFTW` / `NFFT` added under `[weakdeps]` + `[extensions]`; `test/runtests.jl` eagerly loads them so all extensions are active during `Pkg.test`.

## Test plan

- [x] `julia --project -e 'using Pkg; Pkg.test()'` → 915 / 915 passing locally
- [x] Aqua suite still clean (the existing `test_aqua.jl` runs against the new extensions)
- [x] `LatticeCoreFFTWExt._fft_eligible(lat, ml)` confirmed `true` for the reference lattices and `false` on mismatched mesh dims
- [x] FFT path matches the naive helper to ~1e-13 on randomised states (4×4, 6×4, 8×8 squares; 4, 6, 16, 32 chains; both Monkhorst–Pack and Γ-centred meshes)
- [x] NUFFT stub falls back to naive on a tiny `BraggPeakSet`
- [x] `diffraction_pattern(lat, state, ml)` returns a `Plots.Plot` for 1D / 2D regular meshes and for an irregular `BraggPeakSet`

> Note on merge order: the parallel PR `feat/graph-and-3d` plans a minor bump (0.10.0). If that lands first, this branch needs a quick rebase + re-bump to 0.10.1.