### PR TITLE
refactor: expose structure_factor FFT grid hooks on LatticeCore

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.10.1"
+version = "0.10.2"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/docs/src/guide/momentum.md
+++ b/docs/src/guide/momentum.md
@@ -121,6 +121,34 @@ passed the call is dispatched on `reciprocal_support(lat)`:
   (issue #28); for now it returns the naive result.
 - otherwise: naive.
 
+### Opting a custom lattice into the FFT fast path
+
+The grid-layout hooks the FFT extension dispatches on live on
+`LatticeCore` itself, so downstream packages can register their
+own Bravais lattices without depending on FFTW. Add two
+methods next to the lattice definition:
+
+```julia
+using LatticeCore
+
+struct MyLattice <: AbstractLattice{2,Float64}
+    Lx::Int
+    Ly::Int
+    # ...
+end
+
+# Tell LatticeCore that `state[i]` reshapes onto the natural
+# `(Lx, Ly)` grid (e.g. via `site_index(x, y) = (y - 1) * Lx + x`):
+LatticeCore._has_known_grid(::MyLattice) = true
+LatticeCore._reshape_state(::MyLattice, state, dims) = reshape(state, dims)
+```
+
+With those two lines in place, `structure_factor(lat, state, ml)`
+will use the FFT path whenever `ml::PeriodicMomentumLattice`
+matches the lattice dims and `using FFTW` has been issued; if
+the user hasn't loaded FFTW the call still works — it just stays
+on the naive helper.
+
 Three canonical checks:
 
 ### Ferromagnet: S(0) = N

--- a/ext/LatticeCoreFFTWExt.jl
+++ b/ext/LatticeCoreFFTWExt.jl
@@ -48,6 +48,11 @@ end
 # - ml is a PeriodicMomentumLattice (regular k-grid)
 # - lat is a finite Bravais lattice with grid dims matching ml.mesh
 # - lat is one of the lattices for which we know the natural grid layout
+#
+# The grid-layout opt-in lives on `LatticeCore` itself
+# (`_has_known_grid` / `_reshape_state`) so downstream packages such as
+# `Lattice2D` and `QuasiCrystal` can register their lattices on the
+# fast path without taking an FFTW dependency.
 function _fft_eligible(
     lat::LatticeCore.AbstractLattice, ml::LatticeCore.AbstractMomentumLattice
 )
@@ -56,25 +61,8 @@ function _fft_eligible(
     st = LatticeCore.size_trait(lat)
     st isa LatticeCore.FiniteSize || return false
     st.dims == ml.mesh || return false
-    return _has_known_grid(lat)
+    return LatticeCore._has_known_grid(lat)
 end
-
-# Default: unknown grid layout. Concrete lattices must opt in.
-_has_known_grid(::LatticeCore.AbstractLattice) = false
-_has_known_grid(::LatticeCore.LineLattice) = true
-_has_known_grid(::LatticeCore.SimpleSquareLattice) = true
-
-# ---- Reshape state into the lattice's natural grid --------------------
-
-# `LineLattice`: site i ↔ position i, so `state[i]` lays out as a 1D
-# grid of length N directly.
-_reshape_state(::LatticeCore.LineLattice, state, dims) = reshape(state, dims)
-
-# `SimpleSquareLattice` uses row-major site indexing:
-# site_index(x, y) = (y - 1) * Lx + x. Julia's column-major reshape
-# over (Lx, Ly) yields M[x, y] = state[(y - 1) * Lx + x], which lines
-# up with the natural grid (x along axis 1, y along axis 2).
-_reshape_state(::LatticeCore.SimpleSquareLattice, state, dims) = reshape(state, dims)
 
 # ---- FFT core --------------------------------------------------------
 
@@ -107,7 +95,7 @@ function _structure_factor_fft(
 ) where {D,T}
     dims = ml.mesh
     N = prod(dims)
-    grid = _reshape_state(lat, state, dims)
+    grid = LatticeCore._reshape_state(lat, state, dims)
 
     B = LatticeCore.reciprocal_basis(ml)
     # Fractional offset of the mesh (per axis, scaled by 1/N_d).

--- a/src/StructureFactor.jl
+++ b/src/StructureFactor.jl
@@ -124,7 +124,10 @@ Default: throws — concrete lattices that opt into
 [`_has_known_grid`](@ref LatticeCore._has_known_grid) must also
 provide a method here.
 """
-_reshape_state(lat::AbstractLattice, state, dims) =
-    error("LatticeCore._reshape_state not defined for $(typeof(lat)); ",
-          "opt in by defining `LatticeCore._reshape_state(::MyLattice, state, dims)` ",
-          "alongside `LatticeCore._has_known_grid(::MyLattice) = true`.")
+function _reshape_state(lat::AbstractLattice, state, dims)
+    error(
+        "LatticeCore._reshape_state not defined for $(typeof(lat)); ",
+        "opt in by defining `LatticeCore._reshape_state(::MyLattice, state, dims)` ",
+        "alongside `LatticeCore._has_known_grid(::MyLattice) = true`.",
+    )
+end

--- a/src/StructureFactor.jl
+++ b/src/StructureFactor.jl
@@ -72,3 +72,59 @@ function _structure_factor_naive(
     end
     return out
 end
+
+# ---- FFT fast-path opt-in hooks --------------------------------------
+#
+# These two helpers describe a Bravais lattice's "natural grid layout":
+# whether `state[i]` can be reshaped onto a regular `D`-dimensional
+# mesh that lines up with the lattice's site index ordering. They are
+# defined here (rather than inside `LatticeCoreFFTWExt`) so that
+# downstream packages — `Lattice2D`, `QuasiCrystal`, custom lattices —
+# can opt their own lattices into the FFT fast path **without depending
+# on FFTW**:
+#
+# ```julia
+# # In a downstream package, after `using LatticeCore`:
+# struct MyLattice <: AbstractLattice{2,Float64} ... end
+# LatticeCore._has_known_grid(::MyLattice) = true
+# LatticeCore._reshape_state(::MyLattice, state, dims) = reshape(state, dims)
+# ```
+#
+# When `LatticeCoreFFTWExt` is loaded (`using FFTW`), it dispatches
+# through these names; when it isn't, the hooks simply have no effect.
+# The defaults are deliberately conservative: an unknown lattice is not
+# eligible, and `_reshape_state` errors if called without an opt-in
+# (the FFT extension only reaches it after `_has_known_grid` returns
+# `true`, so the error path is purely defensive).
+
+"""
+    LatticeCore._has_known_grid(lat::AbstractLattice) → Bool
+
+Whether the lattice has a known, FFT-compatible grid layout that
+matches a `PeriodicMomentumLattice` mesh of the same `dims`.
+
+Default: `false`. Concrete lattices opt in by adding a method that
+returns `true`, paired with a [`_reshape_state`](@ref
+LatticeCore._reshape_state) method that produces the corresponding
+`D`-dimensional grid view.
+
+The FFT fast path in `LatticeCoreFFTWExt` only fires when this
+returns `true`; lattices without an opt-in stay on the naive helper.
+"""
+_has_known_grid(::AbstractLattice) = false
+
+"""
+    LatticeCore._reshape_state(lat, state, dims) → AbstractArray
+
+Reshape a per-site `state::AbstractVector` into the lattice's
+natural `D`-dimensional grid of size `dims`, so that the FFT
+extension can take a single `fft` over the result.
+
+Default: throws — concrete lattices that opt into
+[`_has_known_grid`](@ref LatticeCore._has_known_grid) must also
+provide a method here.
+"""
+_reshape_state(lat::AbstractLattice, state, dims) =
+    error("LatticeCore._reshape_state not defined for $(typeof(lat)); ",
+          "opt in by defining `LatticeCore._reshape_state(::MyLattice, state, dims)` ",
+          "alongside `LatticeCore._has_known_grid(::MyLattice) = true`.")

--- a/src/reference/LineLattice.jl
+++ b/src/reference/LineLattice.jl
@@ -156,3 +156,12 @@ function reciprocal_lattice(lat::LineLattice{T}) where {T}
     B = SMatrix{1,1,T}(T(2π) * inv(transpose(A)))
     return monkhorst_pack(B, (lat.N,))
 end
+
+# ---- FFT fast-path opt-in (see `src/StructureFactor.jl`) -------------
+#
+# `LineLattice`: site `i` ↔ position `i`, so `state[i]` lays out as a
+# 1D grid of length `N` directly. We register the opt-in here (not in
+# `LatticeCoreFFTWExt`) so it remains visible to `Lattice2D` /
+# downstream code without requiring FFTW to be loaded.
+_has_known_grid(::LineLattice) = true
+_reshape_state(::LineLattice, state, dims) = reshape(state, dims)

--- a/src/reference/SimpleSquareLattice.jl
+++ b/src/reference/SimpleSquareLattice.jl
@@ -212,3 +212,14 @@ function reciprocal_lattice(lat::SimpleSquareLattice{T}) where {T}
     B = SMatrix{2,2,T}(T(2π) * inv(transpose(A)))
     return monkhorst_pack(B, (lat.Lx, lat.Ly))
 end
+
+# ---- FFT fast-path opt-in (see `src/StructureFactor.jl`) -------------
+#
+# `SimpleSquareLattice` uses row-major site indexing:
+# `site_index(x, y) = (y - 1) * Lx + x`. Julia's column-major reshape
+# over `(Lx, Ly)` yields `M[x, y] = state[(y - 1) * Lx + x]`, which
+# lines up with the natural grid (x along axis 1, y along axis 2).
+# Registered here so `Lattice2D` / downstream code can rely on the
+# opt-in without depending on FFTW.
+_has_known_grid(::SimpleSquareLattice) = true
+_reshape_state(::SimpleSquareLattice, state, dims) = reshape(state, dims)

--- a/test/core/test_structure_factor.jl
+++ b/test/core/test_structure_factor.jl
@@ -2,6 +2,23 @@ using LatticeCore
 using StaticArrays
 using Test
 
+# Dummy wrapper used to verify that `LatticeCore._has_known_grid` /
+# `LatticeCore._reshape_state` can be overridden by a *downstream*
+# Bravais lattice without depending on FFTW. Defined at top level so
+# the type is reachable from method tables (a `@testset` block opens
+# a `let`-style local scope, which would prevent that).
+struct DummyBravais{L} <: AbstractLattice{2,Float64}
+    inner::L
+end
+LatticeCore.position(d::DummyBravais, i::Int) = position(d.inner, i)
+LatticeCore.num_sites(d::DummyBravais) = num_sites(d.inner)
+LatticeCore.neighbors(d::DummyBravais, i::Int) = neighbors(d.inner, i)
+LatticeCore.boundary(d::DummyBravais) = boundary(d.inner)
+LatticeCore.size_trait(d::DummyBravais) = LatticeCore.size_trait(d.inner)
+LatticeCore.reciprocal_support(d::DummyBravais) =
+    LatticeCore.reciprocal_support(d.inner)
+LatticeCore.site_layout(d::DummyBravais) = LatticeCore.site_layout(d.inner)
+
 @testset "structure_factor" begin
     @testset "ferromagnet at k=0" begin
         # S(k=0) = |Σ s_i|² / N = N² / N = N for s_i ≡ 1
@@ -125,5 +142,53 @@ using Test
         slow = LatticeCore._structure_factor_naive(lat, state, ml_coarse)
         @test out ≈ slow rtol = 1e-12
         @test length(out) == 4
+    end
+
+    # ---- Downstream opt-in hook -------------------------------------
+    #
+    # The grid-layout hooks `LatticeCore._has_known_grid` /
+    # `LatticeCore._reshape_state` live on `LatticeCore` itself so a
+    # downstream package can register a custom Bravais lattice on the
+    # FFT fast path without depending on FFTW. Verify the dispatch
+    # path works end-to-end by wiring up a tiny clone of
+    # `SimpleSquareLattice`.
+
+    @testset "downstream lattices can opt into the FFT fast path" begin
+        # Reference lattices ship with the opt-in baked in.
+        @test LatticeCore._has_known_grid(SimpleSquareLattice(2, 2, PeriodicAxis())) ==
+            true
+        @test LatticeCore._has_known_grid(LineLattice(4, PeriodicAxis())) == true
+
+        inner = SimpleSquareLattice(4, 4, PeriodicAxis())
+        dlat = DummyBravais(inner)
+
+        # Default: dummy is not on the opt-in list. Confirm before
+        # we exercise the override.
+        @test LatticeCore._has_known_grid(dlat) == false
+        @test_throws ErrorException LatticeCore._reshape_state(dlat, ones(16), (4, 4))
+
+        # Without opt-in the FFT extension's `_fft_eligible` returns
+        # `false`, so `structure_factor(dlat, state, ml)` runs the
+        # naive helper. The numbers must agree with the reference.
+        ml = reciprocal_lattice(inner)
+        state = randn(num_sites(inner))
+        baseline = LatticeCore._structure_factor_naive(inner, state, ml)
+        out_default = structure_factor(dlat, state, ml)
+        @test out_default ≈ baseline rtol = 1e-12
+
+        # Now opt the dummy into the fast path. After the override,
+        # `_has_known_grid` returns `true` and `_reshape_state` no
+        # longer errors. With FFTW loaded eagerly in `runtests.jl`,
+        # `structure_factor(dlat, state, ml)` should still match the
+        # naive baseline (just routed via the FFT path instead).
+        LatticeCore._has_known_grid(::DummyBravais) = true
+        LatticeCore._reshape_state(::DummyBravais, s, dims) = reshape(s, dims)
+
+        @test LatticeCore._has_known_grid(dlat) == true
+        @test LatticeCore._reshape_state(dlat, state, (4, 4)) isa
+            AbstractMatrix{Float64}
+
+        out_opted_in = structure_factor(dlat, state, ml)
+        @test out_opted_in ≈ baseline rtol = 1e-9
     end
 end

--- a/test/core/test_structure_factor.jl
+++ b/test/core/test_structure_factor.jl
@@ -15,8 +15,7 @@ LatticeCore.num_sites(d::DummyBravais) = num_sites(d.inner)
 LatticeCore.neighbors(d::DummyBravais, i::Int) = neighbors(d.inner, i)
 LatticeCore.boundary(d::DummyBravais) = boundary(d.inner)
 LatticeCore.size_trait(d::DummyBravais) = LatticeCore.size_trait(d.inner)
-LatticeCore.reciprocal_support(d::DummyBravais) =
-    LatticeCore.reciprocal_support(d.inner)
+LatticeCore.reciprocal_support(d::DummyBravais) = LatticeCore.reciprocal_support(d.inner)
 LatticeCore.site_layout(d::DummyBravais) = LatticeCore.site_layout(d.inner)
 
 @testset "structure_factor" begin
@@ -155,8 +154,7 @@ LatticeCore.site_layout(d::DummyBravais) = LatticeCore.site_layout(d.inner)
 
     @testset "downstream lattices can opt into the FFT fast path" begin
         # Reference lattices ship with the opt-in baked in.
-        @test LatticeCore._has_known_grid(SimpleSquareLattice(2, 2, PeriodicAxis())) ==
-            true
+        @test LatticeCore._has_known_grid(SimpleSquareLattice(2, 2, PeriodicAxis())) == true
         @test LatticeCore._has_known_grid(LineLattice(4, PeriodicAxis())) == true
 
         inner = SimpleSquareLattice(4, 4, PeriodicAxis())
@@ -185,8 +183,7 @@ LatticeCore.site_layout(d::DummyBravais) = LatticeCore.site_layout(d.inner)
         LatticeCore._reshape_state(::DummyBravais, s, dims) = reshape(s, dims)
 
         @test LatticeCore._has_known_grid(dlat) == true
-        @test LatticeCore._reshape_state(dlat, state, (4, 4)) isa
-            AbstractMatrix{Float64}
+        @test LatticeCore._reshape_state(dlat, state, (4, 4)) isa AbstractMatrix{Float64}
 
         out_opted_in = structure_factor(dlat, state, ml)
         @test out_opted_in ≈ baseline rtol = 1e-9


### PR DESCRIPTION
## Summary
- Move `_has_known_grid` / `_reshape_state` out of `LatticeCoreFFTWExt` and onto `LatticeCore` itself (defaults in `src/StructureFactor.jl`, opt-ins next to `LineLattice` / `SimpleSquareLattice`) so downstream packages (Lattice2D, QuasiCrystal, custom Bravais lattices) can register on the FFT fast path without depending on FFTW.
- The FFTW extension now dispatches through `LatticeCore._has_known_grid` / `LatticeCore._reshape_state`; behaviour for shipped lattices is unchanged.
- New test installs a `DummyBravais` wrapper, confirms the default refuses it, then opts it in and checks the FFT path matches the naive baseline.
- Bumps version 0.10.1 -> 0.10.2.

Depends on #45.

## Test plan
- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes (1055/1055, Aqua included)
- [x] Default `LatticeCore._has_known_grid(::AbstractLattice)` returns `false`
- [x] `LineLattice` / `SimpleSquareLattice` opt-ins still hit the FFT fast path
- [x] Downstream override (`LatticeCore._has_known_grid(::DummyBravais) = true`) routes through the FFT path and matches the naive helper