### PR TITLE
feat: weighted shortest_path + distance_matrix

### DIFF
--- a/src/Graph.jl
+++ b/src/Graph.jl
@@ -285,9 +285,7 @@ end
 # full `(dist, parent)` arrays so callers can either ask for a single
 # `dst` (early termination via the optional `target` argument) or build
 # an all-pairs distance matrix on top.
-function _dijkstra(
-    lat::AbstractLattice, src::Int, weights::Function, target::Int=0
-)
+function _dijkstra(lat::AbstractLattice, src::Int, weights::Function, target::Int=0)
     N = num_sites(lat)
     dist = fill(Inf, N)
     parent = fill(0, N)
@@ -417,9 +415,7 @@ end
 # because we need real-valued weights, not the Bool adjacency.
 # Multi-edges are folded by taking the minimum (consistent with
 # `adjacency_matrix`'s `combine = |` for Bool).
-function _distance_matrix_floyd_warshall(
-    lat::AbstractLattice, weights::Function, N::Int
-)
+function _distance_matrix_floyd_warshall(lat::AbstractLattice, weights::Function, N::Int)
     D = fill(Inf, N, N)
     @inbounds for i in 1:N
         D[i, i] = 0.0
@@ -455,9 +451,7 @@ end
 # Internal: repeated single-source Dijkstra. Faster than Floyd–Warshall
 # on sparse lattice graphs once N is large (graphs from
 # `AbstractLattice` always have O(N) edges).
-function _distance_matrix_dijkstra(
-    lat::AbstractLattice, weights::Function, N::Int
-)
+function _distance_matrix_dijkstra(lat::AbstractLattice, weights::Function, N::Int)
     D = Matrix{Float64}(undef, N, N)
     for s in 1:N
         dist, _ = _dijkstra(lat, s, weights)

--- a/src/Graph.jl
+++ b/src/Graph.jl
@@ -6,10 +6,14 @@ This file provides a small, dependency-light graph layer on top of the
 
 - [`adjacency_matrix`](@ref) — N × N adjacency as a `SparseMatrixCSC{Bool, Int}`
   (or a dense `Matrix{Bool}` when `sparse=false`),
-- [`shortest_path`](@ref) — unweighted hop-count shortest path via BFS,
-  returning both the distance and a reconstructed path,
+- [`shortest_path`](@ref) — shortest path between two sites; unweighted
+  BFS by default, weighted Dijkstra when a `weights` callback is given,
+- [`distance_matrix`](@ref) — N × N all-pairs shortest-path distance
+  matrix; Floyd–Warshall for small lattices, repeated Dijkstra otherwise,
 - [`connected_components`](@ref) — connected components of the lattice
-  graph as a `Vector{Vector{Int}}`.
+  graph as a `Vector{Vector{Int}}`,
+- [`identity_weight`](@ref) — the default `weights` callback returning
+  `1.0` for every bond.
 
 Adjacency is built from the canonical `BondCenter` element iterator
 (`elements(lat, BondCenter())`) so that whatever bonds a lattice
@@ -96,31 +100,105 @@ function _adjacency_matrix_assemble(
 end
 
 """
-    shortest_path(lat::AbstractLattice, src::Int, dst::Int)
-        -> (dist::Int, path::Vector{Int})
+    identity_weight(lat::AbstractLattice, bond::Bond) → 1.0
 
-Unweighted shortest path on the lattice graph from `src` to `dst`,
-computed via breadth-first search using `neighbors(lat, ·)`.
+Default `weights` callback used by [`shortest_path`](@ref) and
+[`distance_matrix`](@ref). Returns `1.0` for every bond.
 
-Returns a tuple `(dist, path)` where:
-- `dist` is the hop count (number of bonds) between `src` and `dst`.
-  `0` if `src == dst`.
-- `path` is the reconstructed sequence of site indices, starting at
-  `src` and ending at `dst`. `[src]` if `src == dst`.
+This sentinel value is checked by `===` inside `shortest_path`:
+when `weights === identity_weight`, the unweighted BFS code path is
+selected for speed and to preserve the `Int`-distance return type
+introduced in PR #44. Any other callback runs the Dijkstra code path
+and yields `Float64` costs.
 
-If `src` and `dst` are in different connected components,
-`(typemax(Int), Int[])` is returned. Edges are treated as having unit
-weight; for weighted shortest paths, downstream packages may add a
-Dijkstra/A* layer on top.
+The callback signature is `(lat, bond) -> Real`. A custom weight
+function should preserve this shape; for example, to use the
+boundary-modifier [`bond_weight`](@ref) from
+[`BoundaryCondition`](@ref AbstractBoundaryCondition):
 
-# Example
+```julia
+ssd_w(lat, b) = bond_weight(boundary(lat).modifier, lat, b.i, b.j)
+shortest_path(lat, src, dst; weights=ssd_w)
+```
+
+`identity_weight` itself ignores its arguments.
+"""
+identity_weight(::AbstractLattice, ::Bond) = 1.0
+
+"""
+    shortest_path(lat::AbstractLattice, src::Int, dst::Int;
+                  weights::Function=identity_weight)
+        -> (cost, path::Vector{Int})
+
+Shortest path on the lattice graph from `src` to `dst`.
+
+The implementation dispatches internally on the identity of the
+`weights` callback:
+
+- `weights === identity_weight` (the default) — the unweighted hop-
+  count BFS introduced in PR #44 is used. Returns
+  `(dist::Int, path::Vector{Int})`. `dist` is the number of bonds
+  between `src` and `dst` (`0` if `src == dst`); on disconnect it
+  returns `(typemax(Int), Int[])`. The no-keyword call form
+  `shortest_path(lat, src, dst)` resolves to this branch and is fully
+  backward compatible with PR #44.
+- Any other callback — Dijkstra on the weighted graph. `weights`
+  must be a callable `(lat, bond) -> Real` returning a non-negative
+  edge cost. Returns `(cost::Float64, path::Vector{Int})`; on
+  disconnect it returns `(Inf, Int[])`.
+
+The `weights` callback is invoked once per directed edge traversal on
+bonds produced by `neighbor_bonds(lat, u)`. The signature deliberately
+takes a `Bond`, not just `(i, j)`, so callbacks can read `bond.type`,
+`bond.vector`, etc. and so the same callback can be passed to
+[`distance_matrix`](@ref). To re-use the existing
+[`bond_weight`](@ref) of an [`AbstractBoundaryModifier`](@ref), wrap
+it in a closure:
+
+```julia
+ssd_w(lat, b) = bond_weight(boundary(lat).modifier, lat, b.i, b.j)
+shortest_path(lat, 1, 9; weights=ssd_w)
+```
+
+Negative-weight edges are not supported; behaviour is undefined if
+`weights` returns a negative value.
+
+# Examples
 ```julia
 lat = SimpleSquareLattice(3, 3, OpenAxis())
-d, p = shortest_path(lat, 1, 9)
-# d == 4, p == [1, 2, 3, 6, 9]   (one of several minimum paths)
+d, p = shortest_path(lat, 1, 9)                       # BFS, Int distance
+c, q = shortest_path(lat, 1, 9; weights=(lat, b) -> 1.0)  # Dijkstra, Float64 cost
+c == Float64(d)                                        # true
 ```
 """
-function shortest_path(lat::AbstractLattice, src::Int, dst::Int)
+function shortest_path(
+    lat::AbstractLattice, src::Int, dst::Int; weights::Function=identity_weight
+)
+    # Method dispatch ignores keyword arguments, so we can only have
+    # one `shortest_path(lat, src, dst)` method. We branch internally on
+    # the `weights` callback:
+    #
+    # - `weights === identity_weight` (default) keeps the PR #44 BFS
+    #   call shape: returns `(dist::Int, path::Vector{Int})` and
+    #   `(typemax(Int), Int[])` on disconnect.
+    # - Any other callback runs Dijkstra and returns
+    #   `(cost::Float64, path::Vector{Int})` with `(Inf, Int[])` on
+    #   disconnect.
+    #
+    # This preserves backward compatibility with the unweighted call
+    # while letting users opt into Float64-cost Dijkstra by passing a
+    # custom `weights`.
+    if weights === identity_weight
+        return _shortest_path_bfs(lat, src, dst)
+    else
+        return _shortest_path_dijkstra(lat, src, dst, weights)
+    end
+end
+
+# Internal: BFS implementation. Kept separate from the Dijkstra path so
+# the no-`weights` call shape (PR #44 API) keeps its `Int` distance
+# return type and avoids paying the priority-queue overhead.
+function _shortest_path_bfs(lat::AbstractLattice, src::Int, dst::Int)
     is_finite(lat) || throw(ArgumentError("shortest_path requires a finite lattice"))
     N = num_sites(lat)
     (1 <= src <= N) || throw(BoundsError(lat, src))
@@ -166,6 +244,228 @@ function shortest_path(lat::AbstractLattice, src::Int, dst::Int)
     end
     reverse!(path)
     return (length(path) - 1, path)
+end
+
+# Internal: Dijkstra single-source, single-target. Uses a binary heap
+# (O((V+E) log V)) on `(cost, site)` pairs. We index the heap by site
+# count which is small for any lattice we expect; if we ever need
+# decrease-key, we can switch to an indexed heap. The "stale entry"
+# trick (skip entries whose recorded cost no longer matches `dist`)
+# is the standard workaround for a non-indexed binary heap.
+function _shortest_path_dijkstra(
+    lat::AbstractLattice, src::Int, dst::Int, weights::Function
+)
+    is_finite(lat) || throw(ArgumentError("shortest_path requires a finite lattice"))
+    N = num_sites(lat)
+    (1 <= src <= N) || throw(BoundsError(lat, src))
+    (1 <= dst <= N) || throw(BoundsError(lat, dst))
+
+    if src == dst
+        return (0.0, [src])
+    end
+
+    dist, parent = _dijkstra(lat, src, weights, dst)
+
+    if dist[dst] == Inf
+        return (Inf, Int[])
+    end
+
+    path = Int[dst]
+    cur = dst
+    while cur != src
+        cur = parent[cur]
+        push!(path, cur)
+    end
+    reverse!(path)
+    return (dist[dst], path)
+end
+
+# Internal: single-source Dijkstra over `lat`, using `weights(lat, b)`
+# for each `Bond` returned by `neighbor_bonds(lat, u)`. Returns the
+# full `(dist, parent)` arrays so callers can either ask for a single
+# `dst` (early termination via the optional `target` argument) or build
+# an all-pairs distance matrix on top.
+function _dijkstra(
+    lat::AbstractLattice, src::Int, weights::Function, target::Int=0
+)
+    N = num_sites(lat)
+    dist = fill(Inf, N)
+    parent = fill(0, N)
+    dist[src] = 0.0
+
+    # Heap stores `(cost, site)` tuples. Default `Base.isless` on
+    # tuples is lex-order, so `cost` dominates which is what we want.
+    heap = Tuple{Float64,Int}[(0.0, src)]
+    while !isempty(heap)
+        d, u = _heappop!(heap)
+        # Stale entry guard: another, cheaper path to `u` has been
+        # popped already, so this entry is obsolete.
+        d > dist[u] && continue
+        u == target && break
+        for b in neighbor_bonds(lat, u)
+            v = b.j
+            w = Float64(weights(lat, b))
+            alt = d + w
+            if alt < dist[v]
+                dist[v] = alt
+                parent[v] = u
+                _heappush!(heap, (alt, v))
+            end
+        end
+    end
+    return dist, parent
+end
+
+# Internal: minimal binary-heap push/pop on a Vector. We keep this
+# self-contained (no DataStructures.jl dep) because Graph.jl is meant
+# to be dependency-light. `_heappush!` / `_heappop!` operate on the
+# default `Base.isless` ordering.
+function _heappush!(heap::Vector{T}, x::T) where {T}
+    push!(heap, x)
+    i = length(heap)
+    while i > 1
+        parent = i >> 1
+        if isless(heap[i], heap[parent])
+            heap[i], heap[parent] = heap[parent], heap[i]
+            i = parent
+        else
+            break
+        end
+    end
+    return heap
+end
+
+function _heappop!(heap::Vector{T}) where {T}
+    top = heap[1]
+    last = pop!(heap)
+    if !isempty(heap)
+        heap[1] = last
+        n = length(heap)
+        i = 1
+        while true
+            l = 2i
+            r = 2i + 1
+            smallest = i
+            if l <= n && isless(heap[l], heap[smallest])
+                smallest = l
+            end
+            if r <= n && isless(heap[r], heap[smallest])
+                smallest = r
+            end
+            smallest == i && break
+            heap[i], heap[smallest] = heap[smallest], heap[i]
+            i = smallest
+        end
+    end
+    return top
+end
+
+"""
+    distance_matrix(lat::AbstractLattice;
+                    weights::Function=identity_weight) → Matrix{Float64}
+
+All-pairs shortest-path distance matrix on the lattice graph. Returns
+an `N × N` `Matrix{Float64}` with `D[i, j]` equal to the cost of the
+shortest path from site `i` to site `j` under `weights`. Diagonal
+entries are `0.0`. Pairs of sites in distinct connected components
+are filled with `Inf`.
+
+The default `weights=identity_weight` reproduces unweighted hop-count
+distances (`Float64`-promoted for uniformity with the weighted case).
+The callback signature is `(lat, bond) -> Real` — see
+[`identity_weight`](@ref) for the convention and an SSD example.
+
+# Algorithm
+
+For lattices with `num_sites(lat) <= floyd_warshall_threshold` (default
+`64`) the implementation uses dense Floyd–Warshall (`O(N^3)`,
+arithmetic-only). For larger lattices it runs Dijkstra from each
+source (`O(N · (V + E) log V)`), which is asymptotically cheaper on
+sparse lattice graphs.
+
+# Keyword arguments
+
+- `weights::Function=identity_weight` — edge cost callback as above.
+- `floyd_warshall_threshold::Int=64` — switch-over `N` between the
+  two algorithms. Mostly a tuning knob; the default is conservative.
+
+# Example
+
+```julia
+lat = SimpleSquareLattice(4, 4, OpenAxis())
+D = distance_matrix(lat)
+@assert D == transpose(D)            # symmetric for undirected graph
+@assert all(iszero, diag(D))
+```
+"""
+function distance_matrix(
+    lat::AbstractLattice;
+    weights::Function=identity_weight,
+    floyd_warshall_threshold::Int=64,
+)
+    is_finite(lat) || throw(ArgumentError("distance_matrix requires a finite lattice"))
+    N = num_sites(lat)
+    if N <= floyd_warshall_threshold
+        return _distance_matrix_floyd_warshall(lat, weights, N)
+    else
+        return _distance_matrix_dijkstra(lat, weights, N)
+    end
+end
+
+# Internal: dense Floyd–Warshall. We seed the matrix from the bond
+# iterator directly (rather than going through `adjacency_matrix`)
+# because we need real-valued weights, not the Bool adjacency.
+# Multi-edges are folded by taking the minimum (consistent with
+# `adjacency_matrix`'s `combine = |` for Bool).
+function _distance_matrix_floyd_warshall(
+    lat::AbstractLattice, weights::Function, N::Int
+)
+    D = fill(Inf, N, N)
+    @inbounds for i in 1:N
+        D[i, i] = 0.0
+    end
+    for b in elements(lat, BondCenter())
+        i, j = b.i, b.j
+        i == j && continue
+        w = Float64(weights(lat, b))
+        # Symmetric: bonds are undirected. If a lattice publishes both
+        # orientations (i->j and j->i) with different weights, the
+        # smaller one wins on each side. We do not currently encode
+        # directed bonds.
+        if w < D[i, j]
+            D[i, j] = w
+            D[j, i] = w
+        end
+    end
+    @inbounds for k in 1:N, i in 1:N
+        dik = D[i, k]
+        dik == Inf && continue
+        for j in 1:N
+            dkj = D[k, j]
+            dkj == Inf && continue
+            alt = dik + dkj
+            if alt < D[i, j]
+                D[i, j] = alt
+            end
+        end
+    end
+    return D
+end
+
+# Internal: repeated single-source Dijkstra. Faster than Floyd–Warshall
+# on sparse lattice graphs once N is large (graphs from
+# `AbstractLattice` always have O(N) edges).
+function _distance_matrix_dijkstra(
+    lat::AbstractLattice, weights::Function, N::Int
+)
+    D = Matrix{Float64}(undef, N, N)
+    for s in 1:N
+        dist, _ = _dijkstra(lat, s, weights)
+        @inbounds for j in 1:N
+            D[s, j] = dist[j]
+        end
+    end
+    return D
 end
 
 """

--- a/src/LatticeCore.jl
+++ b/src/LatticeCore.jl
@@ -87,7 +87,8 @@ export AcceptanceWindow, HyperReciprocalLattice, BraggPeakSet
 export materialize, require_finite
 
 # ---- Graph operations ----
-export adjacency_matrix, shortest_path, connected_components
+export adjacency_matrix, shortest_path, distance_matrix, connected_components
+export identity_weight
 
 # ---- Plotting (methods live in LatticeCorePlotsExt) ----
 export plot_lattice, plot_bonds!, plot_sites!

--- a/test/core/test_graph.jl
+++ b/test/core/test_graph.jl
@@ -1,4 +1,5 @@
 using LatticeCore
+using LinearAlgebra
 using SparseArrays
 using StaticArrays
 using Test
@@ -126,5 +127,148 @@ LatticeCore.size_trait(::TwoTriangles) = FiniteSize((6,))
         @test length(comps2) == 2
         @test comps2[1] == [1, 2, 3]
         @test comps2[2] == [4, 5, 6]
+    end
+
+    @testset "shortest_path with uniform weights matches BFS" begin
+        # When `weights === identity_weight` (the default), the API
+        # falls back to BFS and returns the Int hop count — see the
+        # `shortest_path` docstring. Passing `identity_weight` by
+        # keyword should be observationally identical to the no-kwarg
+        # call shape.
+        for lat in (GraphPath(6), SimpleSquareLattice(3, 3, OpenAxis()))
+            N = num_sites(lat)
+            for s in 1:N, t in 1:N
+                d_bfs, p_bfs = shortest_path(lat, s, t)
+                d_kw, p_kw = shortest_path(lat, s, t; weights=identity_weight)
+                @test d_kw === d_bfs
+                @test p_kw == p_bfs
+            end
+        end
+
+        # A user-supplied uniform-1 callback (≠ identity_weight by
+        # `===`) takes the Dijkstra path and must produce the same
+        # connectivity-distance up to Float64 promotion.
+        uniform_w(_lat, _b) = 1.0
+        for lat in (GraphPath(6), SimpleSquareLattice(3, 3, OpenAxis()))
+            N = num_sites(lat)
+            for s in 1:N, t in 1:N
+                d_bfs, p_bfs = shortest_path(lat, s, t)
+                c_dij, p_dij = shortest_path(lat, s, t; weights=uniform_w)
+                if d_bfs == typemax(Int)
+                    @test c_dij == Inf
+                    @test isempty(p_dij)
+                else
+                    @test c_dij == Float64(d_bfs)
+                    @test first(p_dij) == s && last(p_dij) == t
+                    @test length(p_dij) == length(p_bfs)
+                end
+            end
+        end
+    end
+
+    @testset "shortest_path with custom weights" begin
+        # Path graph 1-2-3-4-5; bond (i, i+1) weight = 1 if i odd, 2 if i even.
+        lat = GraphPath(5)
+        alt_w(_lat, b) = isodd(min(b.i, b.j)) ? 1.0 : 2.0
+
+        c, p = shortest_path(lat, 1, 5; weights=alt_w)
+        # Costs along 1-2-3-4-5: 1 + 2 + 1 + 2 = 6
+        @test c == 6.0
+        @test p == [1, 2, 3, 4, 5]
+
+        # 2 -> 5 traverses bonds (2,3), (3,4), (4,5) with weights 2, 1, 2.
+        c2, p2 = shortest_path(lat, 2, 5; weights=alt_w)
+        @test c2 == 5.0
+        @test p2 == [2, 3, 4, 5]
+
+        # src == dst stays zero-cost regardless of weights.
+        c0, p0 = shortest_path(lat, 3, 3; weights=alt_w)
+        @test c0 == 0.0
+        @test p0 == [3]
+    end
+
+    @testset "shortest_path on disconnected graph (weighted)" begin
+        lat = TwoTriangles()
+        # A genuine custom callback engages the Dijkstra path; cross-
+        # component queries should return `(Inf, Int[])`.
+        uniform_w(_lat, _b) = 1.0
+        c, p = shortest_path(lat, 1, 4; weights=uniform_w)
+        @test c == Inf
+        @test isempty(p)
+        # Heavy custom weights stay Inf across the cut too.
+        big_w(_lat, _b) = 100.0
+        c2, p2 = shortest_path(lat, 2, 5; weights=big_w)
+        @test c2 == Inf
+        @test isempty(p2)
+        # Within a component, total cost = 100 * (one hop) = 100.
+        c3, p3 = shortest_path(lat, 4, 6; weights=big_w)
+        @test c3 == 100.0
+        @test first(p3) == 4 && last(p3) == 6
+    end
+
+    @testset "shortest_path keyword bounds checking" begin
+        lat = GraphPath(3)
+        @test_throws BoundsError shortest_path(lat, 0, 2; weights=identity_weight)
+        @test_throws BoundsError shortest_path(lat, 1, 4; weights=identity_weight)
+    end
+
+    @testset "distance_matrix on small SimpleSquareLattice" begin
+        sq = SimpleSquareLattice(4, 4, OpenAxis())
+        D = distance_matrix(sq)
+        @test D isa Matrix{Float64}
+        @test size(D) == (16, 16)
+        @test D == transpose(D)              # undirected -> symmetric
+        @test all(iszero, diag(D))
+        # Spot-check: corner-to-corner Manhattan distance on a 4x4
+        # OBC square is 6 hops.
+        @test D[1, 16] == 6.0
+        # Same answer via shortest_path
+        d_sp, _ = shortest_path(sq, 1, 16; weights=identity_weight)
+        @test d_sp == D[1, 16]
+    end
+
+    @testset "distance_matrix Floyd-Warshall vs Dijkstra agree" begin
+        # Force the threshold to flip algorithms on the same lattice
+        # and check both code paths produce the same matrix.
+        lat = GraphPath(8)
+        D_fw = distance_matrix(lat; floyd_warshall_threshold=100)
+        D_dj = distance_matrix(lat; floyd_warshall_threshold=0)
+        @test D_fw == D_dj
+        # And the matrix entries must agree element-wise with the
+        # single-pair shortest_path query (Float64-promoted to match
+        # `distance_matrix`'s element type).
+        for s in 1:num_sites(lat), t in 1:num_sites(lat)
+            d_sp, _ = shortest_path(lat, s, t)
+            expected = d_sp == typemax(Int) ? Inf : Float64(d_sp)
+            @test D_fw[s, t] == expected
+        end
+    end
+
+    @testset "distance_matrix on disconnected graph" begin
+        lat = TwoTriangles()
+        D = distance_matrix(lat)
+        @test size(D) == (6, 6)
+        @test all(iszero, diag(D))
+        # Cross-component entries are Inf
+        @test D[1, 4] == Inf
+        @test D[3, 5] == Inf
+        # Within-component entries are finite
+        @test D[1, 2] == 1.0
+        @test D[4, 6] == 1.0
+        # Symmetry
+        @test D == transpose(D)
+    end
+
+    @testset "distance_matrix with custom weights" begin
+        lat = GraphPath(4)
+        # Bond (i, i+1) weight = i (so 1, 2, 3 along the chain).
+        ramp_w(_lat, b) = Float64(min(b.i, b.j))
+        D = distance_matrix(lat; weights=ramp_w)
+        # 1->2: 1, 1->3: 1+2=3, 1->4: 1+2+3=6
+        @test D[1, 2] == 1.0
+        @test D[1, 3] == 3.0
+        @test D[1, 4] == 6.0
+        # Symmetric
+        @test D == transpose(D)
     end
 end


### PR DESCRIPTION
## Summary

- Extends the unweighted BFS `shortest_path` from PR #44 with a weighted Dijkstra code path. `shortest_path(lat, src, dst; weights=identity_weight)` falls back to BFS (preserving the PR #44 `Int`-distance return type); any non-default `(lat, bond) -> Real` callback engages Dijkstra and returns a `Float64` cost.
- Adds `distance_matrix(lat; weights, floyd_warshall_threshold=64) -> Matrix{Float64}` for all-pairs shortest paths, picking dense Floyd–Warshall for `N <= threshold` and repeated single-source Dijkstra otherwise. A self-contained binary heap keeps the layer dependency-light (still `SparseArrays` only).
- Exports `identity_weight`, `distance_matrix`. The boundary-modifier `bond_weight` stays its own interface; the `shortest_path` docstring shows a one-line closure that adapts it to the `(lat, bond) -> Real` callback shape used here.

## Test plan

- [x] `Pkg.test()` — full suite passes (1736/1736), including Aqua `test_all` + ambiguities.
- [x] `shortest_path` BFS path matches `weights=identity_weight` keyword path on `GraphPath(6)` and `SimpleSquareLattice(3, 3, OpenAxis())` for every `(s, t)`.
- [x] `shortest_path` with a uniform-1 wrapper callback (engages Dijkstra) matches BFS hop count promoted to `Float64`.
- [x] Alternating custom weights on a 1D path produce the expected weighted path costs.
- [x] Disconnected `TwoTriangles` returns `(Inf, Int[])` on Dijkstra path and `(typemax(Int), Int[])` on the BFS-fallback path; `BoundsError` propagates through the keyword call.
- [x] `distance_matrix` on `SimpleSquareLattice(4, 4, OpenAxis())` is symmetric, has zero diagonal, and reproduces hop counts.
- [x] Floyd–Warshall and repeated-Dijkstra agree element-wise via the `floyd_warshall_threshold` toggle.
- [x] `distance_matrix` on a disconnected lattice returns `Inf` only across components and stays symmetric.
- [x] Custom ramp weights `b -> min(b.i, b.j)` give the expected analytic prefix-sum distances.

Closes #48