### PR TITLE
feat: implement SSD bond_weight envelope (closes #29)

### DIFF
--- a/docs/src/concepts/boundary_conditions.md
+++ b/docs/src/concepts/boundary_conditions.md
@@ -161,9 +161,13 @@ axis-level BC with any modifier without touching the core code:
 LatticeBoundary((PeriodicAxis(), OpenAxis()), SSD(10.0))
 ```
 
-(The `SSD` weighting function itself is currently a type-level
-placeholder; the concrete envelope evaluation lands with the MC
-layer.)
+[`bond_weight(::SSD, lat, i, j)`](@ref bond_weight) evaluates the
+multi-axis envelope `∏_d sin²(π (c_d − 1/2) / L_d)` at each endpoint
+and averages, reading the per-axis lengths `L_d` from the lattice's
+[`size_trait`](@ref). The `L` field on `SSD(L)` is informational and
+not used by the canonical evaluation; downstream packages may
+override the method on a more specific lattice type to supply
+alternative scales.
 
 ## Finite-size scaling and BC choice
 

--- a/docs/src/guide/boundary.md
+++ b/docs/src/guide/boundary.md
@@ -124,8 +124,13 @@ Every axis BC is a dispatch point for two generic functions:
 
 Modifiers dispatch through [`bond_weight(modifier, lat, i, j)`](@ref
 bond_weight). [`NoModifier`](@ref) returns `1.0` unconditionally;
-[`SSD`](@ref)'s weighting function is a stub until the MC layer
-lands a `center(lat)` accessor.
+[`SSD`](@ref) evaluates the canonical multi-axis envelope
+`∏_d sin²(π (c_d − 1/2) / L_d)` at each endpoint and returns the
+arithmetic mean, taking `(L_1, …, L_D)` from
+[`size_trait`](@ref). It requires a [`FiniteSize`](@ref) lattice
+and is BC-agnostic — typically combined with [`OpenAxis`](@ref) on
+every axis, but the weight evaluation itself is independent of the
+axis tuple.
 
 ## Adding a new axis BC
 

--- a/src/BoundaryCondition.jl
+++ b/src/BoundaryCondition.jl
@@ -90,10 +90,30 @@ struct NoModifier <: AbstractBoundaryModifier end
 """
     SSD(L)
 
-Sine-square deformation modifier. `L` is the characteristic scale
-used by the envelope `sin²(π · x/L)`. The concrete weight implementation
-will land with the MC layer; for now this serves as a placeholder
-carrying the scale parameter.
+Sine-square deformation modifier. `L` is a characteristic scale
+carried by the modifier; the canonical bond weight evaluation
+([`bond_weight(::SSD, lat, i, j)`](@ref bond_weight)) reads the
+per-axis lengths of the lattice from [`size_trait`](@ref) instead, so
+`L` is informational under finite, fully-specified geometries. It is
+retained for downstream packages that may want to override the
+default with an alternative scale (e.g. infinite-system extrapolations).
+
+# Canonical envelope
+
+For a `D`-dimensional finite lattice with per-axis cell counts
+`(L_1, …, L_D)`, the SSD envelope evaluated at a lattice cell with
+1-based per-axis coordinate `cx_d ∈ 1:L_d` is
+
+```math
+f(\\mathbf{r}) = \\prod_{d=1}^{D} \\sin^{2}\\!\\left(
+    \\pi \\, \\frac{c_{x,d} - 1/2}{L_d}
+\\right),
+```
+
+equivalent to the standard ``\\sin^2(\\pi (i + 1/2) / L)`` on
+0-indexed sites. The bond weight between sites `i, j` is the
+arithmetic mean of the two endpoint envelopes,
+``w(i, j) = (f(\\mathbf{r}_i) + f(\\mathbf{r}_j)) / 2``.
 
 `SSD` is exported so downstream MC / TN packages can construct
 boundaries with SSD weighting and dispatch on the type. Custom
@@ -190,5 +210,76 @@ modifier. Default implementation for [`NoModifier`](@ref) returns
 `1.0`. SSD and other non-trivial modifiers will override this.
 """
 bond_weight(::NoModifier, lat, ::Int, ::Int) = 1.0
-# SSD weight is intentionally left unimplemented for now; it will land
-# with the MC layer once we have a `center(lat)` accessor.
+
+"""
+    _ssd_axis_envelope(cx::Real, L::Integer) → Float64
+
+Single-axis SSD envelope `sin²(π (cx - 1/2) / L)` for a 1-based
+real-valued per-axis cell coordinate `cx ∈ [1, L]`. The shift by
+`-1/2` converts the convention to the canonical 0-indexed form
+`sin²(π (i + 1/2) / L)` with `i = cx - 1`.
+
+Internal helper for [`bond_weight(::SSD, lat, i, j)`](@ref bond_weight).
+"""
+@inline function _ssd_axis_envelope(cx::Real, L::Integer)
+    return sin(pi * (float(cx) - 0.5) / L)^2
+end
+
+"""
+    _ssd_site_envelope(lat::AbstractLattice, i::Int) → Float64
+
+Multi-axis SSD envelope evaluated at site `i`: the product of
+[`_ssd_axis_envelope`](@ref) over the per-axis cell coordinates of
+`i`. Uses [`size_trait`](@ref) for per-axis lengths and
+[`to_lattice`](@ref) ∘ [`position`](@ref) for the cell coordinate
+of the site.
+
+The conversion `to_lattice(lat, RealSpace(position(lat, i)))` round-trips
+exactly for the reference lattices (which use unit spacing) and relies
+on the lattice's own `to_lattice(::RealSpace)` for any custom basis.
+"""
+@inline function _ssd_site_envelope(lat::AbstractLattice, i::Int)
+    st = size_trait(lat)
+    st isa FiniteSize ||
+        throw(ArgumentError("SSD weight requires a FiniteSize lattice; got $(typeof(st))"))
+    dims = st.dims
+    coord = to_lattice(lat, RealSpace(position(lat, i)))
+    f = 1.0
+    @inbounds for d in eachindex(dims)
+        f *= _ssd_axis_envelope(coord.cell[d], dims[d])
+    end
+    return f
+end
+
+"""
+    bond_weight(::SSD, lat::AbstractLattice, i::Int, j::Int) → Float64
+
+Sine-square deformation envelope for the bond `(i, j)`. Each axis
+contributes a `sin²(π (c_d - 1/2) / L_d)` factor, where `c_d` is the
+1-based per-axis cell coordinate read from
+`to_lattice(lat, RealSpace(position(lat, i)))` and `L_d` is the
+matching component of `size_trait(lat).dims`. The bond weight is the
+arithmetic mean of the two endpoint envelopes,
+
+```math
+w(i, j) = \\tfrac{1}{2}\\bigl(f(\\mathbf{r}_i) + f(\\mathbf{r}_j)\\bigr).
+```
+
+Requires a [`FiniteSize`](@ref) lattice; an
+[`InfiniteSize`](@ref) / [`QuasiInfiniteSize`](@ref) lattice raises
+`ArgumentError` because the envelope has no canonical scale without
+finite per-axis lengths. Downstream packages may overload the method
+on a more specific lattice type to supply alternative scales.
+
+# Boundary-condition assumptions
+
+SSD is most commonly paired with open boundaries (the envelope
+suppresses surface excitations of an OBC sample); the implementation
+itself is BC-agnostic and will weight any bond regardless of the axis
+BCs in [`LatticeBoundary`](@ref).
+"""
+function bond_weight(modifier::SSD, lat::AbstractLattice, i::Int, j::Int)
+    fi = _ssd_site_envelope(lat, i)
+    fj = _ssd_site_envelope(lat, j)
+    return 0.5 * (fi + fj)
+end

--- a/test/core/test_ssd.jl
+++ b/test/core/test_ssd.jl
@@ -54,8 +54,7 @@ LatticeCore.size_trait(::_SSDInfiniteMockLat) = InfiniteSize()
 
     # Reflection symmetry of the bond weights along the chain.
     for k in 1:(L - 1)
-        @test bond_weight(ssd, lat, k, k + 1) ≈
-            bond_weight(ssd, lat, L - k, L - k + 1)
+        @test bond_weight(ssd, lat, k, k + 1) ≈ bond_weight(ssd, lat, L - k, L - k + 1)
     end
 
     # Order independence in (i, j).

--- a/test/core/test_ssd.jl
+++ b/test/core/test_ssd.jl
@@ -1,0 +1,125 @@
+using LatticeCore
+using Test
+
+# Reference SSD envelope: f(i) = sin^2(π (i + 1/2) / L) on 0-indexed
+# `i ∈ 0:L-1`. Used as the ground-truth comparison for the public
+# `bond_weight(::SSD, lat, i, j)` method.
+ssd_ref(i, L) = sin(pi * (i + 0.5) / L)^2
+
+# Mock lattice with InfiniteSize for the size-trait guard test. We
+# define it at module scope (not inside @testset) so Aqua's piracy
+# / unbound-args checks see a proper top-level type.
+struct _SSDInfiniteMockLat <: LatticeCore.AbstractLattice{1,Float64} end
+LatticeCore.size_trait(::_SSDInfiniteMockLat) = InfiniteSize()
+
+@testset "SSD bond_weight: 1D LineLattice" begin
+    L = 8
+    lat = LineLattice(L, OpenAxis())
+    ssd = SSD(float(L))
+
+    # Axis envelope sanity: the boundary site (cx = 1, i.e. i = 0) is
+    # close to zero; the half-integer center i = L/2 - 1/2 evaluates
+    # to exactly 1.
+    @test ssd_ref(0, L) ≈ sin(pi / 16)^2
+    @test ssd_ref(0, L) ≈ 0.038060233744356625
+    @test ssd_ref(L / 2 - 0.5, L) ≈ 1.0
+
+    # Symmetry: f(i) == f(L - 1 - i).
+    for i in 0:(L - 1)
+        @test ssd_ref(i, L) ≈ ssd_ref(L - 1 - i, L)
+    end
+
+    # bond_weight equals the arithmetic mean of the two endpoint
+    # envelopes for every nearest-neighbor bond.
+    for b in bonds(lat)
+        ci = b.i      # 1-based site index, also equal to the cell index
+        cj = b.j
+        fi = ssd_ref(ci - 1, L)
+        fj = ssd_ref(cj - 1, L)
+        @test bond_weight(ssd, lat, b.i, b.j) ≈ (fi + fj) / 2
+    end
+
+    # Boundary edge bond (sites 1, 2) is suppressed; the central bond
+    # carries the largest weight.
+    edge = bond_weight(ssd, lat, 1, 2)
+    centre = bond_weight(ssd, lat, L ÷ 2, L ÷ 2 + 1)
+    @test edge < 0.2
+    @test centre > 0.9
+    @test edge < centre
+
+    # Monotonicity: walking from the left edge toward the centre, the
+    # bond weight increases for every successive nearest-neighbor pair.
+    weights = [bond_weight(ssd, lat, k, k + 1) for k in 1:(L ÷ 2 - 1)]
+    @test all(weights[k] < weights[k + 1] for k in 1:(length(weights) - 1))
+
+    # Reflection symmetry of the bond weights along the chain.
+    for k in 1:(L - 1)
+        @test bond_weight(ssd, lat, k, k + 1) ≈
+            bond_weight(ssd, lat, L - k, L - k + 1)
+    end
+
+    # Order independence in (i, j).
+    @test bond_weight(ssd, lat, 1, 2) == bond_weight(ssd, lat, 2, 1)
+end
+
+@testset "SSD bond_weight: 2D SimpleSquareLattice (axis product)" begin
+    Lx, Ly = 4, 6
+    lat = SimpleSquareLattice(Lx, Ly, OpenAxis())
+    ssd = SSD(float(min(Lx, Ly)))
+
+    # 2D envelope at site (cx, cy) (1-based) is the product of the
+    # per-axis envelopes. Verify on every site via the self-bond
+    # mean: bond_weight(SSD, lat, i, i) is the envelope itself.
+    for i in 1:num_sites(lat)
+        x = mod1(i, Lx)
+        y = ((i - 1) ÷ Lx) + 1
+        f_expected = ssd_ref(x - 1, Lx) * ssd_ref(y - 1, Ly)
+        @test bond_weight(ssd, lat, i, i) ≈ f_expected
+    end
+
+    # Real bond weight: arithmetic mean of two endpoint envelopes.
+    for b in bonds(lat)
+        x_i = mod1(b.i, Lx)
+        y_i = ((b.i - 1) ÷ Lx) + 1
+        x_j = mod1(b.j, Lx)
+        y_j = ((b.j - 1) ÷ Lx) + 1
+        fi = ssd_ref(x_i - 1, Lx) * ssd_ref(y_i - 1, Ly)
+        fj = ssd_ref(x_j - 1, Lx) * ssd_ref(y_j - 1, Ly)
+        @test bond_weight(ssd, lat, b.i, b.j) ≈ (fi + fj) / 2
+    end
+
+    # Corner bonds are most suppressed; an interior bulk bond carries
+    # a much larger weight.
+    corner_bond_weight = bond_weight(ssd, lat, 1, 2)             # along x at corner
+    bulk_i = (Ly ÷ 2 - 1) * Lx + Lx ÷ 2                          # near-centre site
+    bulk_bond_weight = bond_weight(ssd, lat, bulk_i, bulk_i + 1)
+    @test corner_bond_weight < bulk_bond_weight
+end
+
+@testset "SSD bond_weight: BC-agnostic interface" begin
+    # The implementation evaluates the envelope regardless of the
+    # axis tuple. Bulk PBC and OBC must agree on the weight value
+    # because the weight depends only on lattice cell coordinates,
+    # not on which bonds the BC connects.
+    L = 6
+    obc = LineLattice(L, OpenAxis())
+    pbc = LineLattice(L, PeriodicAxis())
+    ssd = SSD(float(L))
+
+    for k in 1:(L - 1)
+        @test bond_weight(ssd, obc, k, k + 1) ≈ bond_weight(ssd, pbc, k, k + 1)
+    end
+end
+
+@testset "SSD bond_weight: rejects non-finite size" begin
+    @test_throws ArgumentError bond_weight(SSD(8.0), _SSDInfiniteMockLat(), 1, 2)
+end
+
+@testset "SSD bond_weight: type stability and value type" begin
+    lat = LineLattice(4, OpenAxis())
+    ssd = SSD(4.0)
+    w = bond_weight(ssd, lat, 1, 2)
+    @test w isa Float64
+    @test w >= 0.0
+    @test w <= 1.0
+end


### PR DESCRIPTION
## Summary

- Implement `bond_weight(::SSD, lat, i, j)` with the canonical sine-square deformation envelope `f(r) = ∏_d sin²(π (c_d − 1/2) / L_d)`, evaluated at each endpoint from `size_trait(lat)` + `to_lattice(lat, RealSpace(position(lat, i)))`, and returned as the arithmetic mean of the two endpoint values.
- Implementation is BC-agnostic (any axis tuple in `LatticeBoundary`) but guards against non-finite size traits with `ArgumentError`. The `SSD.L` field is now informational; downstream packages may overload on a more specific lattice type to supply alternative scales.
- Update `docs/src/guide/boundary.md` and `docs/src/concepts/boundary_conditions.md` to drop the "stub" notes and describe the canonical envelope.
- Add `test/core/test_ssd.jl` with five testsets: 1D LineLattice envelope sanity / monotonicity / reflection / order independence; 2D SimpleSquareLattice per-site axis-product and corner-vs-bulk ordering; BC-agnostic equality of OBC vs PBC weights; FiniteSize guard; return-type sanity.

Closes #29

## Test plan

- [x] `julia --project -e 'using Pkg; Pkg.test()'` passes (1157 / 1157, including Aqua)
- [x] New `test_ssd.jl`: 102 / 102 passing
- [x] Existing `test_boundary_condition.jl` unchanged (35 / 35)