### PR TITLE
feat: generic tight-binding & spectral analysis layer on AbstractLattice

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.10.2"
+version = "0.11.0"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/Bond.jl
+++ b/src/Bond.jl
@@ -97,7 +97,7 @@ _iter_length(itr, ::Base.HasLength) = length(itr)
 _iter_length(itr, ::Base.HasShape) = length(itr)
 _iter_length(itr, ::Base.SizeUnknown) = count(_ -> true, itr)
 function _iter_length(itr, ::Base.IsInfinite)
-    throw(ArgumentError("cannot take length of infinite iterator"))
+    return throw(ArgumentError("cannot take length of infinite iterator"))
 end
 
 # elements -------------------------------------------------------------
@@ -122,7 +122,7 @@ function _nth(itr, i::Int)
         k += 1
         k == i && return x
     end
-    throw(BoundsError(itr, i))
+    return throw(BoundsError(itr, i))
 end
 
 # element_positions ----------------------------------------------------

--- a/src/Coordinate.jl
+++ b/src/Coordinate.jl
@@ -65,7 +65,7 @@ struct LatticeCoord{D} <: AbstractCoordinate{D}
 end
 
 function LatticeCoord(cell::NTuple{D,Int}, sublattice::Int=1) where {D}
-    LatticeCoord{D}(cell, sublattice)
+    return LatticeCoord{D}(cell, sublattice)
 end
 
 # ---- HigherDimCoord --------------------------------------------------

--- a/src/DynamicStructureFactor.jl
+++ b/src/DynamicStructureFactor.jl
@@ -1,0 +1,110 @@
+# Single-particle momentum-resolved spectral function A(k,ω), the dynamic
+# counterpart of the static `structure_factor`. Generic over `AbstractLattice`.
+
+"""
+    dynamic_structure_factor(lat::AbstractLattice,
+                             kpoints::AbstractVector{<:AbstractVector};
+                             t=1.0, onsite=0.0, omega=nothing, nomega=200,
+                             broadening=0.05) -> (omegas, A)
+
+Momentum-resolved single-particle spectral function of the tight-binding model
+on `lat`,
+
+```math
+A(k, ω) = \\sum_n |\\langle k | ψ_n \\rangle|^2 \\, δ(ω - E_n),
+\\qquad
+\\langle k | ψ_n \\rangle = \\tfrac{1}{\\sqrt N} \\sum_l e^{-i k · r_l} ψ_n(l),
+```
+
+evaluated at every k-vector in `kpoints`. Returns the shared `omegas` grid
+(length `nomega`) and a `length(kpoints) × nomega` matrix `A`. Each δ-peak is a
+normalized Gaussian of width `broadening`, so `sum(A[j, :]) * Δω ≈ 1` for every
+`j` (spectral-weight sum rule). On a periodic crystal `A(k,ω)` collapses onto
+the Bloch bands; on a quasicrystal it resolves the fragmented spectrum.
+
+See also [`structure_factor`](@ref), [`spectrum`](@ref).
+"""
+function dynamic_structure_factor(
+    lat::AbstractLattice,
+    kpoints::AbstractVector{<:AbstractVector};
+    t::Real=1.0,
+    onsite=0.0,
+    omega=nothing,
+    nomega::Int=200,
+    broadening::Real=0.05,
+)
+    nomega ≥ 1 || throw(ArgumentError("nomega must be ≥ 1, got $nomega"))
+    broadening > 0 || throw(ArgumentError("broadening must be > 0, got $broadening"))
+
+    E, V = eigenstates(lat; t=t, onsite=onsite)
+    N = length(E)
+    R = _positions_matrix(lat, N)
+
+    omegas = _omega_grid(omega, E, Float64(broadening), nomega)
+    σ = Float64(broadening)
+    gnorm = 1 / (σ * sqrt(2π))
+
+    nk = length(kpoints)
+    A = zeros(Float64, nk, length(omegas))
+    phase = Vector{ComplexF64}(undef, N)
+    @inbounds for j in 1:nk
+        k = kpoints[j]
+        for l in 1:N
+            kr = 0.0
+            for d in eachindex(k)
+                kr += k[d] * R[d, l]
+            end
+            phase[l] = cis(-kr)
+        end
+        for n in 1:N
+            c = zero(ComplexF64)
+            for l in 1:N
+                c += phase[l] * V[l, n]
+            end
+            w = abs2(c) / N
+            En = E[n]
+            for m in eachindex(omegas)
+                A[j, m] += w * gnorm * exp(-((omegas[m] - En)^2) / (2σ^2))
+            end
+        end
+    end
+    return omegas, A
+end
+
+"""
+    dynamic_structure_factor(lat::AbstractLattice, ml::AbstractMomentumLattice;
+                             kwargs...)
+
+Take the k-points from a momentum lattice (e.g. a `BraggPeakSet`), matching the
+grid used by the static [`structure_factor`](@ref).
+"""
+function dynamic_structure_factor(
+    lat::AbstractLattice, ml::AbstractMomentumLattice; kwargs...
+)
+    kpoints = [k_point(ml, j) for j in 1:num_k_points(ml)]
+    return dynamic_structure_factor(lat, kpoints; kwargs...)
+end
+
+function _omega_grid(omega, E::AbstractVector, σ::Float64, nomega::Int)
+    omega === nothing || return collect(Float64.(omega))
+    Emin, Emax = extrema(E)
+    if Emax ≈ Emin
+        Emin -= 0.5
+        Emax += 0.5
+    end
+    return collect(range(Emin - 3σ, Emax + 3σ; length=nomega))
+end
+
+_spatial_dim(::AbstractLattice{D}) where {D} = D
+
+function _positions_matrix(lat::AbstractLattice, N::Int)
+    D = _spatial_dim(lat)
+    R = Matrix{Float64}(undef, D, N)
+    @inbounds for l in 1:N
+        p = position(lat, l)
+        for d in 1:D
+            R[d, l] = Float64(p[d])
+        end
+    end
+    return R
+end

--- a/src/LatticeCore.jl
+++ b/src/LatticeCore.jl
@@ -1,6 +1,7 @@
 module LatticeCore
 
 using LinearAlgebra
+using SparseArrays
 using StaticArrays
 
 # We extend `Base.position` for `AbstractLattice` so downstream code can
@@ -22,6 +23,10 @@ include("MomentumLattice.jl")
 include("StructureFactor.jl")
 include("LazyInfinite.jl")
 include("Graph.jl")
+include("TightBinding.jl")
+include("Localization.jl")
+include("DynamicStructureFactor.jl")
+include("Regions.jl")
 include("Plot.jl")
 include("reference/LineLattice.jl")
 include("reference/SimpleSquareLattice.jl")
@@ -88,6 +93,15 @@ export materialize, require_finite
 
 # ---- Graph operations ----
 export adjacency_matrix, shortest_path, distance_matrix, connected_components
+
+# Tight-binding & spectral analysis (TightBinding.jl / Localization.jl)
+export tight_binding_hamiltonian, spectrum, eigenstates, density_of_states
+export inverse_participation_ratio, inverse_participation_ratios
+export mean_inverse_participation_ratio, ipr_scaling, ipr_scaling_exponent
+# Dynamic structure factor (DynamicStructureFactor.jl)
+export dynamic_structure_factor
+# Edge / bulk regions (Regions.jl)
+export edge_sites, bulk_sites, edge_bonds
 export identity_weight
 
 # ---- Plotting (methods live in LatticeCorePlotsExt) ----

--- a/src/Localization.jl
+++ b/src/Localization.jl
@@ -1,0 +1,87 @@
+# Localization diagnostics: finite-size scaling of the inverse participation
+# ratio, the standard numerical probe of Anderson / quasiperiodic
+# localization. Generic over `AbstractLattice`.
+
+"""
+    mean_inverse_participation_ratio(H::AbstractMatrix; energy_window=nothing)
+        -> Float64
+
+Mean [`inverse_participation_ratio`](@ref) over the eigenstates of the real
+symmetric Hamiltonian `H`. With `energy_window = (Emin, Emax)` only eigenstates
+in that closed interval are averaged (mobility-edge probe); an empty window is
+an error.
+"""
+function mean_inverse_participation_ratio(H::AbstractMatrix; energy_window=nothing)
+    F = eigen(Symmetric(Matrix(H)))
+    sel = _window_indices(F.values, energy_window)
+    s = 0.0
+    @inbounds for n in sel
+        s += inverse_participation_ratio(@view F.vectors[:, n])
+    end
+    return s / length(sel)
+end
+
+"""
+    mean_inverse_participation_ratio(lat::AbstractLattice; t=1.0, onsite=0.0,
+                                     energy_window=nothing) -> Float64
+
+Convenience method building the uniform-hopping / on-site-modulated
+tight-binding Hamiltonian of `lat` and returning its mean IPR. For
+bond-modulated models, build `H` with the per-bond
+[`tight_binding_hamiltonian`](@ref) and pass it to the matrix form.
+"""
+function mean_inverse_participation_ratio(
+    lat::AbstractLattice; t::Real=1.0, onsite=0.0, energy_window=nothing
+)
+    H = tight_binding_hamiltonian(lat; t=t, onsite=onsite)
+    return mean_inverse_participation_ratio(H; energy_window=energy_window)
+end
+
+_window_indices(vals::AbstractVector, ::Nothing) = eachindex(vals)
+function _window_indices(vals::AbstractVector, window)
+    lo, hi = window
+    sel = findall(e -> lo ≤ e ≤ hi, vals)
+    isempty(sel) && throw(ArgumentError("no eigenstates in energy_window $((lo, hi))"))
+    return sel
+end
+
+"""
+    ipr_scaling(lats; t=1.0, onsite=0.0, energy_window=nothing)
+        -> (sizes::Vector{Int}, mean_iprs::Vector{Float64})
+
+Mean IPR of each lattice in the size-ordered collection `lats` (uniform-hopping
+model), paired with `num_sites`. Feed to [`ipr_scaling_exponent`](@ref) for the
+localization exponent `τ`.
+"""
+function ipr_scaling(lats; t::Real=1.0, onsite=0.0, energy_window=nothing)
+    sizes = Int[num_sites(l) for l in lats]
+    mis = Float64[
+        mean_inverse_participation_ratio(
+            l; t=t, onsite=onsite, energy_window=energy_window
+        ) for l in lats
+    ]
+    return sizes, mis
+end
+
+"""
+    ipr_scaling_exponent(sizes, mean_iprs) -> Float64
+
+Localization exponent `τ` from a least-squares fit of
+`log(mean_iprs) = a - τ · log(sizes)`: `τ ≈ 1` (extended), `τ ≈ 0` (localized),
+`0 < τ < 1` (critical / multifractal). Needs ≥ 2 positive points.
+"""
+function ipr_scaling_exponent(sizes, mean_iprs)
+    length(sizes) == length(mean_iprs) ||
+        throw(DimensionMismatch("sizes and mean_iprs have different lengths"))
+    n = length(sizes)
+    n ≥ 2 || throw(ArgumentError("need at least two size points, got $n"))
+    all(>(0), mean_iprs) ||
+        throw(ArgumentError("all mean_iprs must be positive to take a log"))
+    x = log.(float.(collect(sizes)))
+    y = log.(float.(collect(mean_iprs)))
+    x̄ = sum(x) / n
+    ȳ = sum(y) / n
+    sxx = sum((xi - x̄)^2 for xi in x)
+    sxy = sum((x[i] - x̄) * (y[i] - ȳ) for i in 1:n)
+    return -(sxy / sxx)
+end

--- a/src/MomentumLattice.jl
+++ b/src/MomentumLattice.jl
@@ -161,7 +161,7 @@ The returned object is expected to satisfy the
 is [`PeriodicMomentumLattice`](@ref).
 """
 function reciprocal_lattice(lat::AbstractLattice)
-    throw(MethodError(reciprocal_lattice, (lat,)))
+    return throw(MethodError(reciprocal_lattice, (lat,)))
 end
 
 """
@@ -189,7 +189,7 @@ The returned object is expected to be an
 treat periodic and quasiperiodic lattices uniformly.
 """
 function fourier_module(lat::AbstractLattice)
-    throw(MethodError(fourier_module, (lat,)))
+    return throw(MethodError(fourier_module, (lat,)))
 end
 
 """
@@ -203,7 +203,7 @@ momentum_lattice(lat::AbstractLattice) = _momentum_lattice(lat, reciprocal_suppo
 _momentum_lattice(lat, ::HasReciprocal) = reciprocal_lattice(lat)
 _momentum_lattice(lat, ::HasFourierModule) = fourier_module(lat)
 function _momentum_lattice(lat, ::NoReciprocal)
-    throw(ArgumentError("$(typeof(lat)) has no k-space representation"))
+    return throw(ArgumentError("$(typeof(lat)) has no k-space representation"))
 end
 
 # ---- Quasicrystal hooks (type skeletons only) ------------------------

--- a/src/Regions.jl
+++ b/src/Regions.jl
@@ -1,0 +1,82 @@
+# Edge / bulk partition of a lattice, from the declared connectivity alone
+# (no geometric thresholds). Generic over `AbstractLattice`. Supports
+# symmetry-protected-topological analyses that need an explicit edge/bulk split.
+
+# Under-coordinated boundary sites: coordination below the bulk coordination of
+# their own sublattice (so a low-coordination *bulk* site on e.g. a Lieb/dice
+# lattice is not mistaken for an edge site). A fully periodic sample has none.
+function _boundary_sites(lat::AbstractLattice)
+    N = num_sites(lat)
+    N == 0 && return Int[]
+    deg = [length(neighbors(lat, i)) for i in 1:N]
+    bulk_deg = Dict{Int,Int}()
+    @inbounds for i in 1:N
+        s = sublattice(lat, i)
+        bulk_deg[s] = haskey(bulk_deg, s) ? max(bulk_deg[s], deg[i]) : deg[i]
+    end
+    return [i for i in 1:N if deg[i] < bulk_deg[sublattice(lat, i)]]
+end
+
+"""
+    edge_sites(lat::AbstractLattice; depth::Int=1) -> Vector{Int}
+
+Sorted site indices of the **edge** region: sites within graph distance
+`depth - 1` of an under-coordinated boundary site (coordination below the bulk
+coordination of its sublattice). `depth = 1` is the boundary ring; each
+increment peels one more layer inward. A fully periodic sample has an empty
+edge. `depth ≥ 1`.
+
+See also [`bulk_sites`](@ref), [`edge_bonds`](@ref).
+"""
+function edge_sites(lat::AbstractLattice; depth::Int=1)
+    depth ≥ 1 || throw(ArgumentError("depth must be ≥ 1, got $depth"))
+    N = num_sites(lat)
+    N == 0 && return Int[]
+    ring = _boundary_sites(lat)
+    isempty(ring) && return Int[]
+    dist = fill(-1, N)
+    queue = Int[]
+    for i in ring
+        dist[i] = 0
+        push!(queue, i)
+    end
+    head = 1
+    while head ≤ length(queue)
+        u = queue[head]
+        head += 1
+        dist[u] == depth - 1 && continue
+        for v in neighbors(lat, u)
+            if dist[v] == -1
+                dist[v] = dist[u] + 1
+                push!(queue, v)
+            end
+        end
+    end
+    return findall(d -> 0 ≤ d ≤ depth - 1, dist)
+end
+
+"""
+    bulk_sites(lat::AbstractLattice; depth::Int=1) -> Vector{Int}
+
+Sorted site indices in the **bulk** region — the complement of
+[`edge_sites`](@ref)`(lat; depth)`. On a fully periodic sample this is every
+site. `depth ≥ 1`.
+"""
+function bulk_sites(lat::AbstractLattice; depth::Int=1)
+    edge = Set(edge_sites(lat; depth=depth))
+    return [i for i in 1:num_sites(lat) if i ∉ edge]
+end
+
+"""
+    edge_bonds(lat::AbstractLattice; depth::Int=1) -> Vector{Bond}
+
+Bonds incident to at least one edge site (see [`edge_sites`](@ref)) — the bonds
+touching the boundary region. Empty on a fully periodic sample. `depth ≥ 1`.
+"""
+function edge_bonds(lat::AbstractLattice; depth::Int=1)
+    edge = Set(edge_sites(lat; depth=depth))
+    isempty(edge) && return Bond{_spatial_dim(lat),_position_eltype(lat)}[]
+    return [b for b in collect(bonds(lat)) if b.i ∈ edge || b.j ∈ edge]
+end
+
+_position_eltype(lat::AbstractLattice{D,T}) where {D,T} = T

--- a/src/StructureFactor.jl
+++ b/src/StructureFactor.jl
@@ -125,7 +125,7 @@ Default: throws — concrete lattices that opt into
 provide a method here.
 """
 function _reshape_state(lat::AbstractLattice, state, dims)
-    error(
+    return error(
         "LatticeCore._reshape_state not defined for $(typeof(lat)); ",
         "opt in by defining `LatticeCore._reshape_state(::MyLattice, state, dims)` ",
         "alongside `LatticeCore._has_known_grid(::MyLattice) = true`.",

--- a/src/TightBinding.jl
+++ b/src/TightBinding.jl
@@ -1,0 +1,176 @@
+# Single-particle tight-binding models and spectral tools on any
+# `AbstractLattice`. These are pure functions of the declared connectivity /
+# geometry (via `adjacency_matrix`, `bonds`, `position`), so every concrete
+# lattice — periodic (`Lattice2D`) or aperiodic (`QuasiCrystal`) — gets them.
+
+"""
+    tight_binding_hamiltonian(lat::AbstractLattice; t=1.0, onsite=0.0)
+        -> SparseMatrixCSC{Float64,Int}
+
+Real symmetric single-particle tight-binding Hamiltonian of `lat` with uniform
+hopping `t` on every nearest-neighbour bond,
+
+```math
+H = \\mathrm{diag}(ε) - t \\, A,
+```
+
+where `A` is the [`adjacency_matrix`](@ref). `onsite` is a scalar on-site
+energy or a length-`num_sites(lat)` vector. Requires a finite lattice.
+
+See also [`spectrum`](@ref), [`inverse_participation_ratio`](@ref),
+[`density_of_states`](@ref).
+"""
+function tight_binding_hamiltonian(lat::AbstractLattice; t::Real=1.0, onsite=0.0)
+    N = num_sites(lat)
+    H = (-float(t)) .* adjacency_matrix(lat; sparse=true)
+    ov = _onsite_vector(onsite, N)
+    if any(!iszero, ov)
+        H = H + spdiagm(0 => ov)
+    end
+    return H
+end
+
+"""
+    tight_binding_hamiltonian(lat::AbstractLattice, hoppings::AbstractVector;
+                              onsite=0.0) -> SparseMatrixCSC{Float64,Int}
+
+Per-bond hopping variant: `hoppings[k]` is the amplitude on the `k`-th bond of
+`collect(bonds(lat))`. Use this for bond-modulated models (e.g. a Fibonacci
+`tL`/`tS` chain). `length(hoppings)` must equal the number of bonds.
+"""
+function tight_binding_hamiltonian(
+    lat::AbstractLattice, hoppings::AbstractVector; onsite=0.0
+)
+    bs = collect(bonds(lat))
+    length(hoppings) == length(bs) || throw(
+        DimensionMismatch(
+            "hoppings has length $(length(hoppings)) but lattice has $(length(bs)) bonds",
+        ),
+    )
+    N = num_sites(lat)
+    Is = Int[]
+    Js = Int[]
+    Vs = Float64[]
+    sizehint!(Is, 2 * length(bs) + N)
+    sizehint!(Js, 2 * length(bs) + N)
+    sizehint!(Vs, 2 * length(bs) + N)
+    @inbounds for k in eachindex(bs)
+        b = bs[k]
+        tij = -float(hoppings[k])
+        push!(Is, b.i);
+        push!(Js, b.j);
+        push!(Vs, tij)
+        push!(Is, b.j);
+        push!(Js, b.i);
+        push!(Vs, tij)
+    end
+    ov = _onsite_vector(onsite, N)
+    @inbounds for i in 1:N
+        ov[i] != 0 && (push!(Is, i); push!(Js, i); push!(Vs, ov[i]))
+    end
+    return sparse(Is, Js, Vs, N, N)
+end
+
+_onsite_vector(onsite::Real, N::Int) = fill(Float64(onsite), N)
+function _onsite_vector(onsite::AbstractVector, N::Int)
+    length(onsite) == N ||
+        throw(DimensionMismatch("onsite vector has length $(length(onsite)), expected $N"))
+    return Float64.(onsite)
+end
+
+"""
+    spectrum(lat::AbstractLattice; t=1.0, onsite=0.0) -> Vector{Float64}
+
+Sorted eigenvalues of the tight-binding Hamiltonian of `lat`.
+"""
+function spectrum(lat::AbstractLattice; t::Real=1.0, onsite=0.0)
+    return eigvals(Symmetric(Matrix(tight_binding_hamiltonian(lat; t=t, onsite=onsite))))
+end
+
+"""
+    eigenstates(lat::AbstractLattice; t=1.0, onsite=0.0)
+        -> (values::Vector{Float64}, vectors::Matrix{Float64})
+
+Full eigendecomposition of the tight-binding Hamiltonian: `values` ascending,
+`vectors[:, n]` the eigenvector for `values[n]`.
+"""
+function eigenstates(lat::AbstractLattice; t::Real=1.0, onsite=0.0)
+    F = eigen(Symmetric(Matrix(tight_binding_hamiltonian(lat; t=t, onsite=onsite))))
+    return F.values, F.vectors
+end
+
+"""
+    inverse_participation_ratio(ψ::AbstractVector) -> Float64
+
+Inverse participation ratio `Σ|ψ_i|⁴ / (Σ|ψ_i|²)²` of a single state. Ranges in
+`[1/N, 1]`: `1/N` for a fully extended state, `1` for a state on one site; the
+participation number `1/IPR` estimates how many sites it occupies.
+"""
+function inverse_participation_ratio(ψ::AbstractVector)
+    n2 = zero(real(eltype(ψ)))
+    n4 = zero(real(eltype(ψ)))
+    @inbounds for a in ψ
+        p = abs2(a)
+        n2 += p
+        n4 += p * p
+    end
+    n2 == 0 && throw(ArgumentError("inverse_participation_ratio of the zero vector"))
+    return n4 / (n2 * n2)
+end
+
+"""
+    inverse_participation_ratios(lat::AbstractLattice; t=1.0, onsite=0.0)
+        -> (energies::Vector{Float64}, iprs::Vector{Float64})
+
+Per-eigenstate IPR of the tight-binding spectrum of `lat`, with energies.
+"""
+function inverse_participation_ratios(lat::AbstractLattice; t::Real=1.0, onsite=0.0)
+    vals, vecs = eigenstates(lat; t=t, onsite=onsite)
+    iprs = [inverse_participation_ratio(@view vecs[:, n]) for n in axes(vecs, 2)]
+    return vals, iprs
+end
+
+"""
+    density_of_states(lat::AbstractLattice; t=1.0, onsite=0.0, nbins=100,
+                      broadening=0.0) -> (centers, dos)
+
+Density of states of the tight-binding spectrum, normalized so that
+`sum(dos) * step ≈ num_sites(lat)`. `broadening = 0` gives a histogram over
+`nbins` bins; `broadening = σ > 0` smears each level by a Gaussian of width `σ`.
+"""
+function density_of_states(
+    lat::AbstractLattice; t::Real=1.0, onsite=0.0, nbins::Int=100, broadening::Real=0.0
+)
+    nbins ≥ 1 || throw(ArgumentError("nbins must be ≥ 1, got $nbins"))
+    E = spectrum(lat; t=t, onsite=onsite)
+    return _density_of_states(E, nbins, Float64(broadening))
+end
+
+function _density_of_states(E::AbstractVector, nbins::Int, σ::Float64)
+    Emin, Emax = extrema(E)
+    if Emax ≈ Emin
+        Emin -= 0.5
+        Emax += 0.5
+    end
+    if σ > 0
+        Emin -= 3σ
+        Emax += 3σ
+    end
+    edges = range(Emin, Emax; length=nbins + 1)
+    dE = step(edges)
+    centers = collect(edges[1:(end - 1)] .+ dE / 2)
+    dos = zeros(Float64, nbins)
+    if σ > 0
+        norm = 1 / (σ * sqrt(2π))
+        @inbounds for e in E, b in 1:nbins
+            dos[b] += norm * exp(-((centers[b] - e)^2) / (2σ^2))
+        end
+    else
+        @inbounds for e in E
+            b = clamp(floor(Int, (e - Emin) / dE) + 1, 1, nbins)
+            dos[b] += 1
+        end
+        dos ./= dE
+    end
+    return centers, dos
+end

--- a/src/reference/SimpleSquareLattice.jl
+++ b/src/reference/SimpleSquareLattice.jl
@@ -199,7 +199,7 @@ Real-space basis matrix. For the unit-spacing reference square this
 is the 2×2 identity.
 """
 function basis_vectors(::SimpleSquareLattice{T}) where {T}
-    SMatrix{2,2,T}(one(T), zero(T), zero(T), one(T))
+    return SMatrix{2,2,T}(one(T), zero(T), zero(T), one(T))
 end
 
 function reciprocal_lattice(lat::SimpleSquareLattice{T}) where {T}

--- a/test/core/test_analysis.jl
+++ b/test/core/test_analysis.jl
@@ -1,0 +1,125 @@
+using LatticeCore
+using LinearAlgebra
+using SparseArrays
+using Test
+
+# A 1D open chain: its NN graph is a path, so uniform-hopping tight binding
+# has the exact particle-in-a-box spectrum -2t·cos(kπ/(N+1)).
+chain(N) = LineLattice(N, OpenAxis())
+
+@testset "analysis layer (tight-binding / localization / dynamic SF / regions)" begin
+    @testset "tight_binding_hamiltonian reuses adjacency_matrix" begin
+        lat = chain(12)
+        N = num_sites(lat)
+        nb = length(collect(bonds(lat)))
+        @test nb == N - 1
+        t = 1.3
+        H = tight_binding_hamiltonian(lat; t=t)
+        # exactly -t on adjacency entries, symmetric, zero diagonal
+        @test H ≈ -t .* adjacency_matrix(lat)
+        @test issymmetric(Matrix(H))
+        @test all(iszero, diag(Matrix(H)))
+        @test nnz(H) == 2nb
+        @test tr(Matrix(H)^2) ≈ 2nb * t^2 rtol = 1e-12
+    end
+
+    @testset "path-graph closed-form spectrum" begin
+        for N in (13, 21)
+            lat = chain(N)
+            t = 0.9
+            E = spectrum(lat; t=t)
+            exact = sort([-2t * cos(k * π / (N + 1)) for k in 1:N])
+            @test E ≈ exact rtol = 1e-10
+            @test E ≈ -reverse(E) rtol = 1e-10          # bipartite symmetry
+        end
+    end
+
+    @testset "on-site shift + per-bond hoppings" begin
+        lat = chain(10)
+        N = num_sites(lat)
+        nb = N - 1
+        @test spectrum(lat; onsite=0.7) ≈ spectrum(lat) .+ 0.7 rtol = 1e-10
+        @test Matrix(tight_binding_hamiltonian(lat, fill(2.0, nb))) ==
+            Matrix(tight_binding_hamiltonian(lat; t=2.0))
+        @test_throws DimensionMismatch tight_binding_hamiltonian(lat, fill(1.0, nb + 1))
+    end
+
+    @testset "inverse participation ratio" begin
+        n = 40
+        @test inverse_participation_ratio(fill(1 / sqrt(n), n)) ≈ 1 / n rtol = 1e-12
+        e1 = zeros(n);
+        e1[3] = 1.0
+        @test inverse_participation_ratio(e1) == 1.0
+        s = zeros(n);
+        s[1:5] .= 1 / sqrt(5)
+        @test inverse_participation_ratio(s) ≈ 1 / 5 rtol = 1e-12
+        @test_throws ArgumentError inverse_participation_ratio(zeros(n))
+    end
+
+    @testset "density of states integrates to N" begin
+        lat = chain(21)
+        N = num_sites(lat)
+        centers, dos = density_of_states(lat; nbins=40)
+        @test sum(dos) * (centers[2] - centers[1]) ≈ N rtol = 1e-10
+        c2, d2 = density_of_states(lat; nbins=200, broadening=0.05)
+        @test sum(d2) * (c2[2] - c2[1]) ≈ N rtol = 5e-2
+        @test_throws ArgumentError density_of_states(lat; nbins=0)
+    end
+
+    @testset "IPR scaling exponent (extended vs localized)" begin
+        Ns = [20, 40, 80, 160, 320]
+        @test ipr_scaling_exponent(Ns, [3.0 * n^(-0.7) for n in Ns]) ≈ 0.7 rtol = 1e-10
+        @test_throws ArgumentError ipr_scaling_exponent([10], [0.1])
+        # extended chain: mean IPR ~ 1/N  ⇒  τ ≈ 1
+        chains = [chain(n) for n in (30, 60, 120, 240)]
+        s, m = ipr_scaling(chains)
+        @test ipr_scaling_exponent(s, m) > 0.9
+    end
+
+    @testset "dynamic structure factor A(k,ω): sum rule + first moment" begin
+        lat = chain(21)
+        N = num_sites(lat)
+        t = 1.0
+        kpts = [[0.0], [0.5], [1.0], [Float64(π)]]
+        omegas, A = dynamic_structure_factor(lat, kpts; t=t, nomega=600, broadening=0.03)
+        dω = omegas[2] - omegas[1]
+        @test all(A .≥ 0)
+        bs = collect(bonds(lat))
+        for (j, k) in enumerate(kpts)
+            @test sum(@view A[j, :]) * dω ≈ 1.0 rtol = 1e-3     # ∫A dω = ⟨k|k⟩ = 1
+            m1 = sum(omegas[m] * A[j, m] for m in eachindex(omegas)) * dω
+            exact =
+                -2t / N *
+                sum(cos(sum(k[d] * b.vector[d] for d in eachindex(k))) for b in bs)
+            @test m1 ≈ exact atol = 2e-3                        # ∫ω A dω = ⟨k|H|k⟩
+        end
+    end
+
+    @testset "2D SimpleSquareLattice tight-binding invariants" begin
+        lat = SimpleSquareLattice(5, 5)
+        N = num_sites(lat)
+        nb = length(collect(bonds(lat)))
+        t = 1.0
+        E = eigvals(Symmetric(Matrix(tight_binding_hamiltonian(lat; t=t))))
+        @test sum(E) ≈ 0 atol = 1e-9
+        @test sum(abs2, E) ≈ 2nb * t^2 rtol = 1e-10
+        maxdeg = maximum(length(neighbors(lat, i)) for i in 1:N)
+        @test maximum(abs, E) ≤ t * maxdeg + 1e-9
+    end
+
+    @testset "edge / bulk regions" begin
+        lat = chain(10)                       # open ends are the edge
+        @test edge_sites(lat) == [1, 10]
+        @test edge_sites(lat; depth=2) == [1, 2, 9, 10]
+        @test bulk_sites(lat) == collect(2:9)
+        eb = edge_bonds(lat)
+        @test length(eb) == 2                 # bonds (1-2) and (9-10)
+        @test all(b.i ∈ (1, 10) || b.j ∈ (1, 10) for b in eb)
+        @test_throws ArgumentError edge_sites(lat; depth=0)
+        # periodic chain has no under-coordinated sites
+        per = LineLattice(10, PeriodicAxis())
+        @test isempty(edge_sites(per))
+        @test bulk_sites(per) == collect(1:10)
+        @test isempty(edge_bonds(per))
+    end
+end

--- a/test/core/test_lazy_infinite.jl
+++ b/test/core/test_lazy_infinite.jl
@@ -21,7 +21,7 @@ LatticeCore.site_layout(::_InfiniteChain) = UniformLayout(IsingSite())
 struct _InfiniteChainAbstract end
 
 function LatticeCore.materialize(::_InfiniteChainAbstract; depth::Int)
-    LineLattice(depth, PeriodicAxis())
+    return LineLattice(depth, PeriodicAxis())
 end
 
 @testset "LazyInfinite" begin

--- a/test/core/test_plaquette.jl
+++ b/test/core/test_plaquette.jl
@@ -10,7 +10,7 @@ struct TinySquareLattice <: AbstractLattice{2,Float64} end
 
 LatticeCore.num_sites(::TinySquareLattice) = 4
 function LatticeCore.position(::TinySquareLattice, i::Int)
-    (
+    return (
         if (i == 1)
             SVector(0.0, 0.0)
         elseif (i == 2)
@@ -38,7 +38,7 @@ LatticeCore.size_trait(::TinySquareLattice) = FiniteSize((2, 2))
 
 # One square plaquette covering all four sites, cyclic order 1→2→4→3.
 function LatticeCore.plaquettes(::TinySquareLattice)
-    (Plaquette{2,Float64}([1, 2, 4, 3], SVector(0.5, 0.5), :square),)
+    return (Plaquette{2,Float64}([1, 2, 4, 3], SVector(0.5, 0.5), :square),)
 end
 
 @testset "PlaquetteRule and Plaquette types" begin


### PR DESCRIPTION
## Summary
Hoists the single-particle **electronic-structure toolkit** up to LatticeCore so **every `AbstractLattice`** — periodic (`Lattice2D`) or aperiodic (`QuasiCrystal`) — gets it, instead of it living (and being duplicated) in the leaf packages.

This is the architecturally-correct home: LatticeCore already hosts the generic `structure_factor`, `adjacency_matrix`, `connected_components` on `AbstractLattice` and already depends on LinearAlgebra + SparseArrays. **No new dependencies.**

## New generic API (dispatch on `AbstractLattice`)
- `tight_binding_hamiltonian(lat; t, onsite)` + per-bond method — the uniform form is exactly **`-t · adjacency_matrix(lat)`** + on-site diagonal, i.e. it **reuses the existing graph primitive** rather than re-assembling the bond loop
- `spectrum`, `eigenstates`, `density_of_states`
- `inverse_participation_ratio(ψ)`, `inverse_participation_ratios`, `mean_inverse_participation_ratio`, `ipr_scaling`, `ipr_scaling_exponent`
- `dynamic_structure_factor(lat, kpoints | ml)` — the **dynamic counterpart** of the static `structure_factor` already hosted here
- `edge_sites` / `bulk_sites` / `edge_bonds` — connectivity-based edge/bulk split

## Verification (44/44)
Independent answers against reference lattices: the 1D open chain is a path graph, so uniform TB reproduces the exact **`−2t·cos(kπ/(N+1))`** spectrum; `H == −t·adjacency_matrix`; `Tr H² = 2·nb·t²`; IPR limits (`1/N`, `1`, `1/m`); DOS integrates to `N`; `A(k,ω)` **sum rule** `∫A dω = 1` and **first moment** `⟨k|H|k⟩`; 2D square Gershgorin/trace invariants; edge/bulk on open vs periodic chains.

`Aqua` undefined-exports / piracies / stale-deps clean; JuliaFormatter (Blue). Version `0.10.2 → 0.11.0`.

## Follow-ups (separate PRs, gated on this release)
- **QuasiCrystal**: delete `src/analysis/{tight_binding,localization,dynamic_structure_factor}.jl`, re-export these from LatticeCore, keep the FINUFFT `_structure_factor_fast` override (which already assumed this home).
- **Lattice2D**: delete `src/api/regions.jl`, re-export `edge_sites`/`bulk_sites`/`edge_bonds`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)