### PR TITLE
Add a scaling trait: rescale / size_sequence / cell_partition

### DIFF
--- a/Manifest.toml
+++ b/Manifest.toml
@@ -1,0 +1,124 @@
+# This file is machine-generated - editing it directly is not advised
+
+julia_version = "1.12.2"
+manifest_format = "2.0"
+project_hash = "463e3356a9794da7b6cd1042f90d1b4c14f5fbed"
+
+[[deps.Artifacts]]
+uuid = "56f22d72-fd6d-98f1-02f0-08ddc0907c33"
+version = "1.11.0"
+
+[[deps.CompilerSupportLibraries_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "e66e0078-7015-5450-92f7-15fbd957f2ae"
+version = "1.3.0+1"
+
+[[deps.Dates]]
+deps = ["Printf"]
+uuid = "ade2ca70-3891-5945-98fb-dc099432e06a"
+version = "1.11.0"
+
+[[deps.LatticeCore]]
+deps = ["LinearAlgebra", "SparseArrays", "StaticArrays"]
+path = "."
+uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
+version = "0.12.1"
+
+    [deps.LatticeCore.extensions]
+    LatticeCoreFFTWExt = "FFTW"
+    LatticeCoreMakieExt = "Makie"
+    LatticeCoreNFFTExt = "NFFT"
+    LatticeCorePlotsExt = "Plots"
+
+    [deps.LatticeCore.weakdeps]
+    FFTW = "7a1cc6ca-52ef-59f5-83cd-3a7055c09341"
+    Makie = "ee78f7c6-11fb-53f2-987a-cfe4a2b5a57a"
+    NFFT = "efe261a4-0d2b-5849-be55-fc731d526b0d"
+    Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
+
+[[deps.Libdl]]
+uuid = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
+version = "1.11.0"
+
+[[deps.LinearAlgebra]]
+deps = ["Libdl", "OpenBLAS_jll", "libblastrampoline_jll"]
+uuid = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+version = "1.12.0"
+
+[[deps.OpenBLAS_jll]]
+deps = ["Artifacts", "CompilerSupportLibraries_jll", "Libdl"]
+uuid = "4536629a-c528-5b80-bd46-f80d51c5b363"
+version = "0.3.29+0"
+
+[[deps.PrecompileTools]]
+deps = ["Preferences"]
+git-tree-sha1 = "edbeefc7a4889f528644251bdb5fc9ab5348bc2c"
+uuid = "aea7be01-6a6a-4083-8856-8a6e6704d82a"
+version = "1.3.4"
+
+[[deps.Preferences]]
+deps = ["TOML"]
+git-tree-sha1 = "8b770b60760d4451834fe79dd483e318eee709c4"
+uuid = "21216c6a-2e73-6563-6e65-726566657250"
+version = "1.5.2"
+
+[[deps.Printf]]
+deps = ["Unicode"]
+uuid = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+version = "1.11.0"
+
+[[deps.Random]]
+deps = ["SHA"]
+uuid = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
+version = "1.11.0"
+
+[[deps.SHA]]
+uuid = "ea8e919c-243c-51af-8825-aaa63cd721ce"
+version = "0.7.0"
+
+[[deps.Serialization]]
+uuid = "9e88b42a-f829-5b0c-bbe9-9e923198166b"
+version = "1.11.0"
+
+[[deps.SparseArrays]]
+deps = ["Libdl", "LinearAlgebra", "Random", "Serialization", "SuiteSparse_jll"]
+uuid = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
+version = "1.12.0"
+
+[[deps.StaticArrays]]
+deps = ["LinearAlgebra", "PrecompileTools", "Random", "StaticArraysCore"]
+git-tree-sha1 = "246a8bb2e6667f832eea063c3a56aef96429a3db"
+uuid = "90137ffa-7385-5640-81b9-e52037218182"
+version = "1.9.18"
+
+    [deps.StaticArrays.extensions]
+    StaticArraysChainRulesCoreExt = "ChainRulesCore"
+    StaticArraysStatisticsExt = "Statistics"
+
+    [deps.StaticArrays.weakdeps]
+    ChainRulesCore = "d360d2e6-b24c-11e9-a2a3-2a2ae2dbcce4"
+    Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
+
+[[deps.StaticArraysCore]]
+git-tree-sha1 = "6ab403037779dae8c514bad259f32a447262455a"
+uuid = "1e83bf80-4336-4d27-bf5d-d5a4f845583c"
+version = "1.4.4"
+
+[[deps.SuiteSparse_jll]]
+deps = ["Artifacts", "Libdl", "libblastrampoline_jll"]
+uuid = "bea87d4a-7f5b-5778-9afe-8cc45184846c"
+version = "7.8.3+2"
+
+[[deps.TOML]]
+deps = ["Dates"]
+uuid = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
+version = "1.0.3"
+
+[[deps.Unicode]]
+uuid = "4ec0a83e-493e-50e2-b9ac-8f72acf5a8f5"
+version = "1.11.0"
+
+[[deps.libblastrampoline_jll]]
+deps = ["Artifacts", "Libdl"]
+uuid = "8e850b90-86db-534c-a0d3-1478176c7d93"
+version = "5.15.0+0"

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.12.0"
+version = "0.12.1"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/LatticeCore.jl
+++ b/src/LatticeCore.jl
@@ -22,6 +22,7 @@ include("Indexing.jl")
 include("MomentumLattice.jl")
 include("StructureFactor.jl")
 include("LazyInfinite.jl")
+include("Scaling.jl")
 include("Graph.jl")
 include("TightBinding.jl")
 include("Localization.jl")
@@ -90,6 +91,10 @@ export AcceptanceWindow, HyperReciprocalLattice, BraggPeakSet
 
 # ---- Lazy / infinite ----
 export materialize, require_finite
+
+# ---- Scale changes ----
+export AbstractScalingRule, NoScaling, LinearScaling, SubstitutionScaling
+export scaling_rule, rescale, size_sequence, cell_partition
 
 # ---- Graph operations ----
 export adjacency_matrix, shortest_path, distance_matrix, connected_components

--- a/src/Scaling.jl
+++ b/src/Scaling.jl
@@ -1,0 +1,81 @@
+# Scale changes: generating a size sequence of lattices of the same family.
+#
+# Trait types live in `Traits.jl`; this file holds the accessors and the generic
+# fallbacks. Concrete lattice packages provide `rescale` / `cell_partition`.
+
+"""
+    scaling_rule(lat::AbstractLattice) -> AbstractScalingRule
+
+How this lattice family changes scale. Defaults to [`NoScaling`](@ref), i.e. the
+lattice offers no canonical size sequence and [`rescale`](@ref) is unavailable.
+
+A Bravais-like lattice normally reports [`LinearScaling`](@ref) — its per-axis
+cell counts simply multiply. An aperiodic lattice normally reports
+[`SubstitutionScaling`](@ref), where the natural sequence of sizes is generated
+by its substitution rule rather than by an integer side length (Fibonacci
+lengths, Penrose inflation radii, …), so "the next size up" is a well defined
+notion even though there is no `L` to double.
+
+See also [`rescale`](@ref), [`size_sequence`](@ref), [`cell_partition`](@ref).
+"""
+scaling_rule(::AbstractLattice) = NoScaling()
+
+"""
+    rescale(lat::AbstractLattice, k::Integer = 1) -> AbstractLattice
+
+The same lattice `k` scale steps larger, in the sense of [`scaling_rule`](@ref).
+`k = 0` returns a lattice equivalent to `lat`; negative `k` steps down where the
+family supports it.
+
+For [`LinearScaling`](@ref)`(f)` one step multiplies every per-axis cell count by
+`f`. For [`SubstitutionScaling`](@ref)`(d)` one step advances the substitution
+depth by `d`. The point of the common verb is that a routine which studies how
+some quantity behaves as the system grows can be written once and applied to
+periodic and aperiodic lattices alike, instead of threading `(Lx, Ly)` through
+code that a quasicrystal cannot supply.
+
+Concrete lattice packages implement this; there is no meaningful generic
+fallback, so the default throws.
+"""
+function rescale(lat::AbstractLattice, k::Integer = 1)
+    return throw(ArgumentError(
+        "rescale is not implemented for $(typeof(lat)) (scaling_rule = $(scaling_rule(lat))). " *
+        "A lattice family must define `rescale(lat, k)` to take part in size sequences."
+    ))
+end
+
+"""
+    size_sequence(lat::AbstractLattice, n::Integer) -> Vector{<:AbstractLattice}
+
+`[rescale(lat, k) for k in 0:n]` — the lattice at successive scales, for
+sweeping a quantity against system size without hard-coding how the family is
+parameterized.
+
+```julia
+for l in size_sequence(lat, 4)
+    push!(xs, num_sites(l))
+    push!(ys, measure_something(l))
+end
+```
+"""
+size_sequence(lat::AbstractLattice, n::Integer) = [rescale(lat, k) for k in 0:n]
+
+"""
+    cell_partition(lat::AbstractLattice, k::Integer = 1) -> Vector{Vector{Int}}
+
+Group the sites of `lat` by which cell of `rescale(lat, k)` they fall into: entry
+`c` lists the site indices of `lat` belonging to cell `c` of the larger-scale
+lattice. Together the groups partition `1:num_sites(lat)`.
+
+Useful whenever a quantity defined per site has to be compared across scales —
+cell averages of a local observable, cell-resolved densities, or transferring a
+configuration between two members of a [`size_sequence`](@ref).
+
+Concrete lattice packages implement this; the default throws.
+"""
+function cell_partition(lat::AbstractLattice, k::Integer = 1)
+    return throw(ArgumentError(
+        "cell_partition is not implemented for $(typeof(lat)) " *
+        "(scaling_rule = $(scaling_rule(lat)))."
+    ))
+end

--- a/src/Scaling.jl
+++ b/src/Scaling.jl
@@ -37,11 +37,13 @@ code that a quasicrystal cannot supply.
 Concrete lattice packages implement this; there is no meaningful generic
 fallback, so the default throws.
 """
-function rescale(lat::AbstractLattice, k::Integer = 1)
-    return throw(ArgumentError(
-        "rescale is not implemented for $(typeof(lat)) (scaling_rule = $(scaling_rule(lat))). " *
-        "A lattice family must define `rescale(lat, k)` to take part in size sequences."
-    ))
+function rescale(lat::AbstractLattice, k::Integer=1)
+    return throw(
+        ArgumentError(
+            "rescale is not implemented for $(typeof(lat)) (scaling_rule = $(scaling_rule(lat))). " *
+            "A lattice family must define `rescale(lat, k)` to take part in size sequences.",
+        ),
+    )
 end
 
 """
@@ -73,9 +75,11 @@ configuration between two members of a [`size_sequence`](@ref).
 
 Concrete lattice packages implement this; the default throws.
 """
-function cell_partition(lat::AbstractLattice, k::Integer = 1)
-    return throw(ArgumentError(
-        "cell_partition is not implemented for $(typeof(lat)) " *
-        "(scaling_rule = $(scaling_rule(lat)))."
-    ))
+function cell_partition(lat::AbstractLattice, k::Integer=1)
+    return throw(
+        ArgumentError(
+            "cell_partition is not implemented for $(typeof(lat)) " *
+            "(scaling_rule = $(scaling_rule(lat))).",
+        ),
+    )
 end

--- a/src/Traits.jl
+++ b/src/Traits.jl
@@ -93,3 +93,54 @@ the lattice family.
 struct QuasiInfiniteSize{T} <: AbstractSizeTrait
     cutoff::T
 end
+
+# ---- Scale changes ----------------------------------------------------
+
+"""
+    AbstractScalingRule
+
+Trait describing how a lattice family generates a sequence of sizes, i.e. what
+"the same lattice, one step larger" means for it.
+
+Subtypes:
+- [`NoScaling`](@ref): no canonical size sequence.
+- [`LinearScaling`](@ref): per-axis cell counts multiply by a fixed factor.
+- [`SubstitutionScaling`](@ref): sizes come from a substitution/inflation rule,
+  as for a quasicrystal, where there is no single side length to double.
+
+See [`scaling_rule`](@ref), [`rescale`](@ref), [`size_sequence`](@ref).
+"""
+abstract type AbstractScalingRule end
+
+"""Trait: the lattice offers no canonical way to change scale."""
+struct NoScaling <: AbstractScalingRule end
+
+"""
+    LinearScaling(factor::Int)
+
+Trait: one scale step multiplies every per-axis cell count by `factor`.
+The ordinary Bravais case.
+"""
+struct LinearScaling <: AbstractScalingRule
+    factor::Int
+    function LinearScaling(factor::Integer)
+        factor > 1 || throw(ArgumentError("LinearScaling needs factor > 1; got $factor"))
+        return new(Int(factor))
+    end
+end
+
+"""
+    SubstitutionScaling(depth_step::Int = 1)
+
+Trait: one scale step advances a substitution/inflation rule by `depth_step`.
+The aperiodic case — the sequence of admissible sizes is dictated by the rule
+(Fibonacci lengths, inflation radii, …) rather than by an integer side length.
+"""
+struct SubstitutionScaling <: AbstractScalingRule
+    depth_step::Int
+    function SubstitutionScaling(depth_step::Integer = 1)
+        depth_step > 0 ||
+            throw(ArgumentError("SubstitutionScaling needs depth_step > 0; got $depth_step"))
+        return new(Int(depth_step))
+    end
+end

--- a/src/Traits.jl
+++ b/src/Traits.jl
@@ -138,9 +138,10 @@ The aperiodic case — the sequence of admissible sizes is dictated by the rule
 """
 struct SubstitutionScaling <: AbstractScalingRule
     depth_step::Int
-    function SubstitutionScaling(depth_step::Integer = 1)
-        depth_step > 0 ||
-            throw(ArgumentError("SubstitutionScaling needs depth_step > 0; got $depth_step"))
+    function SubstitutionScaling(depth_step::Integer=1)
+        depth_step > 0 || throw(
+            ArgumentError("SubstitutionScaling needs depth_step > 0; got $depth_step")
+        )
         return new(Int(depth_step))
     end
 end

--- a/test/core/test_scaling.jl
+++ b/test/core/test_scaling.jl
@@ -10,9 +10,10 @@ struct _StepLattice <: AbstractLattice{2,Float64}
     n::Int
 end
 LatticeCore.scaling_rule(::_StepLattice) = LinearScaling(2)
-LatticeCore.rescale(l::_StepLattice, k::Integer = 1) = _StepLattice(l.n * 2^k)
-LatticeCore.cell_partition(l::_StepLattice, k::Integer = 1) =
-    [collect(((c - 1) * 2^k + 1):(c * 2^k)) for c in 1:(l.n ÷ 2^k)]
+LatticeCore.rescale(l::_StepLattice, k::Integer=1) = _StepLattice(l.n * 2^k)
+function LatticeCore.cell_partition(l::_StepLattice, k::Integer=1)
+    return [collect(((c - 1) * 2 ^ k + 1):(c * 2 ^ k)) for c in 1:(l.n ÷ 2 ^ k)]
+end
 
 @testset "scaling rule traits" begin
     @test NoScaling() isa AbstractScalingRule

--- a/test/core/test_scaling.jl
+++ b/test/core/test_scaling.jl
@@ -1,0 +1,64 @@
+using LatticeCore
+using Test
+
+# A minimal lattice that opts out of scaling (the default), and one that opts in,
+# so the generic fallbacks and `size_sequence` can both be exercised without
+# depending on a concrete lattice package.
+struct _NoScaleLattice <: AbstractLattice{2,Float64} end
+
+struct _StepLattice <: AbstractLattice{2,Float64}
+    n::Int
+end
+LatticeCore.scaling_rule(::_StepLattice) = LinearScaling(2)
+LatticeCore.rescale(l::_StepLattice, k::Integer = 1) = _StepLattice(l.n * 2^k)
+LatticeCore.cell_partition(l::_StepLattice, k::Integer = 1) =
+    [collect(((c - 1) * 2^k + 1):(c * 2^k)) for c in 1:(l.n ÷ 2^k)]
+
+@testset "scaling rule traits" begin
+    @test NoScaling() isa AbstractScalingRule
+    @test LinearScaling(2) isa AbstractScalingRule
+    @test SubstitutionScaling() isa AbstractScalingRule
+
+    @test LinearScaling(3).factor == 3
+    @test SubstitutionScaling().depth_step == 1
+    @test SubstitutionScaling(2).depth_step == 2
+
+    # a scale step must actually change the scale
+    @test_throws ArgumentError LinearScaling(1)
+    @test_throws ArgumentError LinearScaling(0)
+    @test_throws ArgumentError SubstitutionScaling(0)
+    @test_throws ArgumentError SubstitutionScaling(-1)
+end
+
+@testset "defaults: a lattice opts out unless it says otherwise" begin
+    l = _NoScaleLattice()
+    @test scaling_rule(l) === NoScaling()
+    # no silent no-op: an unsupported scale change is an error, not the identity
+    @test_throws ArgumentError rescale(l)
+    @test_throws ArgumentError rescale(l, 3)
+    @test_throws ArgumentError cell_partition(l)
+end
+
+@testset "size_sequence rides rescale" begin
+    l = _StepLattice(1)
+    @test scaling_rule(l) === LinearScaling(2)
+
+    @test rescale(l, 0).n == 1          # k = 0 is the lattice itself
+    @test rescale(l).n == 2             # default step is one
+    @test rescale(l, 3).n == 8
+
+    seq = size_sequence(l, 4)
+    @test length(seq) == 5
+    @test [s.n for s in seq] == [1, 2, 4, 8, 16]
+end
+
+@testset "cell_partition partitions the sites" begin
+    l = _StepLattice(8)
+    for k in 1:3
+        groups = cell_partition(l, k)
+        flat = reduce(vcat, groups)
+        @test sort(flat) == collect(1:8)          # a partition: covers, no repeats
+        @test length(groups) == 8 ÷ 2^k
+        @test all(g -> length(g) == 2^k, groups)
+    end
+end


### PR DESCRIPTION
Finite-size studies currently have to know how each lattice family is parameterized.

That is fine for Bravais lattices, where you double `Lx` and `Ly`. It does not work for aperiodic ones, which have no single side length to double — their admissible sizes are dictated by a substitution rule. Analysis code written against `(Lx, Ly)` cannot be reused there.

## What this adds

One trait:

```julia
abstract type AbstractScalingRule end
struct NoScaling           <: AbstractScalingRule end   # default
struct LinearScaling       <: AbstractScalingRule end   # per-axis cell counts multiply by `factor`
struct SubstitutionScaling <: AbstractScalingRule end   # substitution depth advances

scaling_rule(lat) = NoScaling()
```

Three verbs:

| | |
|---|---|
| `rescale(lat, k)` | the same lattice `k` scale steps larger (`k = 0` is the lattice itself) |
| `size_sequence(lat, n)` | `[rescale(lat, k) for k in 0:n]` |
| `cell_partition(lat, k)` | which sites of `lat` sit in which cell of `rescale(lat, k)` |

`cell_partition` is needed whenever a per-site quantity has to be compared across scales — cell averages of a local observable, cell-resolved densities, or transferring a configuration between two members of a `size_sequence`.

The point is that a routine sweeping a quantity against system size can then be written once and applied to periodic and aperiodic lattices alike:

```julia
for l in size_sequence(lat, 4)
    push!(xs, num_sites(l))
    push!(ys, measure_something(l))
end
```

## Design note

`rescale` and `cell_partition` have no meaningful generic implementation, so **the default throws rather than silently returning the identity**, naming the lattice type and its `scaling_rule` in the message.

A silent no-op would be worse than an error here: applying a size sweep to a lattice that does not support scaling would produce a flat curve, which reads as "no size dependence" rather than "not implemented".

`scaling_rule` defaults to `NoScaling()`, so every existing lattice keeps its current behaviour without changes.

## Scope

- Additive only. No existing type, function or behaviour changes.
- 29 new tests: trait argument validation, the throwing defaults, `size_sequence` riding `rescale`, and that `cell_partition` really is a partition (covers `1:num_sites`, no repeats).
- `0.12.0` → `0.12.1`.

This should compose cleanly with the existing `AbstractSizeTrait`, which already distinguishes `QuasiInfiniteSize` from `FiniteSize`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
