### PR TITLE
Fix the direction stated in the cell_partition docstring

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.12.1"
+version = "0.12.2"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/src/Scaling.jl
+++ b/src/Scaling.jl
@@ -65,9 +65,15 @@ size_sequence(lat::AbstractLattice, n::Integer) = [rescale(lat, k) for k in 0:n]
 """
     cell_partition(lat::AbstractLattice, k::Integer = 1) -> Vector{Vector{Int}}
 
-Group the sites of `lat` by which cell of `rescale(lat, k)` they fall into: entry
-`c` lists the site indices of `lat` belonging to cell `c` of the larger-scale
-lattice. Together the groups partition `1:num_sites(lat)`.
+Group the sites of `lat` by which cell of the lattice `k` steps **coarser** —
+that is, of `rescale(lat, -k)` — they fall into. Entry `c` lists the site indices
+of `lat` belonging to cell `c` of that coarser lattice, and together the groups
+partition `1:num_sites(lat)`.
+
+Note the direction: `rescale(lat, k)` goes *up* in size and has more cells than
+`lat`, so it is the `-k` lattice whose cells are unions of `lat`'s. A family that
+cannot take the downward step (`LinearScaling` with cell counts not divisible by
+`factor^k`, say) should raise rather than round.
 
 Useful whenever a quantity defined per site has to be compared across scales —
 cell averages of a local observable, cell-resolved densities, or transferring a


### PR DESCRIPTION
Documentation fix in the scaling interface added by #80. My wording, my mistake.

The `cell_partition` docstring said the sites of `lat` are grouped by which cell of `rescale(lat, k)` they fall into. That is backwards: `rescale(lat, k)` goes *up* in size and therefore has **more** cells than `lat`, so grouping `lat`'s sites into it is not a partition into unions — most groups would be empty or singletons.

The lattice whose cells are unions of `lat`'s is the one `k` steps **coarser**, `rescale(lat, -k)`.

The intended semantics were already the coarser direction — the tests in #80 check `n` sites landing in `n / factor^k` groups — so only the prose was wrong. No behaviour changes.

Also adds a note on the direction and on what a family should do when the downward step is inexact (raise, not round), since that is the case an implementer hits first.

`0.12.1` → `0.12.2`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
