### PR TITLE
feat: orbit-level element centring (site/bond/plaquette) for infinite lattices

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.12.4"
+version = "0.12.5"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]

--- a/docs/make.jl
+++ b/docs/make.jl
@@ -64,6 +64,7 @@ makedocs(;
             "Lattice element" => "reference/lattice_element.md",
             "Momentum space" => "reference/momentum.md",
             "Lazy / infinite" => "reference/lazy_infinite.md",
+            "Translation cell / orbits" => "reference/translation_cell.md",
             "Reference lattices" => "reference/reference_lattices.md",
         ],
         "Design notes" => "design.md",

--- a/docs/src/reference/translation_cell.md
+++ b/docs/src/reference/translation_cell.md
@@ -1,0 +1,41 @@
+# Translation-cell / orbit API
+
+The translation-cell layer describes a lattice by its unit-cell motif —
+a finite site basis and a finite bond motif — plus a translation action,
+and exposes the fundamental domain through *orbit* accessors that work
+for finite and infinite lattices alike. See the
+[Lazy / infinite lattices guide](../guide/lazy_infinite.md) for context.
+
+## Motif identities
+
+```@docs
+CellSite
+CellBond
+```
+
+## Motif interface
+
+```@docs
+translation_vectors
+num_basis_sites
+basis_position
+cell_bonds
+```
+
+## Orbit accessors
+
+```@docs
+site_orbits
+bond_orbits
+plaquette_orbits
+element_orbits
+```
+
+## Lazy access and orbit positions
+
+```@docs
+cell_position
+incident_cell_bonds
+neighbors_at
+element_orbit_position
+```

--- a/src/LatticeCore.jl
+++ b/src/LatticeCore.jl
@@ -97,8 +97,9 @@ export materialize, require_finite
 # ---- Translation-cell (unit-cell motif) layer ----
 export CellSite, CellBond
 export translation_vectors, num_basis_sites, basis_position, cell_bonds
-export site_orbits, bond_orbits
+export site_orbits, bond_orbits, plaquette_orbits
 export cell_position, incident_cell_bonds, neighbors_at
+export element_orbits, element_orbit_position
 
 # ---- Scale changes ----
 export AbstractScalingRule, NoScaling, LinearScaling, SubstitutionScaling

--- a/src/TranslationCell.jl
+++ b/src/TranslationCell.jl
@@ -223,7 +223,7 @@ end
     plaquette_orbits(lat::AbstractLattice) → iterator of PlaquetteRule
 
 Representatives of the plaquette (face) orbits under the translation
-group — the unit cell's plaquette rules. Defaults to `()` (lattices
+group — the unit cell's `PlaquetteRule`s. Defaults to `()` (lattices
 with no plaquette notion). The bond / site analogues are
 [`bond_orbits`](@ref) / [`site_orbits`](@ref).
 """
@@ -237,7 +237,7 @@ group: [`site_orbits`](@ref) for [`VertexCenter`](@ref),
 [`bond_orbits`](@ref) for [`BondCenter`](@ref), and
 [`plaquette_orbits`](@ref) for [`PlaquetteCenter`](@ref). A finite
 fundamental domain — defined for infinite lattices, where the
-enumeration [`elements`](@ref) is not.
+enumeration `elements` is not.
 """
 element_orbits(lat::AbstractLattice, ::VertexCenter) = site_orbits(lat)
 element_orbits(lat::AbstractLattice, ::BondCenter) = bond_orbits(lat)
@@ -253,10 +253,10 @@ evaluated on the home unit cell via [`cell_position`](@ref):
   position;
 - [`BondCenter`](@ref), `rep::`[`CellBond`](@ref) → the midpoint of the
   bond's two endpoints;
-- [`PlaquetteCenter`](@ref), `rep::`[`PlaquetteRule`](@ref) → the
-  centroid of its corner sites.
+- [`PlaquetteCenter`](@ref), `rep::PlaquetteRule` → the centroid of its
+  corner sites.
 
-Consistent with [`bond_center`](@ref) / [`plaquette_center`](@ref), but
+Consistent with [`bond_center`](@ref) / `plaquette_center`, but
 evaluated on the fundamental domain: it needs no boundary wrapping (the
 motif carries unwrapped cell offsets) and works for infinite lattices.
 """

--- a/src/TranslationCell.jl
+++ b/src/TranslationCell.jl
@@ -206,3 +206,80 @@ materialised.
 function neighbors_at(lat::AbstractLattice{D}, s::CellSite{D}) where {D}
     return [CellSite{D}(s.cell + cb.offset, cb.dst) for cb in incident_cell_bonds(lat, s)]
 end
+
+# ---- Element centring on the fundamental domain (orbits) ------------
+#
+# The [`AbstractLatticeElement`](@ref) centring trait — `VertexCenter` /
+# `BondCenter` / `PlaquetteCenter` — applied at the *orbit* level: one
+# representative per translation orbit, plus its real-space
+# representative position. Unlike the enumeration API
+# (`elements` / `element_position`, which walk `1:num_sites` / `bonds` /
+# `plaquettes`), these read the finite fundamental domain and so are
+# defined for infinite lattices — the geometry substrate for attaching
+# one degree of freedom per site / bond / plaquette orbit in the
+# thermodynamic limit.
+
+"""
+    plaquette_orbits(lat::AbstractLattice) → iterator of PlaquetteRule
+
+Representatives of the plaquette (face) orbits under the translation
+group — the unit cell's plaquette rules. Defaults to `()` (lattices
+with no plaquette notion). The bond / site analogues are
+[`bond_orbits`](@ref) / [`site_orbits`](@ref).
+"""
+plaquette_orbits(::AbstractLattice) = ()
+
+"""
+    element_orbits(lat::AbstractLattice, e::AbstractLatticeElement)
+
+Representatives of the orbits of centring `e` under the translation
+group: [`site_orbits`](@ref) for [`VertexCenter`](@ref),
+[`bond_orbits`](@ref) for [`BondCenter`](@ref), and
+[`plaquette_orbits`](@ref) for [`PlaquetteCenter`](@ref). A finite
+fundamental domain — defined for infinite lattices, where the
+enumeration [`elements`](@ref) is not.
+"""
+element_orbits(lat::AbstractLattice, ::VertexCenter) = site_orbits(lat)
+element_orbits(lat::AbstractLattice, ::BondCenter) = bond_orbits(lat)
+element_orbits(lat::AbstractLattice, ::PlaquetteCenter) = plaquette_orbits(lat)
+
+"""
+    element_orbit_position(lat, e::AbstractLatticeElement, rep) → SVector{D,T}
+
+Real-space position of an orbit representative `rep` of centring `e`,
+evaluated on the home unit cell via [`cell_position`](@ref):
+
+- [`VertexCenter`](@ref), `rep::Int` (basis index) → the basis-site
+  position;
+- [`BondCenter`](@ref), `rep::`[`CellBond`](@ref) → the midpoint of the
+  bond's two endpoints;
+- [`PlaquetteCenter`](@ref), `rep::`[`PlaquetteRule`](@ref) → the
+  centroid of its corner sites.
+
+Consistent with [`bond_center`](@ref) / [`plaquette_center`](@ref), but
+evaluated on the fundamental domain: it needs no boundary wrapping (the
+motif carries unwrapped cell offsets) and works for infinite lattices.
+"""
+function element_orbit_position(
+    lat::AbstractLattice{D,T}, ::VertexCenter, b::Int
+) where {D,T}
+    return cell_position(lat, zero(SVector{D,Int}), b)
+end
+
+function element_orbit_position(
+    lat::AbstractLattice{D,T}, ::BondCenter, cb::CellBond{D}
+) where {D,T}
+    p_src = cell_position(lat, zero(SVector{D,Int}), cb.src)
+    p_dst = cell_position(lat, cb.offset, cb.dst)
+    return (p_src + p_dst) / 2
+end
+
+function element_orbit_position(
+    lat::AbstractLattice{2,T}, ::PlaquetteCenter, pr::PlaquetteRule
+) where {T}
+    acc = zero(SVector{2,T})
+    for (sub, dx, dy) in pr.corners
+        acc += cell_position(lat, SVector{2,Int}(dx, dy), sub)
+    end
+    return acc / length(pr.corners)
+end

--- a/src/reference/InfiniteSquareLattice.jl
+++ b/src/reference/InfiniteSquareLattice.jl
@@ -62,6 +62,11 @@ function cell_bonds(::InfiniteSquareLattice)
     return (CellBond(1, 1, (1, 0), :nearest), CellBond(1, 1, (0, 1), :nearest))
 end
 
+# The single unit-square plaquette, corners in cyclic order.
+function plaquette_orbits(::InfiniteSquareLattice)
+    return (PlaquetteRule([(1, 0, 0), (1, 1, 0), (1, 1, 1), (1, 0, 1)], :square),)
+end
+
 # ---- Size / traits ---------------------------------------------------
 
 size_trait(::InfiniteSquareLattice) = InfiniteSize()

--- a/src/reference/SimpleSquareLattice.jl
+++ b/src/reference/SimpleSquareLattice.jl
@@ -218,6 +218,10 @@ function cell_bonds(::SimpleSquareLattice)
     return (CellBond(1, 1, (1, 0), :nearest), CellBond(1, 1, (0, 1), :nearest))
 end
 
+function plaquette_orbits(::SimpleSquareLattice)
+    return (PlaquetteRule([(1, 0, 0), (1, 1, 0), (1, 1, 1), (1, 0, 1)], :square),)
+end
+
 function reciprocal_lattice(lat::SimpleSquareLattice{T}) where {T}
     reciprocal_support(lat) isa HasReciprocal || throw(
         ArgumentError(

--- a/test/core/test_element_orbits.jl
+++ b/test/core/test_element_orbits.jl
@@ -1,0 +1,84 @@
+using LatticeCore
+using LatticeCore: CellBond
+using StaticArrays
+using Test
+
+@testset "element_orbits routes centring to the motif orbits" begin
+    inf = InfiniteSquareLattice()
+
+    @test collect(element_orbits(inf, VertexCenter())) == collect(site_orbits(inf))
+    @test collect(element_orbits(inf, BondCenter())) == collect(bond_orbits(inf))
+
+    pl = collect(element_orbits(inf, PlaquetteCenter()))
+    @test length(pl) == 1
+    @test pl[1].type == :square
+    @test length(pl[1].corners) == 4
+end
+
+@testset "element centring is accessible on the infinite lattice (no throw)" begin
+    inf = InfiniteSquareLattice()
+    # The enumeration API throws (no linear index); the orbit API must not.
+    @test_throws DomainError elements(inf, VertexCenter())         # 1:num_sites
+    @test element_orbits(inf, VertexCenter()) == 1:1
+    @test length(collect(element_orbits(inf, BondCenter()))) == 2
+    @test length(collect(element_orbits(inf, PlaquetteCenter()))) == 1
+end
+
+@testset "orbit representative positions are geometrically consistent" begin
+    inf = InfiniteSquareLattice()
+
+    # Vertex: the single basis site sits at the cell origin.
+    @test element_orbit_position(inf, VertexCenter(), 1) == SVector(0.0, 0.0)
+
+    # Bond: midpoint of the two endpoints.
+    bx, by = collect(bond_orbits(inf))
+    @test element_orbit_position(inf, BondCenter(), bx) == SVector(0.5, 0.0)
+    @test element_orbit_position(inf, BondCenter(), by) == SVector(0.0, 0.5)
+    # Independent check: the midpoint equals mean of the two endpoint
+    # cell positions, reconstructed directly.
+    for cb in (bx, by)
+        p =
+            (
+                cell_position(inf, (0, 0), cb.src) +
+                cell_position(inf, Tuple(cb.offset), cb.dst)
+            ) / 2
+        @test element_orbit_position(inf, BondCenter(), cb) == p
+    end
+
+    # Plaquette: centroid of the unit square is its centre.
+    sq = only(element_orbits(inf, PlaquetteCenter()))
+    @test element_orbit_position(inf, PlaquetteCenter(), sq) == SVector(0.5, 0.5)
+    # Independent check: centroid == mean of the four corner positions.
+    corners = [cell_position(inf, (dx, dy), sub) for (sub, dx, dy) in sq.corners]
+    @test element_orbit_position(inf, PlaquetteCenter(), sq) == sum(corners) / 4
+end
+
+@testset "finite and infinite agree on every centring" begin
+    fin = SimpleSquareLattice(4, 4, PeriodicAxis())
+    inf = InfiniteSquareLattice()
+
+    @test collect(element_orbits(fin, VertexCenter())) ==
+        collect(element_orbits(inf, VertexCenter()))
+    fkey(cb) = (cb.src, cb.dst, cb.offset, cb.type)
+    @test Set(fkey.(element_orbits(fin, BondCenter()))) ==
+        Set(fkey.(element_orbits(inf, BondCenter())))
+
+    fpl = only(element_orbits(fin, PlaquetteCenter()))
+    ipl = only(element_orbits(inf, PlaquetteCenter()))
+    @test fpl.corners == ipl.corners && fpl.type == ipl.type
+
+    @test element_orbit_position(fin, VertexCenter(), 1) ==
+        element_orbit_position(inf, VertexCenter(), 1)
+    for cb in element_orbits(inf, BondCenter())
+        @test element_orbit_position(fin, BondCenter(), cb) ==
+            element_orbit_position(inf, BondCenter(), cb)
+    end
+    @test element_orbit_position(fin, PlaquetteCenter(), fpl) ==
+        element_orbit_position(inf, PlaquetteCenter(), ipl)
+end
+
+@testset "plaquette_orbits defaults to empty for lattices without faces" begin
+    line = LineLattice(5)
+    @test plaquette_orbits(line) == ()
+    @test element_orbits(line, PlaquetteCenter()) == ()
+end


### PR DESCRIPTION
Makes the `AbstractLatticeElement` centring abstraction (`VertexCenter` / `BondCenter` / `PlaquetteCenter`) accessible **lazily on the infinite lattice** — pure geometry, the substrate for attaching one degree of freedom per site/bond/plaquette orbit in the thermodynamic limit.

## Problem

The enumeration element API (`elements`/`num_elements`/`element_position`) walks `1:num_sites` / `bonds` / `plaquettes`, all of which throw or are empty for an `InfiniteSize` lattice. So on the infinite abstraction the site/bond/plaquette centring was unreachable.

## What

A parallel **orbit-level** API on the finite fundamental domain — one representative per translation orbit + its real-space position:

- `element_orbits(lat, e)` → `site_orbits` / `bond_orbits` / `plaquette_orbits` for the three centrings.
- `plaquette_orbits(lat)` → the unit cell's `PlaquetteRule`s (default `()`; unit-square reference for the square lattices).
- `element_orbit_position(lat, e, rep)`:
  - VertexCenter → basis-site position,
  - BondCenter → **midpoint** of the bond's two endpoints,
  - PlaquetteCenter → **centroid** of the corner sites,
  all via `cell_position` on the home cell — no boundary wrapping, so it works for infinite lattices and stays consistent with `bond_center` / `plaquette_center`.

Uniform across finite (PBC) and infinite lattices.

## Geometric consistency (tested, 25 assertions)

- Centring routes to the right orbits.
- The centring API is **reachable on `InfiniteSquareLattice`** where the enumeration API throws (the core point).
- Bond-midpoint and plaquette-centroid positions match independent reconstructions from the corner `cell_position`s.
- Finite and infinite agree on all three centrings (orbits + positions).
- `plaquette_orbits` defaults to empty (`LineLattice`).

Version 0.12.4 → 0.12.5 (additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)