### PR TITLE
ci(labeler): call the QAtlasHub reusable workflow instead of `gh pr edit`

### DIFF
--- a/.github/workflows/PRLabeler.yml
+++ b/.github/workflows/PRLabeler.yml
@@ -1,54 +1,15 @@
-name: Checkbox Labeler
-
+# Thin caller. The implementation lives ONCE, in QAtlasHub/.github (public, callable from any
+# owner), so the next breakage is one commit there instead of one PR per repo — this file used
+# to be a hand-rolled `gh pr edit` script, which GitHub's Projects-classic sunset broke in
+# every repo at once on 2026-07-28.
+name: PR Labeler
 on:
   pull_request:
-    types: [opened, edited]
-
+    types: [opened, edited, synchronize, reopened]
 permissions:
+  contents: read
   pull-requests: write
-  issues: write          # required for gh label create
-
+  issues: write            # addLabels / createLabel are issue-scoped, even on a PR
 jobs:
-  labeler:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Update Labels based on Checkboxes
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          PR_BODY: ${{ github.event.pull_request.body }}
-          PR_NUMBER: ${{ github.event.pull_request.number }}
-          REPO: ${{ github.repository }}
-        run: |
-          # Ensure all labels exist (--force updates color/description if already present)
-          gh label create "enhancement"   --repo "$REPO" --color "a2eeef" --force
-          gh label create "bug"           --repo "$REPO" --color "d73a4a" --force
-          gh label create "performance"   --repo "$REPO" --color "e4e669" --force
-          gh label create "documentation" --repo "$REPO" --color "0075ca" --force
-          gh label create "chore"         --repo "$REPO" --color "e8e8e8" --force
-          gh label create "breaking"      --repo "$REPO" --color "b60205" --force
-
-          if echo "$PR_BODY" | grep -qi "\- \[x\].*Feature"; then
-            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "enhancement"
-          fi
-
-          if echo "$PR_BODY" | grep -qi "\- \[x\].*Bug Fix"; then
-            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "bug"
-          fi
-
-          if echo "$PR_BODY" | grep -qi "\- \[x\].*Performance"; then
-            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "performance"
-          fi
-
-          if echo "$PR_BODY" | grep -qi "\- \[x\].*Documentation"; then
-            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "documentation"
-          fi
-
-          if echo "$PR_BODY" | grep -qi "\- \[x\].*Maintenance"; then
-            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "chore"
-          fi
-
-          if echo "$PR_BODY" | grep -qi "\- \[x\].*Breaking"; then
-            gh pr edit "$PR_NUMBER" --repo "$REPO" --add-label "breaking"
-          else
-            gh pr edit "$PR_NUMBER" --repo "$REPO" --remove-label "breaking" 2>/dev/null || true
-          fi
+  label:
+    uses: QAtlasHub/.github/.github/workflows/labeler.yml@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.12.5"
+version = "0.12.6"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]


### PR DESCRIPTION
> [!WARNING]
> **Merging this cuts a release.** This repo is public, so AutoRegister answers the
> `Project.toml` bump on main with a `@JuliaRegistrator register` comment → General registry.
> The bump is not optional (VersionCheck runs on every PR by design), so v0.12.5 → v0.12.6 is
> the price of a CI-only change here. Hold the merge if you do not want v0.12.6 published.

## Description

`gh pr edit --add-label` reads the pull request over GraphQL, and GitHub now answers that query
with the Projects-classic sunset notice (`repository.pullRequest.projectCards`); `gh` reports it
as an error and exits 1. The hand-rolled `PRLabeler.yml` therefore fails on a deprecation message
that has nothing to do with labelling — measured on lab-sotashimozono/FunctionMeasures.jl, green
on 07-27 and red on 07-28, with no change to the workflow.

**40 repos** across lab-sotashimozono / QAtlasHub / sotashimozono carried that copy. This replaces
it with the thin caller of the reusable workflow that already serves 4 repos, so the
implementation lives **once** in `QAtlasHub/.github` ([labeler.yml@v1](https://github.com/QAtlasHub/.github/blob/v1/.github/workflows/labeler.yml),
fixed in QAtlasHub/.github#18) and the next breakage is one commit there instead of one PR per repo.

Behaviour is preserved: same six labels, same colours (created on demand), same
Type-of-Change checkbox parsing, and `breaking` is still removed when its box is unticked.
A public repo takes the workflow's default runner (`ubuntu-latest`), so the caller needs no inputs.

## Type of Change

- [x] 🧰 **Maintenance** (`chore`)

## Proposed Changes

- `.github/workflows/PRLabeler.yml` → thin caller of `QAtlasHub/.github/.github/workflows/labeler.yml@v1`
- `Project.toml` v0.12.5 → v0.12.6 (VersionCheck runs on every PR, deliberately, so a
  workflow-only change still needs the bump)

## Usage or Results

This PR labels itself: the `chore` box above is what the reusable workflow reads, so a green
**PR Labeler** check plus a `chore` label on this PR is the end-to-end proof that the replacement
works in this repo.