### PR TITLE
Split the test suite, through TestShards.jl

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,34 +1,36 @@
 name: CI
 on:
   push:
-    branches:
-      - main
+    branches: [main]
     tags: '*'
   pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+# This suite was not split before. The whole sharded-test vertical is QAtlasHub/TestShards.jl:
+# nothing is planned up front — each shard decides what it owns from the same timing history —
+# and the reusable merges the shards' coverage into one Codecov upload, merges their records into
+# one ordered document, checks that every unit ran exactly once, and refreshes `ci-timings` on
+# pushes to main.
+#
+# The split is not the only thing gained. The exactly-once check and the merged record hold for a
+# small suite too, and with no history the first run is round-robin and balances itself from the
+# second push onward.
 jobs:
   test:
-    name: Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }}
-    runs-on: ${{ matrix.os }}
-    strategy:
-      fail-fast: false
-      matrix:
-        version:
-          - '1'
-        os:
-          - ubuntu-latest
-        arch:
-          - x64
-    steps:
-      - uses: actions/checkout@v7
-      - uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.version }}
-          arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v3
-      - uses: julia-actions/julia-buildpkg@v1
-      - uses: julia-actions/julia-runtest@v1
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v7
-        with:
-          file: lcov.info
-          token: ${{ secrets.CODECOV_TOKEN }}
+    permissions:
+      contents: write   # the timing history is pushed to the `ci-timings` orphan branch
+    uses: QAtlasHub/TestShards.jl/.github/workflows/sharded-tests.yml@main
+    with:
+      # A starting point. The diagnosis printed on every run names the knee for THIS suite —
+      # read it and set what it says rather than keeping this number out of inertia.
+      shards: 8
+      # Also refreshes: a registry present but stale resolves fine while failing to see anything
+      # published since it was last pulled.
+      registries: |
+        General
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LatticeCore"
 uuid = "84b1cbd8-bc58-4618-bc4f-b46a399f49f1"
-version = "0.12.7"
+version = "0.12.8"
 authors = ["sota shimozono <shimozono-sota631@g.ecc.u-tokyo.ac.jp>"]
 
 [deps]
@@ -32,6 +32,7 @@ Random = "1"
 SparseArrays = "1"
 StaticArrays = "1"
 Test = "1"
+TestShards = "0.3"
 julia = "1.10"
 
 [extras]
@@ -42,6 +43,7 @@ NFFT = "efe261a4-0d2b-5849-be55-fc731d526b0d"
 Plots = "91a5bcdd-55d7-5caf-9e0b-520d859cae80"
 Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
+TestShards = "acceef1d-f5e0-4fe4-a546-818dc56ce7b2"
 
 [targets]
-test = ["Aqua", "CairoMakie", "FFTW", "NFFT", "Plots", "Random", "Test"]
+test = ["Aqua", "CairoMakie", "FFTW", "NFFT", "Plots", "Random", "Test", "TestShards"]

--- a/src/TightBinding.jl
+++ b/src/TightBinding.jl
@@ -57,11 +57,11 @@ function tight_binding_hamiltonian(
     @inbounds for k in eachindex(bs)
         b = bs[k]
         tij = -float(hoppings[k])
-        push!(Is, b.i);
-        push!(Js, b.j);
+        push!(Is, b.i)
+        push!(Js, b.j)
         push!(Vs, tij)
-        push!(Is, b.j);
-        push!(Js, b.i);
+        push!(Is, b.j)
+        push!(Js, b.i)
         push!(Vs, tij)
     end
     ov = _onsite_vector(onsite, N)

--- a/test/core/test_analysis.jl
+++ b/test/core/test_analysis.jl
@@ -47,10 +47,10 @@ chain(N) = LineLattice(N, OpenAxis())
     @testset "inverse participation ratio" begin
         n = 40
         @test inverse_participation_ratio(fill(1 / sqrt(n), n)) ≈ 1 / n rtol = 1e-12
-        e1 = zeros(n);
+        e1 = zeros(n)
         e1[3] = 1.0
         @test inverse_participation_ratio(e1) == 1.0
-        s = zeros(n);
+        s = zeros(n)
         s[1:5] .= 1 / sqrt(5)
         @test inverse_participation_ratio(s) ≈ 1 / 5 rtol = 1e-12
         @test_throws ArgumentError inverse_participation_ratio(zeros(n))

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,6 +1,7 @@
 ENV["GKSwstype"] = "100"
 
 using LatticeCore, Test
+using TestShards
 
 # Eagerly load the optional weak-dependency packages so the
 # `LatticeCoreFFTWExt`, `LatticeCoreNFFTExt`, and `LatticeCorePlotsExt`
@@ -9,34 +10,25 @@ using FFTW
 using NFFT
 using Plots
 
-const dirs = ["core"]
-
-const FIG_BASE = joinpath(pkgdir(LatticeCore), "docs", "src", "assets")
-const PATHS = Dict()
-mkpath.(values(PATHS))
-
-@testset "tests" begin
-    test_args = copy(ARGS)
-    println("Passed arguments ARGS = $(test_args) to tests.")
-    @time for dir in dirs
-        dirpath = joinpath(@__DIR__, dir)
-        println("\nTest $(dirpath)")
-        files = sort(
-            filter(f -> startswith(f, "test_") && endswith(f, ".jl"), readdir(dirpath))
-        )
-        if isempty(files)
-            println("  No test files found in $(dirpath).")
-            @test false
-        else
-            for f in files
-                @testset "$f" begin
-                    filepath = joinpath(dirpath, f)
-                    @time begin
-                        println("  Including $(filepath)")
-                        include(filepath)
-                    end
-                end
-            end
+# Every `test_*.jl` under `test/`, in a deterministic order, each one its own shardable unit.
+# `@shard` shadows `include` inside the block, so a unit is whatever this loop includes — a new
+# file, or a whole new directory, is picked up BY BEING ON DISK, rather than by being added to
+# the `dirs` list that used to sit here and could disagree with the tree.
+#
+# Two rules when adding to this, and they are the only two:
+#
+#   1. SHARED FIXTURES GO ABOVE THIS BLOCK. A helper included inside becomes a unit of its own,
+#      lands on ONE shard, and every test file on the other shards that needed it fails.
+#   2. ANYTHING THAT IS NOT A `test_*.jl` FILE MUST BE NAMED. The glob does not error on what it
+#      does not match; it silently stops running it.
+#
+# A bare `Pkg.test()` with nothing set in the environment runs all of it, in this order. Run one
+# shard locally with `TESTSHARDS_ID=s2 TESTSHARDS_N=8 julia --project -e 'using Pkg; Pkg.test()'`.
+TestShards.@shard begin
+    for (dir, _, files) in sort!(collect(walkdir(@__DIR__)))
+        for f in sort(files)
+            startswith(f, "test_") && endswith(f, ".jl") || continue
+            include(joinpath(dir, f))
         end
     end
 end


### PR DESCRIPTION
This suite ran as **one job**. It is now 27 units, split 8 ways by measured per-unit runtime.

## What changes

`runtests.jl` globs `test_*.jl` under `test/` and includes each one. A new file, or a whole new directory, is picked up **by being on disk** rather than by being added to the `dirs` list that used to sit here and could disagree with the tree.

`dirs`, `FIG_BASE` and `PATHS` go with it: nothing in `test/` referenced the latter two, and `dirs` was only the loop's own input.

## The split is not the only thing gained

On a suite this size it may not even be the main one. The reusable also:

- checks that **every unit ran exactly once** — a claim no unsharded run has to make, and none was making;
- merges the shards' coverage into **one** Codecov upload;
- merges their records into one ordered document.

With no timing history the first run is round-robin and balances itself from the second push onward.

## Notes

- `shards: 8` is a starting point. The diagnosis printed on every run names the knee for *this* suite — read it and set what it says rather than keeping the number out of inertia.
- `registries: General` also **refreshes**: a registry present but stale resolves fine while failing to see anything published since it was last pulled.

Refs QAtlasHub/TestShards.jl#13.

🤖 Generated with [Claude Code](https://claude.com/claude-code)